### PR TITLE
VB-683 use visitStatus filter

### DIFF
--- a/server/@types/visit-scheduler-api.d.ts
+++ b/server/@types/visit-scheduler-api.d.ts
@@ -11,6 +11,9 @@ export interface paths {
     /** Delete a visit by visit reference */
     delete: operations['deleteVisit']
   }
+  '/visits/{reference}/cancel': {
+    put: operations['cancelVisit']
+  }
   '/visits': {
     /** Retrieve visits with optional filters, sorted by startTimestamp ascending */
     get: operations['getVisitsByFilter']
@@ -189,11 +192,31 @@ export interface components {
        * @description The finishing date and time of the visit
        */
       endTimestamp: string
+      /** @description Visit Notes */
+      visitNotes: components['schemas']['VisitNoteDto'][]
       visitContact?: components['schemas']['ContactDto']
       /** @description List of visitors associated with the visit */
       visitors: components['schemas']['VisitorDto'][]
       /** @description List of additional support associated with the visit */
       visitorSupport: components['schemas']['VisitorSupportDto'][]
+      /**
+       * Format: date-time
+       * @description The visit created date and time
+       */
+      createdTimestamp: string
+    }
+    /** @description VisitNote */
+    VisitNoteDto: {
+      /**
+       * @description Note type
+       * @example VISITOR_CONCERN
+       */
+      type: 'VISITOR_CONCERN' | 'VISIT_OUTCOMES' | 'VISIT_COMMENT' | 'STATUS_CHANGED_REASON'
+      /**
+       * @description Note text
+       * @example Visitor is concerned that his mother in-law is coming!
+       */
+      text: string
     }
     /** @description Visitor */
     VisitorDto: {
@@ -275,19 +298,6 @@ export interface components {
       visitorSupport?: components['schemas']['CreateSupportOnVisitRequestDto'][]
       /** @description Visit notes */
       visitNotes?: components['schemas']['VisitNoteDto'][]
-    }
-    /** @description VisitNote */
-    VisitNoteDto: {
-      /**
-       * @description Note type
-       * @example VISITOR_CONCERN
-       */
-      type: 'VISITOR_CONCERN' | 'VISIT_OUTCOMES' | 'VISIT_COMMENT' | 'STATUS_CHANGED_REASON'
-      /**
-       * @description Note text
-       * @example Visitor is concerned that his mother in-law is coming!
-       */
-      text: string
     }
     CreateSessionTemplateRequestDto: {
       /**
@@ -594,6 +604,50 @@ export interface operations {
       }
     }
   }
+  cancelVisit: {
+    parameters: {
+      path: {
+        reference: string
+      }
+    }
+    responses: {
+      /** Visit cancelled */
+      200: {
+        content: {
+          'application/json': components['schemas']['VisitDto']
+        }
+      }
+      /** Incorrect request to cancel a visit */
+      400: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** Unauthorized to access this endpoint */
+      401: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** Incorrect permissions to cancel a visit */
+      403: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** Visit not found */
+      404: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateVisitRequestDto']
+      }
+    }
+  }
   /** Retrieve visits with optional filters, sorted by startTimestamp ascending */
   getVisitsByFilter: {
     parameters: {
@@ -608,6 +662,8 @@ export interface operations {
         endTimestamp?: string
         /** Filter results by visitor (contact id) */
         nomisPersonId?: number
+        /** Filter results by visit status */
+        visitStatus?: 'RESERVED' | 'BOOKED' | 'CANCELLED'
       }
     }
     responses: {

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -121,6 +121,7 @@ describe('visitSchedulerApiClient', () => {
           prisonerId: offenderNo,
           prisonId: 'HEI',
           startTimestamp: timestamp,
+          visitStatus: 'BOOKED',
         })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, results)
@@ -167,6 +168,7 @@ describe('visitSchedulerApiClient', () => {
           prisonerId: offenderNo,
           prisonId: 'HEI',
           endTimestamp: timestamp,
+          visitStatus: 'BOOKED',
         })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, results)

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -59,6 +59,7 @@ describe('visitSchedulerApiClient', () => {
         visitRestriction: 'OPEN',
         startTimestamp: timestamp,
         endTimestamp: '',
+        visitNotes: [],
         visitors: [
           {
             nomisPersonId: 1234,
@@ -70,6 +71,7 @@ describe('visitSchedulerApiClient', () => {
             text: 'custom support details',
           },
         ],
+        createdTimestamp: '2022-02-14T10:00:00',
       }
 
       fakeVisitSchedulerApi
@@ -97,6 +99,7 @@ describe('visitSchedulerApiClient', () => {
           visitRestriction: 'OPEN',
           startTimestamp: timestamp,
           endTimestamp: '',
+          visitNotes: [],
           visitors: [
             {
               nomisPersonId: 1234,
@@ -108,6 +111,7 @@ describe('visitSchedulerApiClient', () => {
               text: 'custom support details',
             },
           ],
+          createdTimestamp: '2022-02-14T10:00:00',
         },
       ]
 
@@ -141,6 +145,7 @@ describe('visitSchedulerApiClient', () => {
           visitRestriction: 'OPEN',
           startTimestamp: '',
           endTimestamp: timestamp,
+          visitNotes: [],
           visitors: [
             {
               nomisPersonId: 1234,
@@ -152,6 +157,7 @@ describe('visitSchedulerApiClient', () => {
               text: 'custom support details',
             },
           ],
+          createdTimestamp: '2022-02-14T10:00:00',
         },
       ]
 
@@ -220,6 +226,7 @@ describe('visitSchedulerApiClient', () => {
         visitRestriction,
         startTimestamp: '2022-02-14T10:00:00',
         endTimestamp: '2022-02-14T11:00:00',
+        visitNotes: [],
         visitContact: {
           name: 'John Smith',
           telephone: '01234 567890',
@@ -235,6 +242,7 @@ describe('visitSchedulerApiClient', () => {
             text: 'custom support details',
           },
         ],
+        createdTimestamp: '2022-02-14T10:00:00',
       }
       const visitSessionData = <VisitSessionData>{
         prisoner: {
@@ -288,7 +296,7 @@ describe('visitSchedulerApiClient', () => {
           }),
         })
         .matchHeader('authorization', `Bearer ${token}`)
-        .reply(200, result)
+        .reply(201, result)
 
       const output = await client.createVisit(visitSessionData)
 
@@ -312,6 +320,7 @@ describe('visitSchedulerApiClient', () => {
         visitRestriction: 'OPEN',
         startTimestamp: '2022-02-14T10:00:00',
         endTimestamp: '2022-02-14T11:00:00',
+        visitNotes: [],
         visitContact: {
           name: 'John Smith',
           telephone: '01234 567890',
@@ -329,6 +338,7 @@ describe('visitSchedulerApiClient', () => {
             text: 'custom request',
           },
         ],
+        createdTimestamp: '2022-02-14T10:00:00',
       }
 
       const visitSessionData: VisitSessionData = {
@@ -413,12 +423,14 @@ describe('visitSchedulerApiClient', () => {
         visitRestriction: 'OPEN',
         startTimestamp: '2022-02-14T10:00:00',
         endTimestamp: '2022-02-14T11:00:00',
+        visitNotes: [],
         visitors: [
           {
             nomisPersonId: 1234,
           },
         ],
         visitorSupport: [],
+        createdTimestamp: '2022-02-14T10:00:00',
       }
       const visitSessionData: VisitSessionData = {
         prisoner: {

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -24,6 +24,8 @@ class VisitSchedulerApiClient {
 
   private visitType = 'SOCIAL'
 
+  private visitStatus = 'BOOKED'
+
   getAvailableSupportOptions(): Promise<SupportType[]> {
     return this.restclient.get({
       path: '/visit-support',
@@ -41,6 +43,7 @@ class VisitSchedulerApiClient {
         prisonerId: offenderNo,
         prisonId: this.prisonId,
         startTimestamp: startTimestamp || new Date().toISOString(),
+        visitStatus: this.visitStatus,
       }).toString(),
     })
   }
@@ -52,6 +55,7 @@ class VisitSchedulerApiClient {
         prisonerId: offenderNo,
         prisonId: this.prisonId,
         endTimestamp: endTimestamp || new Date().toISOString(),
+        visitStatus: this.visitStatus,
       }).toString(),
     })
   }

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -583,12 +583,14 @@ describe('Visit sessions service', () => {
         visitRestriction: 'OPEN',
         startTimestamp: '2022-02-14T10:00:00',
         endTimestamp: '2022-02-14T11:00:00',
+        visitNotes: [],
         visitors: [
           {
             nomisPersonId: 1234,
           },
         ],
         visitorSupport: [],
+        createdTimestamp: '2022-02-14T10:00:00',
       }
 
       visitSchedulerApiClient.createVisit.mockResolvedValue(visit)
@@ -635,7 +637,7 @@ describe('Visit sessions service', () => {
             banned: false,
           },
         ],
-        visitorSupport: [{ type: 'WHEELCHAIR' }, { type: 'MASK_EXEMPT' }, { type: 'OTHER' }],
+        visitorSupport: [{ type: 'WHEELCHAIR' }, { type: 'MASK_EXEMPT' }, { type: 'OTHER', text: 'custom request' }],
         mainContact: {
           phoneNumber: '01234 567890',
           contactName: 'John Smith',
@@ -652,6 +654,7 @@ describe('Visit sessions service', () => {
         visitRestriction: 'OPEN',
         startTimestamp: '2022-02-14T10:00:00',
         endTimestamp: '2022-02-14T11:00:00',
+        visitNotes: [],
         visitContact: {
           name: 'John Smith',
           telephone: '01234 567890',
@@ -662,6 +665,7 @@ describe('Visit sessions service', () => {
           },
         ],
         visitorSupport: [{ type: 'WHEELCHAIR' }, { type: 'MASK_EXEMPT' }, { type: 'OTHER', text: 'custom request' }],
+        createdTimestamp: '2022-02-14T10:00:00',
       }
 
       visitSchedulerApiClient.updateVisit.mockResolvedValue(visit)
@@ -679,9 +683,11 @@ describe('Visit sessions service', () => {
         visitRestriction: 'OPEN',
         startTimestamp: '2022-02-14T10:00:00',
         endTimestamp: '2022-02-14T11:00:00',
+        visitNotes: [],
         visitContact: { name: 'John Smith', telephone: '01234 567890' },
         visitors: [{ nomisPersonId: 1234 }],
         visitorSupport: [{ type: 'WHEELCHAIR' }, { type: 'MASK_EXEMPT' }, { type: 'OTHER', text: 'custom request' }],
+        createdTimestamp: '2022-02-14T10:00:00',
       })
     })
   })
@@ -698,6 +704,7 @@ describe('Visit sessions service', () => {
         visitRestriction: 'OPEN',
         startTimestamp: '2022-02-14T10:00:00',
         endTimestamp: '2022-02-14T11:15:00',
+        visitNotes: [],
         visitContact: {
           name: 'John Smith',
           telephone: '01234 567890',
@@ -708,6 +715,7 @@ describe('Visit sessions service', () => {
           },
         ],
         visitorSupport: [],
+        createdTimestamp: '2022-02-14T10:00:00',
       }
 
       visitSchedulerApiClient.getVisit.mockResolvedValue(visit)
@@ -738,6 +746,7 @@ describe('Visit sessions service', () => {
           visitRestriction: 'OPEN',
           startTimestamp: '2022-02-14T10:00:00',
           endTimestamp: '2022-02-14T11:15:00',
+          visitNotes: [],
           visitContact: {
             name: 'John Smith',
             telephone: '01234 567890',
@@ -748,6 +757,7 @@ describe('Visit sessions service', () => {
             },
           ],
           visitorSupport: [],
+          createdTimestamp: '2022-02-14T10:00:00',
         },
       ]
 


### PR DESCRIPTION
* update the types from the Visit Scheduler
* add the `visitStatus` filter (hard-coded to `BOOKED`) to `GET /visits` requests so that cancelled or reserved visits don't show in listings (e.g. on prisoner profile tabs or prisoner visits listing)