### PR TITLE
Simplify tables: style table rather than each cell

### DIFF
--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -2,7 +2,7 @@
   min-height: 600px;
 }
 
-.bapv-table_cell {
+.bapv-table th, .bapv-table td  {
   padding: govuk-spacing(4) govuk-spacing(4) govuk-spacing(4) 0;
 }
 

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -2,7 +2,6 @@ import { InmateDetail, VisitBalances } from '../data/prisonApiTypes'
 import { VisitorSupport } from '../data/visitSchedulerApiTypes'
 
 export type PrisonerDetailsItem = {
-  classes: string
   html: string
 }
 

--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -78,11 +78,7 @@ describe('Prisoner search page', () => {
       it('should render prisoner results page with results and no next/prev when there are less than 11 results', () => {
         getPrisonersReturnData = {
           results: [
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
           ],
           numberOfPages: 1,
           numberOfResults: 1,
@@ -105,61 +101,17 @@ describe('Prisoner search page', () => {
       it('should render prisoner results page with results and prev/next when there are more than 10 results', () => {
         getPrisonersReturnData = {
           results: [
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
           ],
           numberOfPages: 12,
           numberOfResults: 11,
@@ -219,11 +171,7 @@ describe('Prisoner search page', () => {
       it('should render prisoner results page with results and no next/prev when there are less than 11 results', () => {
         getPrisonersReturnData = {
           results: [
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
           ],
           numberOfPages: 1,
           numberOfResults: 1,
@@ -246,61 +194,17 @@ describe('Prisoner search page', () => {
       it('should render prisoner results page with results and prev/next when there are more than 10 results', () => {
         getPrisonersReturnData = {
           results: [
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
-            [
-              { html: '<a href="/prisoner/A1234BC">Smith, John</a>', classes: '' },
-              { html: 'A1234BC', classes: '' },
-              { html: '2 April 1975', classes: '' },
-            ],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
+            [{ html: '<a href="/prisoner/A1234BC">Smith, John</a>' }, { html: 'A1234BC' }, { html: '2 April 1975' }],
           ],
           numberOfPages: 12,
           numberOfResults: 11,

--- a/server/services/prisonerSearchService.test.ts
+++ b/server/services/prisonerSearchService.test.ts
@@ -49,15 +49,12 @@ describe('Prisoner search service', () => {
           [
             {
               html: '<a href="/prisoner/A1234BC">Smith, John</a>',
-              classes: 'bapv-table_cell',
             },
             {
               html: 'A1234BC',
-              classes: 'bapv-table_cell',
             },
             {
               html: '2 April 1975',
-              classes: 'bapv-table_cell',
             },
           ],
         ])
@@ -101,15 +98,12 @@ describe('Prisoner search service', () => {
           [
             {
               html: '<a href="/prisoner/visits/A1234BC">Smith, John</a>',
-              classes: 'bapv-table_cell',
             },
             {
               html: 'A1234BC',
-              classes: 'bapv-table_cell',
             },
             {
               html: '2 April 1975',
-              classes: 'bapv-table_cell',
             },
           ],
         ])

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -55,15 +55,12 @@ export default class PrisonerSearchService {
       const row: PrisonerDetailsItem[] = [
         {
           html: url,
-          classes: 'bapv-table_cell',
         },
         {
           html: prisoner.prisonerNumber,
-          classes: 'bapv-table_cell',
         },
         {
           html: prisonerDatePretty({ dateToFormat: prisoner.dateOfBirth }),
-          classes: 'bapv-table_cell',
         },
       ]
 

--- a/server/views/pages/prisoner/visits.njk
+++ b/server/views/pages/prisoner/visits.njk
@@ -22,44 +22,36 @@
           {% set visitRows = (visitRows.push([
             {
               html: '<a href="/visit/' + visit.reference + '">' + visit.reference + '</a>',
-              classes: "bapv-table_cell",
               attributes: { "data-test": "visit-reference-" + loop.index }
             },
             {
               text: visit.mainContact | formatMainContact,
-              classes: "bapv-table_cell",
               attributes: { "data-test": "visit-mainContact-" + loop.index }
             },
             {
               text: visit.visitDate,
-              classes: "bapv-table_cell",
               attributes: { "data-test": "visit-date-" + loop.index }
             },
             {
               text: visit.visitTime,
-              classes: "bapv-table_cell",
               attributes: { "data-test": "visit-time-" + loop.index }
             }
           ]), visitRows) %}
         {% endfor %}
         {{ govukTable({
-            classes: " govuk-!-margin-top-3",
+            classes: "bapv-table govuk-!-margin-top-3",
             head: [
                 {
-                  text: "Booking reference",
-                  classes: "bapv-table_cell"
+                  text: "Booking reference"
                 },
                 {
-                  text: "Main contact",
-                  classes: "bapv-table_cell"
+                  text: "Main contact"
                 },
                 {
-                  text: "Visit date",
-                  classes: "bapv-table_cell"
+                  text: "Visit date"
                 },
                 {
-                  text: "Visit time",
-                  classes: "bapv-table_cell"
+                  text: "Visit time"
                 }
             ],
             rows: visitRows

--- a/server/views/pages/search/prisonerResults.njk
+++ b/server/views/pages/search/prisonerResults.njk
@@ -39,23 +39,20 @@
       {{ pagination | safe if numberOfResults > 10 }}
 
         {{ govukTable({
-            classes: " govuk-!-margin-top-3",
+            classes: "bapv-table govuk-!-margin-top-3",
             captionClasses: "govuk-table__caption--m",
             attributes: {
               "id": "search-results-true"
             },
             head: [
                 {
-                  text: "Name",
-                  classes: "bapv-table_cell"
+                  text: "Name"
                 },
                 {
-                  text: "Prison number",
-                  classes: "bapv-table_cell"
+                  text: "Prison number"
                 },
                 {
-                  text: "Date of birth",
-                  classes: "bapv-table_cell"
+                  text: "Date of birth"
                 }
             ],
             rows: results

--- a/server/views/pages/search/visitResults.njk
+++ b/server/views/pages/search/visitResults.njk
@@ -40,62 +40,50 @@
       {{ pagination | safe if numberOfResults > 10 }}
 
         {{ govukTable({
-            classes: " govuk-!-margin-top-3",
+            classes: "bapv-table govuk-!-margin-top-3",
             captionClasses: "govuk-table__caption--m",
             attributes: {
               "id": "search-results-true"
             },
             head: [
                 {
-                  text: "Booking reference",
-                  classes: "bapv-table_cell"
+                  text: "Booking reference"
                 },
                 {
-                  text: "Prisoner name",
-                  classes: "bapv-table_cell"
+                  text: "Prisoner name"
                 },
                 {
-                  text: "Prison number",
-                  classes: "bapv-table_cell"
+                  text: "Prison number"
                 },
                 {
-                  text: "Main contact",
-                  classes: "bapv-table_cell"
+                  text: "Main contact"
                 },
                 {
-                  text: "Visit date",
-                  classes: "bapv-table_cell"
+                  text: "Visit date"
                 },
                 {
-                  text: "Visit time",
-                  classes: "bapv-table_cell"
+                  text: "Visit time"
                 }
             ],
             rows: [
               [
                 {
-                  html: '<a href="/visit/' + results[0].reference + '">' + results[0].reference + '</a>',
-                  classes: 'bapv-table_cell'
+                  html: '<a href="/visit/' + results[0].reference + '">' + results[0].reference + '</a>'
                 },
                 {
-                  text: results[0].prisonerName | properCaseFullName,
-                  classes: 'bapv-table_cell'
+                  text: results[0].prisonerName | properCaseFullName
                 },
                 {
-                  text: results[0].prisonNumber,
-                  classes: 'bapv-table_cell'
+                  text: results[0].prisonNumber
                 },
                 {
-                  text: results[0].mainContact | formatMainContact,
-                  classes: 'bapv-table_cell'
+                  text: results[0].mainContact | formatMainContact
                 },
                 {
-                  text: results[0].visitDate,
-                  classes: 'bapv-table_cell'
+                  text: results[0].visitDate
                 },
                 {
-                  text: results[0].visitTime,
-                  classes: 'bapv-table_cell'
+                  text: results[0].visitTime
                 }
               ]
             ]


### PR DESCRIPTION
Simplify markup for tables by adding the extra spacing to the whole table (using class `bap-table`) rather than to every cell (using `bapv-table_cell`).