### PR TITLE
Back link related fixes

### DIFF
--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -71,12 +71,15 @@ class VisitSchedulerApiClient {
   }
 
   updateVisit(visitData: VisitSessionData, visitStatus: string): Promise<Visit> {
-    const mainContact = {
-      contactPhone: visitData.mainContact.phoneNumber,
-      contactName: visitData.mainContact.contactName
-        ? visitData.mainContact.contactName
-        : visitData.mainContact.contact.name,
-    }
+    const mainContact = visitData.mainContact
+      ? {
+          contactPhone: visitData.mainContact.phoneNumber,
+          contactName: visitData.mainContact.contactName
+            ? visitData.mainContact.contactName
+            : visitData.mainContact.contact.name,
+        }
+      : undefined
+
     const additionalSupport = visitData.additionalSupport?.keys
       ? visitData.additionalSupport.keys.concat([visitData.additionalSupport.other]).join(',')
       : ''

--- a/server/routes/visitors.ts
+++ b/server/routes/visitors.ts
@@ -32,6 +32,7 @@ export default function routes(
 
     res.render('pages/visitors', {
       errors: req.flash('errors'),
+      offenderNo: visitSessionData.prisoner.offenderNo,
       prisonerName: visitSessionData.prisoner.name,
       visitorList: prisonerVisitors.visitorList,
       restrictions,


### PR DESCRIPTION
* Fix crash when going back from date/time picker - `updateVisit()` assumed `mainContact` is present in session but it isn't on first time through journey
* Fix broken link back to profile that was missing `offenderNo`