### PR TITLE
VB-326 Add offenderNo to session to fix 404s

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,4 +1,4 @@
-import { Contact, VisitorListItem } from '../bapv'
+import { VisitorListItem } from '../bapv'
 
 export default {}
 
@@ -8,7 +8,7 @@ declare module 'express-session' {
     returnTo: string
     nowInMinutes: number
     prisonerName: string
-    contacts: Contact[]
+    offenderNo: string
     visitorList: VisitorListItem[]
   }
 }

--- a/server/routes/visitors.test.ts
+++ b/server/routes/visitors.test.ts
@@ -112,6 +112,7 @@ describe('GET /visit/select-visitors/A1234BC', () => {
         expect(res.text).toMatch(/Bob Smith.|\s*?Not entered.|\s*?Brother.|\s*?1st listed address.|\s*?None/)
         expect(res.text).toMatch(/Anne Smith.|\s*?2 March 2018<br>(Child).|\s*?Not entered.|\s*?None/)
         expect(res.text).toMatch(/<button.|\s*?Continue.|\s*?<\/button>/)
+        expect(res.text).toContain('<form action="/visit/select-visitors/A1234BC"')
       })
   })
 
@@ -204,6 +205,7 @@ describe('POST /visit/select-visitors/A1234BC', () => {
         expect(res.text).toMatch(/Bob Smith.|\s*?Not entered.|\s*?Brother.|\s*?1st listed address.|\s*?None/)
         expect(res.text).toMatch(/Anne Smith.|\s*?2 March 2018<br>(Child).|\s*?Not entered.|\s*?None/)
         expect(res.text).toMatch(/<button.|\s*?Continue.|\s*?<\/button>/)
+        expect(res.text).toContain('<form action="/visit/select-visitors/A1234BC"')
       })
       .end((err, res) => {
         if (err) return done(err)
@@ -228,6 +230,7 @@ describe('POST /visit/select-visitors/A1234BC', () => {
       expect(res.text).not.toContain('Select no more than 3 visitors with a maximum of 2 adults')
       expect(res.text).not.toContain('Select no more than 2 adults')
       expect(res.text).not.toContain('Add an adult to the visit')
+      expect(res.text).toContain('<form action="/visit/select-visitors/A1234BC"')
     })
   })
 

--- a/server/routes/visitors.ts
+++ b/server/routes/visitors.ts
@@ -25,6 +25,7 @@ export default function routes(
     const prisonerVisitors = await prisonerVisitorsService.getVisitors(offenderNo, res.locals.user?.username)
 
     req.session.prisonerName = prisonerVisitors.prisonerName
+    req.session.offenderNo = offenderNo
     req.session.visitorList = prisonerVisitors.visitorList
 
     res.render('pages/visitors', { ...prisonerVisitors, offenderNo })
@@ -83,7 +84,7 @@ export default function routes(
       return res.render('pages/visitors', {
         errors: !errors.isEmpty() ? errors.array() : [],
         prisonerName: req.session.prisonerName,
-        contacts: req.session.contacts,
+        offenderNo: req.session.offenderNo,
         visitorList: req.session.visitorList,
       })
     }


### PR DESCRIPTION
`offenderNo` wasn't coming through on POST requests (following failed validation) to get visitor list. Added to the session on the initial GET so it's available. Added test coverage for this.