### PR TITLE
Use full path for Nunjucks include path

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -2,6 +2,7 @@
 import nunjucks, { Environment } from 'nunjucks'
 import express from 'express'
 import { format, parseISO } from 'date-fns'
+import path from 'path'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -29,7 +30,7 @@ export default function nunjucksSetup(app: express.Express): void {
 export function registerNunjucks(app?: express.Express): Environment {
   const njkEnv = nunjucks.configure(
     [
-      'server/views',
+      path.join(__dirname, '../../server/views'),
       'node_modules/govuk-frontend/',
       'node_modules/govuk-frontend/components/',
       'node_modules/@ministryofjustice/frontend/',


### PR DESCRIPTION
Should fix templates not found error - which happens on Cloud Platform but not locally.