### PR TITLE
VB-810: Use visitRestriction (open/closed) in session and to filter available slots

### DIFF
--- a/server/middleware/sessionCheckMiddleware.test.ts
+++ b/server/middleware/sessionCheckMiddleware.test.ts
@@ -3,13 +3,13 @@ import { Cookie } from 'express-session'
 import { VisitSessionData, VisitSlot } from '../@types/bapv'
 import sessionCheckMiddleware from './sessionCheckMiddleware'
 
-const prisonerData = {
+const prisonerData: VisitSessionData['prisoner'] = {
   name: 'abc',
   offenderNo: 'A1234BC',
   dateOfBirth: '12 May 1977',
   location: 'abc',
 }
-const visitorsData = [
+const visitorsData: VisitSessionData['visitors'] = [
   {
     personId: 123,
     name: 'abc',
@@ -27,13 +27,14 @@ const visitorsData = [
     banned: false,
   },
 ]
-const visit = {
+const visit: VisitSessionData['visit'] = {
   id: 'ab-cd-ef-gh',
   startTimestamp: '123',
   endTimestamp: '123',
   availableTables: 1,
   visitRoomName: 'visitRoom',
 }
+const visitRestriction: VisitSessionData['visitRestriction'] = 'OPEN'
 
 describe('sessionCheckMiddleware', () => {
   let mockResponse: Partial<Response>
@@ -64,7 +65,7 @@ describe('sessionCheckMiddleware', () => {
     expect(mockResponse.redirect).toHaveBeenCalledWith('/search/?error=missing-session')
   })
 
-  describe('prisoner data missing', () => {
+  describe('prisoner or default visitRestriction data missing', () => {
     ;[
       {
         prisoner: {},
@@ -85,10 +86,11 @@ describe('sessionCheckMiddleware', () => {
           name: 'abc',
           offenderNo: 'A1234BC',
           dateOfBirth: '12 May 1977',
+          location: 'abc',
         },
       },
     ].forEach((testData: VisitSessionData) => {
-      it('should redirect to the search page when there are missing bits of prisoner data', () => {
+      it('should redirect to the search page when there are missing bits of prisoner or visitRestriction data', () => {
         req.session.visitSessionData = testData
 
         sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
@@ -97,7 +99,7 @@ describe('sessionCheckMiddleware', () => {
       })
     })
 
-    it('should not redirect when there are no bits of missing prisoner data at stage 1', () => {
+    it('should not redirect when there are no bits of missing prisoner and visitRestriction data at stage 1', () => {
       req.session.visitSessionData = {
         prisoner: {
           name: 'abc',
@@ -105,6 +107,7 @@ describe('sessionCheckMiddleware', () => {
           dateOfBirth: '12 May 1977',
           location: 'abc',
         },
+        visitRestriction: 'OPEN',
       }
 
       sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
@@ -117,9 +120,11 @@ describe('sessionCheckMiddleware', () => {
     ;[
       {
         prisoner: prisonerData,
+        visitRestriction,
       },
       {
         prisoner: prisonerData,
+        visitRestriction,
         visitors: [],
       },
     ].forEach((testData: VisitSessionData) => {
@@ -137,10 +142,12 @@ describe('sessionCheckMiddleware', () => {
     ;[
       {
         prisoner: prisonerData,
+        visitRestriction,
         visitors: visitorsData,
       },
       {
         prisoner: prisonerData,
+        visitRestriction,
         visitors: visitorsData,
         visit: {
           id: 'ab-cd-ef-gh',
@@ -148,6 +155,7 @@ describe('sessionCheckMiddleware', () => {
       },
       {
         prisoner: prisonerData,
+        visitRestriction,
         visitors: visitorsData,
         visit: {
           id: 'ab-cd-ef-gh',
@@ -156,6 +164,7 @@ describe('sessionCheckMiddleware', () => {
       },
       {
         prisoner: prisonerData,
+        visitRestriction,
         visitors: visitorsData,
         visit: {
           id: 'ab-cd-ef-gh',
@@ -165,6 +174,7 @@ describe('sessionCheckMiddleware', () => {
       },
       {
         prisoner: prisonerData,
+        visitRestriction,
         visitors: visitorsData,
         visit: {
           id: 'ab-cd-ef-gh',
@@ -187,11 +197,13 @@ describe('sessionCheckMiddleware', () => {
     ;[
       {
         prisoner: prisonerData,
+        visitRestriction,
         visit,
         visitors: visitorsData,
       },
       {
         prisoner: prisonerData,
+        visitRestriction,
         visit,
         visitors: visitorsData,
         mainContact: {

--- a/server/middleware/sessionCheckMiddleware.ts
+++ b/server/middleware/sessionCheckMiddleware.ts
@@ -14,7 +14,8 @@ export default function sessionCheckMiddleware({ stage }: { stage: number }): Re
       !visitSessionData.prisoner.name ||
       !isValidPrisonerNumber(visitSessionData.prisoner.offenderNo || '') ||
       !visitSessionData.prisoner.dateOfBirth ||
-      !visitSessionData.prisoner.location
+      !visitSessionData.prisoner.location ||
+      !visitSessionData.visitRestriction
     ) {
       return res.redirect('/search/?error=missing-prisoner')
     }

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -149,6 +149,7 @@ describe('GET /book-a-visit/select-visitors', () => {
         dateOfBirth: '25 May 1988',
         location: 'location place',
       },
+      visitRestriction: 'OPEN',
     }
 
     prisonerVisitorsService.getVisitors.mockResolvedValue(returnData)
@@ -458,6 +459,7 @@ describe('POST /book-a-visit/select-visitors', () => {
         dateOfBirth: '25 May 1988',
         location: 'location place',
       },
+      visitRestriction: 'OPEN',
     }
 
     sessionApp = appWithAllRoutes(null, null, null, null, systemToken, false, {
@@ -757,6 +759,7 @@ describe('/book-a-visit/select-date-and-time', () => {
         dateOfBirth: '25 May 1988',
         location: 'location place',
       },
+      visitRestriction: 'OPEN',
       visitors: [
         {
           personId: 4323,
@@ -1009,6 +1012,7 @@ describe('GET /book-a-visit/additional-support', () => {
         dateOfBirth: '25 May 1988',
         location: 'location place',
       },
+      visitRestriction: 'OPEN',
       visit: {
         id: 'visitId',
         startTimestamp: '123',
@@ -1178,6 +1182,7 @@ describe('POST /book-a-visit/additional-support', () => {
         dateOfBirth: '25 May 1988',
         location: 'location place',
       },
+      visitRestriction: 'OPEN',
       visit: {
         id: 'visitId',
         startTimestamp: '123',
@@ -1399,6 +1404,7 @@ describe('/book-a-visit/select-main-contact', () => {
         dateOfBirth: '25 May 1988',
         location: 'location place',
       },
+      visitRestriction: 'OPEN',
       visit: {
         id: 'visitId',
         startTimestamp: '123',
@@ -1672,6 +1678,7 @@ describe('GET /book-a-visit/check-your-booking', () => {
         dateOfBirth: '25 May 1988',
         location: 'location place',
       },
+      visitRestriction: 'OPEN',
       visit: {
         id: 'visitId',
         startTimestamp: '2022-03-12T09:30:00',
@@ -1679,7 +1686,6 @@ describe('GET /book-a-visit/check-your-booking', () => {
         availableTables: 1,
         visitRoomName: 'room name',
       },
-      visitRestriction: 'OPEN',
       visitors: [
         {
           personId: 123,
@@ -1743,6 +1749,7 @@ describe('GET /book-a-visit/check-your-booking', () => {
           dateOfBirth: '25 May 1988',
           location: 'location place',
         },
+        visitRestriction: 'OPEN',
         visit: {
           id: 'visitId',
           startTimestamp: '2022-03-12T09:30:00',
@@ -1813,6 +1820,7 @@ describe('GET /book-a-visit/confirmation', () => {
         dateOfBirth: '25 May 1988',
         location: 'location place',
       },
+      visitRestriction: 'OPEN',
       visit: {
         id: 'visitId',
         startTimestamp: '2022-03-12T09:30:00',
@@ -1882,6 +1890,7 @@ describe('GET /book-a-visit/confirmation', () => {
           dateOfBirth: '25 May 1988',
           location: 'location place',
         },
+        visitRestriction: 'OPEN',
         visit: {
           id: 'visitId',
           startTimestamp: '2022-03-12T09:30:00',

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -1732,6 +1732,7 @@ describe('GET /book-a-visit/check-your-booking', () => {
         expect($('.test-prisoner-location').text()).toContain('location place')
         expect($('.test-visit-date').text()).toContain('Saturday 12 March 2022')
         expect($('.test-visit-time').text()).toContain('9:30am to 10:30am')
+        expect($('.test-visit-type').text()).toContain('Open')
         expect($('.test-visitor-name1').text()).toContain('name last (relate of the prisoner)')
         expect($('.test-visitor-address1').text()).toContain('123 Street, Test Town, S1 2QZ')
         expect($('.test-additional-support1').text()).toContain('Wheelchair ramp')
@@ -1800,6 +1801,7 @@ describe('GET /book-a-visit/check-your-booking', () => {
           expect($('.test-prisoner-location').text()).toContain('location place')
           expect($('.test-visit-date').text()).toContain('Saturday 12 March 2022')
           expect($('.test-visit-time').text()).toContain('9:30am to 10:30am')
+          expect($('.test-visit-type').text()).toContain('Open')
           expect($('.test-visitor-name1').text()).toContain('name last (relate of the prisoner)')
           expect($('.test-visitor-address1').text()).toContain('123 Street, Test Town, S1 2QZ')
           expect($('[data-test="no-addition-support-chosen"]').text()).toContain(
@@ -1873,6 +1875,7 @@ describe('GET /book-a-visit/confirmation', () => {
         expect($('.test-prisoner-location').text()).toContain('location place')
         expect($('.test-visit-date').text()).toContain('Saturday 12 March 2022')
         expect($('.test-visit-time').text()).toContain('9:30am to 10:30am')
+        expect($('.test-visit-type').text()).toContain('Open')
         expect($('.test-visitor-name1').text()).toContain('name last (relate of the prisoner)')
         expect($('.test-additional-support1').text()).toContain('Wheelchair ramp')
         expect($('.test-additional-support2').text()).toContain('Portable induction loop for people with hearing aids')
@@ -1943,6 +1946,7 @@ describe('GET /book-a-visit/confirmation', () => {
           expect($('.test-prisoner-location').text()).toContain('location place')
           expect($('.test-visit-date').text()).toContain('Saturday 12 March 2022')
           expect($('.test-visit-time').text()).toContain('9:30am to 10:30am')
+          expect($('.test-visit-type').text()).toContain('Open')
           expect($('.test-visitor-name1').text()).toContain('name last (relate of the prisoner)')
           expect($('[data-test="no-addition-support-chosen"]').text()).toContain(
             'No additional support options were chosen.'

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -800,6 +800,7 @@ describe('/book-a-visit/select-date-and-time', () => {
           const $ = cheerio.load(res.text)
           expect($('h1').text().trim()).toBe('Select date and time of visit')
           expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+          expect($('[data-test="visit-restriction"]').text()).toBe('Open')
           expect($('input[name="visit-date-and-time"]').length).toBe(5)
           expect($('input[name="visit-date-and-time"]:checked').length).toBe(0)
           expect($('.govuk-accordion__section--expanded').length).toBe(0)

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -191,9 +191,6 @@ export default function routes(
 
       visitSessionData.visit = getSelectedSlot(req.session.slotsList, req.body['visit-date-and-time'])
 
-      // @TODO placeholder until open/closed visits handled properly
-      visitSessionData.visitRestriction = 'OPEN'
-
       if (req.session.visitSessionData.visitReference) {
         await visitSessionsService.updateVisit({
           username: res.locals.user?.username,

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -377,6 +377,7 @@ export default function routes(
       mainContact: visitSessionData.mainContact,
       prisoner: visitSessionData.prisoner,
       visit: visitSessionData.visit,
+      visitRestriction: visitSessionData.visitRestriction,
       visitors: visitSessionData.visitors,
       additionalSupport,
     })
@@ -403,6 +404,7 @@ export default function routes(
         mainContact: visitSessionData.mainContact,
         prisoner: visitSessionData.prisoner,
         visit: visitSessionData.visit,
+        visitRestriction: visitSessionData.visitRestriction,
         visitors: visitSessionData.visitors,
         additionalSupport,
       })
@@ -429,6 +431,7 @@ export default function routes(
         mainContact: visitSessionData.mainContact,
         prisoner: visitSessionData.prisoner,
         visit: visitSessionData.visit,
+        visitRestriction: visitSessionData.visitRestriction,
         visitors: visitSessionData.visitors,
         additionalSupport,
       })
@@ -452,6 +455,7 @@ export default function routes(
       prisoner: visitSessionData.prisoner,
       mainContact: visitSessionData.mainContact,
       visit: visitSessionData.visit,
+      visitRestriction: visitSessionData.visitRestriction,
       visitors: visitSessionData.visitors,
       additionalSupport,
     })

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -152,6 +152,7 @@ export default function routes(
 
       res.render('pages/dateAndTime', {
         errors: req.flash('errors'),
+        visitRestriction: visitSessionData.visitRestriction,
         prisonerName: visitSessionData.prisoner.name,
         slotsList,
         timeOfDay,

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -137,6 +137,7 @@ export default function routes(
       const slotsList = await visitSessionsService.getVisitSessions({
         username: res.locals.user?.username,
         offenderNo: visitSessionData.prisoner.offenderNo,
+        visitRestriction: visitSessionData.visitRestriction,
         timeOfDay,
         dayOfTheWeek,
       })

--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -279,7 +279,7 @@ describe('POST /prisoner/A1234BC', () => {
     prisonerProfileService.getPrisonerAndVisitBalances.mockResolvedValue({ inmateDetail, visitBalances })
   })
 
-  it('should set up visitSessionData and redirect to select visitors page', () => {
+  it('should set up visitSessionData (with default OPEN visit) and redirect to select visitors page', () => {
     return request(app)
       .post('/prisoner/A1234BC')
       .expect(302)
@@ -294,6 +294,7 @@ describe('POST /prisoner/A1234BC', () => {
             dateOfBirth: '2 April 1975',
             location: '1-1-C-028, HMP Hewell',
           },
+          visitRestriction: 'OPEN',
         })
       })
   })
@@ -305,6 +306,7 @@ describe('POST /prisoner/A1234BC', () => {
       dateOfBirth: '5 May 1980',
       location: 'a cell, HMP Prison',
     }
+    visitSessionData.visitRestriction = 'CLOSED'
 
     return request(app)
       .post('/prisoner/A1234BC')
@@ -320,6 +322,7 @@ describe('POST /prisoner/A1234BC', () => {
             dateOfBirth: '2 April 1975',
             location: '1-1-C-028, HMP Hewell',
           },
+          visitRestriction: 'OPEN',
         })
       })
   })

--- a/server/routes/prisoner.ts
+++ b/server/routes/prisoner.ts
@@ -59,6 +59,9 @@ export default function routes(
         : '',
     }
 
+    // default to an OPEN visit; later checks could change this to CLOSED
+    visitSessionData.visitRestriction = 'OPEN'
+
     req.session.visitSessionData = visitSessionData
 
     return res.redirect('/book-a-visit/select-visitors')

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -66,7 +66,11 @@ describe('Visit sessions service', () => {
     it('Should return empty object if no visit sessions', async () => {
       visitSchedulerApiClient.getVisitSessions.mockResolvedValue([])
       whereaboutsApiClient.getEvents.mockResolvedValue([])
-      const results = await visitSessionsService.getVisitSessions({ username: 'user', offenderNo: 'A1234BC' })
+      const results = await visitSessionsService.getVisitSessions({
+        username: 'user',
+        offenderNo: 'A1234BC',
+        visitRestriction: 'OPEN',
+      })
 
       expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
       expect(results).toEqual({})
@@ -112,7 +116,11 @@ describe('Visit sessions service', () => {
           },
         ]
         whereaboutsApiClient.getEvents.mockResolvedValue(events)
-        const results = await visitSessionsService.getVisitSessions({ username: 'user', offenderNo: 'A1234BC' })
+        const results = await visitSessionsService.getVisitSessions({
+          username: 'user',
+          offenderNo: 'A1234BC',
+          visitRestriction: 'OPEN',
+        })
 
         expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
         expect(whereaboutsApiClient.getEvents).toHaveBeenCalledTimes(1)
@@ -165,7 +173,11 @@ describe('Visit sessions service', () => {
           },
         ]
         whereaboutsApiClient.getEvents.mockResolvedValue(events)
-        const results = await visitSessionsService.getVisitSessions({ username: 'user', offenderNo: 'A1234BC' })
+        const results = await visitSessionsService.getVisitSessions({
+          username: 'user',
+          offenderNo: 'A1234BC',
+          visitRestriction: 'OPEN',
+        })
 
         expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
         expect(whereaboutsApiClient.getEvents).toHaveBeenCalledTimes(1)
@@ -196,7 +208,11 @@ describe('Visit sessions service', () => {
 
       it('with no prisoner events', async () => {
         whereaboutsApiClient.getEvents.mockResolvedValue([])
-        const results = await visitSessionsService.getVisitSessions({ username: 'user', offenderNo: 'A1234BC' })
+        const results = await visitSessionsService.getVisitSessions({
+          username: 'user',
+          offenderNo: 'A1234BC',
+          visitRestriction: 'OPEN',
+        })
 
         expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
         expect(whereaboutsApiClient.getEvents).toHaveBeenCalledTimes(1)
@@ -223,6 +239,56 @@ describe('Visit sessions service', () => {
             },
           ],
         })
+      })
+    })
+
+    it('Should handle closed visits', async () => {
+      const sessions: VisitSession[] = [
+        {
+          sessionTemplateId: 10,
+          visitRoomName: 'A1',
+          visitType: 'SOCIAL',
+          prisonId: 'HEI',
+          openVisitCapacity: 15,
+          openVisitBookedCount: 1,
+          closedVisitCapacity: 10,
+          closedVisitBookedCount: 2,
+          startTimestamp: '2022-02-14T10:00:00',
+          endTimestamp: '2022-02-14T11:00:00',
+        },
+      ]
+
+      visitSchedulerApiClient.getVisitSessions.mockResolvedValue(sessions)
+      whereaboutsApiClient.getEvents.mockResolvedValue([])
+      const results = await visitSessionsService.getVisitSessions({
+        username: 'user',
+        offenderNo: 'A1234BC',
+        visitRestriction: 'CLOSED',
+      })
+
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+      expect(results).toEqual(<VisitSlotList>{
+        'February 2022': [
+          {
+            date: 'Monday 14 February',
+            prisonerEvents: {
+              morning: [],
+              afternoon: [],
+            },
+            slots: {
+              morning: [
+                {
+                  id: '1',
+                  startTimestamp: '2022-02-14T10:00:00',
+                  endTimestamp: '2022-02-14T11:00:00',
+                  availableTables: 8,
+                  visitRoomName: 'A1',
+                },
+              ],
+              afternoon: [],
+            },
+          },
+        ],
       })
     })
 
@@ -292,7 +358,11 @@ describe('Visit sessions service', () => {
 
       visitSchedulerApiClient.getVisitSessions.mockResolvedValue(sessions)
       whereaboutsApiClient.getEvents.mockResolvedValue([])
-      const results = await visitSessionsService.getVisitSessions({ username: 'user', offenderNo: 'A1234BC' })
+      const results = await visitSessionsService.getVisitSessions({
+        username: 'user',
+        offenderNo: 'A1234BC',
+        visitRestriction: 'OPEN',
+      })
 
       expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
       expect(results).toEqual(<VisitSlotList>{
@@ -396,6 +466,7 @@ describe('Visit sessions service', () => {
       const results = await visitSessionsService.getVisitSessions({
         username: 'user',
         offenderNo: 'A1234BC',
+        visitRestriction: 'OPEN',
         timeOfDay: 'morning',
       })
 
@@ -446,6 +517,7 @@ describe('Visit sessions service', () => {
       const results = await visitSessionsService.getVisitSessions({
         username: 'user',
         offenderNo: 'A1234BC',
+        visitRestriction: 'OPEN',
         timeOfDay: 'afternoon',
       })
 
@@ -488,6 +560,7 @@ describe('Visit sessions service', () => {
       const results = await visitSessionsService.getVisitSessions({
         username: 'user',
         offenderNo: 'A1234BC',
+        visitRestriction: 'OPEN',
         dayOfTheWeek: '1',
       })
 
@@ -538,6 +611,7 @@ describe('Visit sessions service', () => {
       const results = await visitSessionsService.getVisitSessions({
         username: 'user',
         offenderNo: 'A1234BC',
+        visitRestriction: 'OPEN',
         dayOfTheWeek: '2',
       })
 

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -42,11 +42,13 @@ export default class VisitSessionsService {
   async getVisitSessions({
     username,
     offenderNo,
+    visitRestriction,
     dayOfTheWeek = '',
     timeOfDay = '',
   }: {
     username: string
     offenderNo: string
+    visitRestriction: VisitSessionData['visitRestriction']
     dayOfTheWeek?: string
     timeOfDay?: string
   }): Promise<VisitSlotList> {
@@ -85,8 +87,10 @@ export default class VisitSessionsService {
             id: (slotIdCounter + 1).toString(),
             startTimestamp: visitSession.startTimestamp,
             endTimestamp: visitSession.endTimestamp,
-            // @TODO this will need fixing to handle open/closed visits
-            availableTables: visitSession.openVisitCapacity - visitSession.openVisitBookedCount,
+            availableTables:
+              visitRestriction === 'OPEN'
+                ? visitSession.openVisitCapacity - visitSession.openVisitBookedCount
+                : visitSession.closedVisitCapacity - visitSession.closedVisitBookedCount,
             visitRoomName: visitSession.visitRoomName,
           }
 

--- a/server/views/pages/checkYourBooking.njk
+++ b/server/views/pages/checkYourBooking.njk
@@ -98,7 +98,8 @@
                         text: "Visit type"
                     },
                     value: {
-                        text: "Open"
+                        text: visitRestriction | capitalize,
+                        classes: "test-visit-type"
                     }
                 }
             ]

--- a/server/views/pages/confirmation.njk
+++ b/server/views/pages/confirmation.njk
@@ -71,7 +71,8 @@
                         text: "Visit type"
                     },
                     value: {
-                        text: "Open"
+                        text: visitRestriction | capitalize,
+                        classes: "test-visit-type"
                     }
                 }
             ]

--- a/server/views/pages/dateAndTime.njk
+++ b/server/views/pages/dateAndTime.njk
@@ -40,7 +40,7 @@
 
     <p><strong>Prisoner name:</strong> <span data-test="prisoner-name">{{ prisonerName }}</span></p>
 
-    <p><strong>Visit type:</strong> Open</p>
+    <p><strong>Visit type:</strong> <span data-test="visit-restriction">{{ visitRestriction | capitalize }}</span></p>
 
     {% if slotsList | length %}
     <p>Showing visit time slots for the next 28 days.</p>

--- a/server/views/pages/dateAndTime.test.ts
+++ b/server/views/pages/dateAndTime.test.ts
@@ -27,6 +27,7 @@ describe('Views - Date and time of visit', () => {
   it('should display date and time picker for two months with morning and afternoon slots', () => {
     viewContext = {
       prisonerName: 'John Smith',
+      visitRestriction: 'OPEN',
       slotsList: {
         'February 2022': [
           {
@@ -95,6 +96,7 @@ describe('Views - Date and time of visit', () => {
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
     expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+    expect($('[data-test="visit-restriction"]').text()).toBe('Open')
 
     expect($('[data-test="month"]').eq(0).text()).toBe('February 2022')
     expect($('#slots-month-February2022-heading-1').text().trim()).toBe('Monday 14 February')


### PR DESCRIPTION
Set `visitRestriction` (defaulting to `OPEN`) when `visitSessionData` is first created. Use this value throughout journey (instead of hardcoded 'Open') and use it to filter available date/time slots.