### PR TITLE
VB-826: Clear session after booking

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -1,5 +1,5 @@
 import { InmateDetail, VisitBalances } from '../data/prisonApiTypes'
-import { VisitorSupport } from '../data/visitSchedulerApiTypes'
+import { Visit, VisitorSupport } from '../data/visitSchedulerApiTypes'
 
 export type PrisonerDetailsItem = {
   html?: string
@@ -185,6 +185,7 @@ export type VisitSessionData = {
     contactName?: string
   }
   visitReference?: string
+  visitStatus?: Visit['visitStatus']
 }
 
 export type VisitInformation = {

--- a/server/middleware/sessionCheckMiddleware.test.ts
+++ b/server/middleware/sessionCheckMiddleware.test.ts
@@ -28,7 +28,7 @@ const visitorsData: VisitSessionData['visitors'] = [
   },
 ]
 const visit: VisitSessionData['visit'] = {
-  id: 'ab-cd-ef-gh',
+  id: '1',
   startTimestamp: '123',
   endTimestamp: '123',
   availableTables: 1,
@@ -150,7 +150,7 @@ describe('sessionCheckMiddleware', () => {
         visitRestriction,
         visitors: visitorsData,
         visit: {
-          id: 'ab-cd-ef-gh',
+          id: '1',
         } as VisitSlot,
       },
       {
@@ -158,7 +158,7 @@ describe('sessionCheckMiddleware', () => {
         visitRestriction,
         visitors: visitorsData,
         visit: {
-          id: 'ab-cd-ef-gh',
+          id: '1',
           startTimestamp: '123',
         } as VisitSlot,
       },
@@ -167,7 +167,7 @@ describe('sessionCheckMiddleware', () => {
         visitRestriction,
         visitors: visitorsData,
         visit: {
-          id: 'ab-cd-ef-gh',
+          id: '1',
           startTimestamp: '123',
           endTimestamp: '123',
         } as VisitSlot,
@@ -177,7 +177,7 @@ describe('sessionCheckMiddleware', () => {
         visitRestriction,
         visitors: visitorsData,
         visit: {
-          id: 'ab-cd-ef-gh',
+          id: '1',
           startTimestamp: '123',
           endTimestamp: '123',
         } as VisitSlot,
@@ -193,6 +193,23 @@ describe('sessionCheckMiddleware', () => {
     })
   })
 
+  describe('visit reference', () => {
+    it('should redirect to the prisoner profile if visit booking reference not set', () => {
+      const testData: VisitSessionData = {
+        prisoner: prisonerData,
+        visitRestriction,
+        visit,
+        visitors: visitorsData,
+      }
+
+      req.session.visitSessionData = testData
+
+      sessionCheckMiddleware({ stage: 3 })(req as Request, mockResponse as Response, next)
+
+      expect(mockResponse.redirect).toHaveBeenCalledWith('/prisoner/A1234BC?error=missing-visit-reference')
+    })
+  })
+
   describe('main contact data missing', () => {
     ;[
       {
@@ -200,7 +217,9 @@ describe('sessionCheckMiddleware', () => {
         visitRestriction,
         visit,
         visitors: visitorsData,
-      },
+        visitReference: 'ab-cd-ef-gh',
+        visitStatus: 'RESERVED',
+      } as VisitSessionData,
       {
         prisoner: prisonerData,
         visitRestriction,
@@ -209,7 +228,9 @@ describe('sessionCheckMiddleware', () => {
         mainContact: {
           phoneNumber: '',
         },
-      },
+        visitReference: 'ab-cd-ef-gh',
+        visitStatus: 'RESERVED',
+      } as VisitSessionData,
     ].forEach((testData: VisitSessionData) => {
       it('should redirect to the prisoner profile when there is missing main contact data', () => {
         req.session.visitSessionData = testData
@@ -218,6 +239,65 @@ describe('sessionCheckMiddleware', () => {
 
         expect(mockResponse.redirect).toHaveBeenCalledWith('/prisoner/A1234BC?error=missing-main-contact')
       })
+    })
+  })
+
+  describe('check visit status', () => {
+    beforeEach(() => {
+      const testData: VisitSessionData = {
+        prisoner: prisonerData,
+        visitRestriction,
+        visit,
+        visitors: visitorsData,
+        mainContact: {
+          phoneNumber: '01234567899',
+          contactName: 'abc',
+        },
+      }
+
+      req.session.visitSessionData = testData
+    })
+
+    it('should not redirect if visit status missing prior to selecting a visit slot', () => {
+      sessionCheckMiddleware({ stage: 2 })(req as Request, mockResponse as Response, next)
+
+      expect(mockResponse.redirect).not.toHaveBeenCalled()
+    })
+
+    it('should not redirect if visit status is RESERVED during booking journey', () => {
+      req.session.visitSessionData.visitReference = 'ab-cd-ef-gh'
+      req.session.visitSessionData.visitStatus = 'RESERVED'
+
+      sessionCheckMiddleware({ stage: 3 })(req as Request, mockResponse as Response, next)
+
+      expect(mockResponse.redirect).not.toHaveBeenCalled()
+    })
+
+    it('should redirect to the prisoner profile if visit status is not RESERVED during booking journey', () => {
+      req.session.visitSessionData.visitReference = 'ab-cd-ef-gh'
+      req.session.visitSessionData.visitStatus = 'BOOKED'
+
+      sessionCheckMiddleware({ stage: 3 })(req as Request, mockResponse as Response, next)
+
+      expect(mockResponse.redirect).toHaveBeenCalledWith('/prisoner/A1234BC?error=visit-already-booked')
+    })
+
+    it('should not redirect if visit status is BOOKED at end of booking journey', () => {
+      req.session.visitSessionData.visitReference = 'ab-cd-ef-gh'
+      req.session.visitSessionData.visitStatus = 'BOOKED'
+
+      sessionCheckMiddleware({ stage: 6 })(req as Request, mockResponse as Response, next)
+
+      expect(mockResponse.redirect).not.toHaveBeenCalled()
+    })
+
+    it('should redirect to the prisoner profile if visit status is not BOOKED at end of booking journey', () => {
+      req.session.visitSessionData.visitReference = 'ab-cd-ef-gh'
+      req.session.visitSessionData.visitStatus = 'RESERVED'
+
+      sessionCheckMiddleware({ stage: 6 })(req as Request, mockResponse as Response, next)
+
+      expect(mockResponse.redirect).toHaveBeenCalledWith('/prisoner/A1234BC?error=visit-not-booked')
     })
   })
 })

--- a/server/middleware/sessionCheckMiddleware.test.ts
+++ b/server/middleware/sessionCheckMiddleware.test.ts
@@ -59,10 +59,10 @@ describe('sessionCheckMiddleware', () => {
     }
   })
 
-  it('should redirect to the search page when there is no session', () => {
+  it('should redirect to the prisoner search page when there is no session', () => {
     sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
 
-    expect(mockResponse.redirect).toHaveBeenCalledWith('/search/?error=missing-session')
+    expect(mockResponse.redirect).toHaveBeenCalledWith('/search/prisoner/?error=missing-session')
   })
 
   describe('prisoner or default visitRestriction data missing', () => {
@@ -90,12 +90,12 @@ describe('sessionCheckMiddleware', () => {
         },
       },
     ].forEach((testData: VisitSessionData) => {
-      it('should redirect to the search page when there are missing bits of prisoner or visitRestriction data', () => {
+      it('should redirect to the prisoner search page when there are missing bits of prisoner or visitRestriction data', () => {
         req.session.visitSessionData = testData
 
         sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
 
-        expect(mockResponse.redirect).toHaveBeenCalledWith('/search/?error=missing-prisoner')
+        expect(mockResponse.redirect).toHaveBeenCalledWith('/search/prisoner/?error=missing-prisoner')
       })
     })
 

--- a/server/middleware/sessionCheckMiddleware.ts
+++ b/server/middleware/sessionCheckMiddleware.ts
@@ -6,7 +6,7 @@ export default function sessionCheckMiddleware({ stage }: { stage: number }): Re
     const { visitSessionData } = req.session
 
     if (!visitSessionData) {
-      return res.redirect('/search/?error=missing-session')
+      return res.redirect('/search/prisoner/?error=missing-session')
     }
 
     if (
@@ -17,7 +17,7 @@ export default function sessionCheckMiddleware({ stage }: { stage: number }): Re
       !visitSessionData.prisoner.location ||
       !visitSessionData.visitRestriction
     ) {
-      return res.redirect('/search/?error=missing-prisoner')
+      return res.redirect('/search/prisoner/?error=missing-prisoner')
     }
 
     if (stage > 1 && (!visitSessionData.visitors || visitSessionData.visitors.length === 0)) {

--- a/server/middleware/sessionCheckMiddleware.ts
+++ b/server/middleware/sessionCheckMiddleware.ts
@@ -35,6 +35,14 @@ export default function sessionCheckMiddleware({ stage }: { stage: number }): Re
       return res.redirect(`/prisoner/${visitSessionData.prisoner.offenderNo}?error=missing-visit`)
     }
 
+    if (stage > 2 && !visitSessionData.visitReference) {
+      return res.redirect(`/prisoner/${visitSessionData.prisoner.offenderNo}?error=missing-visit-reference`)
+    }
+
+    if (stage > 2 && stage < 6 && visitSessionData.visitStatus !== 'RESERVED') {
+      return res.redirect(`/prisoner/${visitSessionData.prisoner.offenderNo}?error=visit-already-booked`)
+    }
+
     if (
       stage > 4 &&
       (!visitSessionData.mainContact ||
@@ -42,6 +50,10 @@ export default function sessionCheckMiddleware({ stage }: { stage: number }): Re
         (!visitSessionData.mainContact.contact && !visitSessionData.mainContact.contactName))
     ) {
       return res.redirect(`/prisoner/${visitSessionData.prisoner.offenderNo}?error=missing-main-contact`)
+    }
+
+    if (stage > 5 && visitSessionData.visitStatus !== 'BOOKED') {
+      return res.redirect(`/prisoner/${visitSessionData.prisoner.offenderNo}?error=visit-not-booked`)
     }
 
     return next()

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -10,6 +10,7 @@ import VisitSessionsService from '../services/visitSessionsService'
 import { appWithAllRoutes, flashProvider } from './testutils/appSetup'
 import { Restriction } from '../data/prisonerContactRegistryApiTypes'
 import { SupportType, Visit, VisitorSupport } from '../data/visitSchedulerApiTypes'
+import * as visitorUtils from './visitorUtils'
 
 jest.mock('../services/prisonerProfileService')
 jest.mock('../services/prisonerVisitorsService')
@@ -1829,6 +1830,8 @@ describe('GET /book-a-visit/check-your-booking', () => {
 
 describe('GET /book-a-visit/confirmation', () => {
   beforeEach(() => {
+    jest.spyOn(visitorUtils, 'clearSession')
+
     visitSessionData = {
       prisoner: {
         name: 'prisoner name',
@@ -1896,11 +1899,15 @@ describe('GET /book-a-visit/confirmation', () => {
         expect($('.test-main-contact-name').text()).toContain('abc')
         expect($('.test-main-contact-number').text()).toContain('123')
         expect($('.test-booking-reference').text()).toContain('ab-cd-ef-gh')
+
+        expect(visitorUtils.clearSession).toBeCalledTimes(1)
       })
   })
 
   describe('when no additional support options are chosen', () => {
     beforeEach(() => {
+      jest.spyOn(visitorUtils, 'clearSession')
+
       visitSessionData = {
         prisoner: {
           name: 'prisoner name',
@@ -1969,6 +1976,8 @@ describe('GET /book-a-visit/confirmation', () => {
           expect($('.test-main-contact-name').text()).toContain('abc')
           expect($('.test-main-contact-number').text()).toContain('123')
           expect($('.test-booking-reference').text()).toContain('ab-cd-ef-gh')
+
+          expect(visitorUtils.clearSession).toBeCalledTimes(1)
         })
     })
   })

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -9,7 +9,7 @@ import PrisonerProfileService from '../services/prisonerProfileService'
 import VisitSessionsService from '../services/visitSessionsService'
 import { appWithAllRoutes, flashProvider } from './testutils/appSetup'
 import { Restriction } from '../data/prisonerContactRegistryApiTypes'
-import { SupportType, VisitorSupport } from '../data/visitSchedulerApiTypes'
+import { SupportType, Visit, VisitorSupport } from '../data/visitSchedulerApiTypes'
 
 jest.mock('../services/prisonerProfileService')
 jest.mock('../services/prisonerVisitorsService')
@@ -881,8 +881,10 @@ describe('/book-a-visit/select-date-and-time', () => {
       systemToken
     ) as jest.Mocked<VisitSessionsService>
 
+    const createdVisit: Partial<Visit> = { reference: '2a-bc-3d-ef', visitStatus: 'RESERVED' }
+
     beforeEach(() => {
-      visitSessionsService.createVisit = jest.fn().mockResolvedValue('2a-bc-3d-ef')
+      visitSessionsService.createVisit = jest.fn().mockResolvedValue(createdVisit)
       visitSessionsService.updateVisit = jest.fn()
 
       sessionApp = appWithAllRoutes(null, null, null, visitSessionsService, systemToken, false, {
@@ -908,6 +910,7 @@ describe('/book-a-visit/select-date-and-time', () => {
           expect(visitSessionsService.createVisit).toHaveBeenCalledTimes(1)
           expect(visitSessionsService.updateVisit).not.toHaveBeenCalled()
           expect(visitSessionData.visitReference).toEqual('2a-bc-3d-ef')
+          expect(visitSessionData.visitStatus).toEqual('RESERVED')
         })
     })
 
@@ -1030,6 +1033,8 @@ describe('GET /book-a-visit/additional-support', () => {
           banned: false,
         },
       ],
+      visitReference: 'ab-cd-ef-gh',
+      visitStatus: 'RESERVED',
     }
 
     sessionApp = appWithAllRoutes(null, null, null, null, systemToken, false, {
@@ -1209,6 +1214,8 @@ describe('POST /book-a-visit/additional-support', () => {
           banned: false,
         },
       ],
+      visitReference: 'ab-cd-ef-gh',
+      visitStatus: 'RESERVED',
     }
     sessionApp = appWithAllRoutes(null, null, null, null, systemToken, false, {
       availableSupportTypes,
@@ -1423,6 +1430,8 @@ describe('/book-a-visit/select-main-contact', () => {
         },
       ],
       visitorSupport: [],
+      visitReference: 'ab-cd-ef-gh',
+      visitStatus: 'RESERVED',
     }
 
     sessionApp = appWithAllRoutes(null, null, null, null, systemToken, false, {
@@ -1711,6 +1720,8 @@ describe('GET /book-a-visit/check-your-booking', () => {
         phoneNumber: '123',
         contactName: 'abc',
       },
+      visitReference: 'ab-cd-ef-gh',
+      visitStatus: 'RESERVED',
     }
     sessionApp = appWithAllRoutes(null, null, null, null, systemToken, false, {
       availableSupportTypes,
@@ -1783,6 +1794,8 @@ describe('GET /book-a-visit/check-your-booking', () => {
           phoneNumber: '123',
           contactName: 'abc',
         },
+        visitReference: 'ab-cd-ef-gh',
+        visitStatus: 'RESERVED',
       }
       sessionApp = appWithAllRoutes(null, null, null, null, systemToken, false, { visitSessionData } as SessionData)
     })
@@ -1856,6 +1869,7 @@ describe('GET /book-a-visit/confirmation', () => {
         contactName: 'abc',
       },
       visitReference: 'ab-cd-ef-gh',
+      visitStatus: 'BOOKED',
     }
     sessionApp = appWithAllRoutes(null, null, null, null, systemToken, false, {
       availableSupportTypes,
@@ -1927,6 +1941,7 @@ describe('GET /book-a-visit/confirmation', () => {
           contactName: 'abc',
         },
         visitReference: 'ab-cd-ef-gh',
+        visitStatus: 'BOOKED',
       }
       sessionApp = appWithAllRoutes(null, null, null, null, systemToken, false, {
         availableSupportTypes,

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -5,7 +5,7 @@ import sessionCheckMiddleware from '../middleware/sessionCheckMiddleware'
 import PrisonerVisitorsService from '../services/prisonerVisitorsService'
 import PrisonerProfileService from '../services/prisonerProfileService'
 import VisitSessionsService from '../services/visitSessionsService'
-import { getFlashFormValues, getSelectedSlot, getSupportTypeDescriptions } from './visitorUtils'
+import { clearSession, getFlashFormValues, getSelectedSlot, getSupportTypeDescriptions } from './visitorUtils'
 import { SupportType, VisitorSupport } from '../data/visitSchedulerApiTypes'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 
@@ -424,23 +424,21 @@ export default function routes(
 
   get('/confirmation', sessionCheckMiddleware({ stage: 6 }), async (req, res) => {
     const { visitSessionData } = req.session
-    const { offenderNo } = req.session.visitSessionData.prisoner
 
-    const additionalSupport = getSupportTypeDescriptions(
+    res.locals.prisoner = visitSessionData.prisoner
+    res.locals.visit = visitSessionData.visit
+    res.locals.visitRestriction = visitSessionData.visitRestriction
+    res.locals.visitors = visitSessionData.visitors
+    res.locals.mainContact = visitSessionData.mainContact
+    res.locals.visitReference = visitSessionData.visitReference
+    res.locals.additionalSupport = getSupportTypeDescriptions(
       req.session.availableSupportTypes,
       visitSessionData.visitorSupport
     )
 
-    res.render('pages/confirmation', {
-      visitReference: visitSessionData.visitReference,
-      offenderNo,
-      prisoner: visitSessionData.prisoner,
-      mainContact: visitSessionData.mainContact,
-      visit: visitSessionData.visit,
-      visitRestriction: visitSessionData.visitRestriction,
-      visitors: visitSessionData.visitors,
-      additionalSupport,
-    })
+    clearSession(req)
+
+    res.render('pages/confirmation')
   })
 
   return router

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -199,12 +199,13 @@ export default function routes(
           visitData: visitSessionData,
         })
       } else {
-        const visitReference = await visitSessionsService.createVisit({
+        const { reference, visitStatus } = await visitSessionsService.createVisit({
           username: res.locals.user?.username,
           visitData: visitSessionData,
         })
 
-        req.session.visitSessionData.visitReference = visitReference
+        req.session.visitSessionData.visitReference = reference
+        req.session.visitSessionData.visitStatus = visitStatus
       }
 
       return res.redirect('/book-a-visit/additional-support')
@@ -392,24 +393,6 @@ export default function routes(
       visitSessionData.visitorSupport
     )
 
-    if (!req.session.visitSessionData.visitReference) {
-      return res.render('pages/checkYourBooking', {
-        errors: [
-          {
-            msg: 'The visit id is missing',
-            param: 'id',
-          },
-        ],
-        offenderNo,
-        mainContact: visitSessionData.mainContact,
-        prisoner: visitSessionData.prisoner,
-        visit: visitSessionData.visit,
-        visitRestriction: visitSessionData.visitRestriction,
-        visitors: visitSessionData.visitors,
-        additionalSupport,
-      })
-    }
-
     try {
       const bookedVisit = await visitSessionsService.updateVisit({
         username: res.locals.user?.username,
@@ -417,8 +400,7 @@ export default function routes(
         visitStatus: 'BOOKED',
       })
 
-      // TODO: Update to the correct value when schema updated
-      req.session.visitSessionData.visitReference = bookedVisit.reference
+      req.session.visitSessionData.visitStatus = bookedVisit.visitStatus
     } catch (error) {
       return res.render('pages/checkYourBooking', {
         errors: [

--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -9,6 +9,7 @@ import PrisonerSearchService from '../services/prisonerSearchService'
 import VisitSessionsService from '../services/visitSessionsService'
 import { appWithAllRoutes, flashProvider } from './testutils/appSetup'
 import { Prisoner } from '../data/prisonerOffenderSearchTypes'
+import { clearSession } from './visitorUtils'
 
 jest.mock('../services/prisonerProfileService')
 jest.mock('../services/prisonerSearchService')
@@ -32,6 +33,12 @@ const visitSessionsService = new VisitSessionsService(
   null,
   systemToken
 ) as jest.Mocked<VisitSessionsService>
+
+jest.mock('./visitorUtils', () => ({
+  clearSession: jest.fn((req: Express.Request) => {
+    req.session.visitSessionData = visitSessionData as VisitSessionData
+  }),
+}))
 
 beforeEach(() => {
   flashData = { errors: [], formValues: [] }
@@ -287,6 +294,7 @@ describe('POST /prisoner/A1234BC', () => {
       .expect(res => {
         expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledTimes(1)
         expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', undefined)
+        expect(clearSession).toHaveBeenCalledTimes(1)
         expect(visitSessionData).toEqual(<VisitSessionData>{
           prisoner: {
             name: 'Smith, John',

--- a/server/routes/prisoner.ts
+++ b/server/routes/prisoner.ts
@@ -8,6 +8,7 @@ import PrisonerSearchService from '../services/prisonerSearchService'
 import VisitSessionsService from '../services/visitSessionsService'
 import { prisonerDateTimePretty, properCaseFullName } from '../utils/utils'
 import { isValidPrisonerNumber } from './validationChecks'
+import { clearSession } from './visitorUtils'
 
 export default function routes(
   router: Router,
@@ -48,7 +49,8 @@ export default function routes(
       }
     }
 
-    const visitSessionData: VisitSessionData = req.session.visitSessionData || { prisoner: undefined }
+    clearSession(req)
+    const visitSessionData: VisitSessionData = req.session.visitSessionData ?? { prisoner: undefined }
 
     visitSessionData.prisoner = {
       name: properCaseFullName(`${inmateDetail.lastName}, ${inmateDetail.firstName}`),
@@ -59,7 +61,7 @@ export default function routes(
         : '',
     }
 
-    // default to an OPEN visit; later checks could change this to CLOSED
+    // default to an OPEN visit; later checks in journey could change this to CLOSED
     visitSessionData.visitRestriction = 'OPEN'
 
     req.session.visitSessionData = visitSessionData

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -1,6 +1,7 @@
 import { Request } from 'express'
+import { Session, SessionData } from 'express-session'
 import { VisitSlotList } from '../@types/bapv'
-import { getFlashFormValues, getSelectedSlot } from './visitorUtils'
+import { clearSession, getFlashFormValues, getSelectedSlot } from './visitorUtils'
 
 const slotsList: VisitSlotList = {
   'February 2022': [
@@ -119,5 +120,33 @@ describe('getFlashFormValues', () => {
 
     expect(getFlashFormValues(req)).toEqual({})
     expect(req.flash).toHaveBeenNthCalledWith(1, 'formValues')
+  })
+})
+
+describe('clearSession', () => {
+  const req: Partial<Request> = {}
+  const sessionData: SessionData = {
+    returnTo: '/url',
+    nowInMinutes: 123456,
+    cookie: undefined,
+    availableSupportTypes: [{ type: 'WHEELCHAIR', description: 'Wheelchair ramp' }],
+    visitorList: { visitors: [] },
+    adultVisitors: { adults: [] },
+    slotsList: {},
+    timeOfDay: 'morning',
+    dayOfTheWeek: '1',
+    visitSessionData: { prisoner: undefined },
+  }
+
+  req.session = sessionData as Session & SessionData
+
+  it('should clear only booking journey related data from the session', () => {
+    clearSession(req as Request)
+
+    expect(req.session).toStrictEqual(<Session & Partial<SessionData>>{
+      returnTo: '/url',
+      nowInMinutes: 123456,
+      cookie: undefined,
+    })
   })
 })

--- a/server/routes/visitorUtils.ts
+++ b/server/routes/visitorUtils.ts
@@ -25,3 +25,17 @@ export const getSupportTypeDescriptions = (
       : availableSupportTypes.find(type => type.type === support.type).description
   })
 }
+
+export const clearSession = (req: Request): void => {
+  ;[
+    'availableSupportTypes',
+    'visitorList',
+    'adultVisitors',
+    'slotsList',
+    'timeOfDay',
+    'dayOfTheWeek',
+    'visitSessionData',
+  ].forEach(sessionItem => {
+    delete req.session[sessionItem]
+  })
+}

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -682,7 +682,7 @@ describe('Visit sessions service', () => {
       const result = await visitSessionsService.createVisit({ username: 'user', visitData: visitSessionData })
 
       expect(visitSchedulerApiClient.createVisit).toHaveBeenCalledTimes(1)
-      expect(result).toEqual('ab-cd-ef-gh')
+      expect(result).toEqual(visit)
     })
   })
 

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -165,14 +165,14 @@ export default class VisitSessionsService {
     return availableSessions
   }
 
-  async createVisit({ username, visitData }: { username: string; visitData: VisitSessionData }): Promise<string> {
+  async createVisit({ username, visitData }: { username: string; visitData: VisitSessionData }): Promise<Visit> {
     const token = await this.systemToken(username)
     const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
 
     const reservation = await visitSchedulerApiClient.createVisit(visitData)
     logger.info(`Created visit ${reservation?.reference} for offender ${visitData.prisoner.offenderNo}`)
 
-    return reservation.reference ? reservation.reference : undefined
+    return reservation
   }
 
   async updateVisit({

--- a/server/views/pages/confirmation.njk
+++ b/server/views/pages/confirmation.njk
@@ -38,7 +38,8 @@
         </ul>
         {{ govukButton({
             classes: "govuk-!-margin-top-3, govuk-!-margin-bottom-6",
-            text: "Manage prison visits"
+            text: "Manage prison visits",
+            href: "/"
         }) }}
     </div>
 </div>


### PR DESCRIPTION
Better handle session data and ensure it it cleared out to prevent existing bookings being amended rather than creating new ones.
* keeps `visitStatus` in session and checks this and visit reference added to session check middleware
* session date cleared at start/end of booking journey
* updated tests