### PR TITLE
VB-741: Refactor to use POST route to start booking journey

### DIFF
--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -64,10 +64,13 @@
         {% endif %}
       </ul>
 
-      {{ govukButton({
-        text: "Book a prison visit",
-        href: "/book-a-visit/select-visitors"
-      }) }}
+      <form action="/prisoner/{{ inmateDetail.offenderNo }}" method="POST" novalidate>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        {{ govukButton({
+          text: "Book a prison visit",
+          attributes: { "data-test": "book-a-visit" }
+        }) }}
+      </form>
 
     </div>
   </div>


### PR DESCRIPTION
Current Prisoner Profile page behaviour is to:
* Render 'Book a prison visit' button as a link to continue the journey (on to Select Visitors)
* Populate `visitSessionData` with the requested prisoner on load

In preparation for VB-741 (adding VO override checkbox), this changes the page to:
* use the button to submit to a new POST route that redirects to the next step in the journey (and will be used to validate the checkbox)
* populates `visitSessionData` in the POST route so that the session is only 'started' when the Book button is pressed rather than just by viewing a profile