### PR TITLE
Format contact with middle name correctly

### DIFF
--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -26,6 +26,16 @@ describe('Nunjucks Filters', () => {
       const $ = cheerio.load(compiledTemplate.render(viewContext))
       expect($('body').text()).toBe('Bloggs, Joe')
     })
+
+    it('should handle contact with middle name', () => {
+      viewContext = {
+        fullName: 'ONE TWO THREE',
+      }
+      const nunjucksString = '{{ fullName | formatLastNameFirst }}'
+      compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+      expect($('body').text()).toBe('Three, One')
+    })
   })
 
   describe('properCaseFullName', () => {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -61,7 +61,7 @@ export function registerNunjucks(app?: express.Express): Environment {
       return null
     }
     const array = fullName.split(' ')
-    return `${properCaseFullName(array[1])}, ${properCaseFullName(array[0])}`
+    return `${properCaseFullName(array.at(-1))}, ${properCaseFullName(array[0])}`
   })
 
   njkEnv.addFilter('properCaseFullName', (name: string) => {


### PR DESCRIPTION
If a custom main contact was entered with a middle name (e.g. `Firstname Middlename Lastname`) this was rendered in the booking summary incorrectly as `Middlename, Firstname`. This fix displays it as `Lastname, Firstname`.