### PR TITLE
VB-810: Only show closed slots for visitors with closed restriction

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -180,6 +180,7 @@ export type VisitSessionData = {
   }
   visit?: VisitSlot
   visitRestriction?: Visit['visitRestriction']
+  closedVisitReason?: 'prisoner' | 'visitor'
   visitors?: VisitorListItem[]
   visitorSupport?: VisitorSupport[]
   mainContact?: {

--- a/server/middleware/sessionCheckMiddleware.test.ts
+++ b/server/middleware/sessionCheckMiddleware.test.ts
@@ -65,7 +65,7 @@ describe('sessionCheckMiddleware', () => {
     expect(mockResponse.redirect).toHaveBeenCalledWith('/search/prisoner/?error=missing-session')
   })
 
-  describe('prisoner or default visitRestriction data missing', () => {
+  describe('prisoner data missing', () => {
     ;[
       {
         prisoner: {},
@@ -86,11 +86,10 @@ describe('sessionCheckMiddleware', () => {
           name: 'abc',
           offenderNo: 'A1234BC',
           dateOfBirth: '12 May 1977',
-          location: 'abc',
         },
       },
     ].forEach((testData: VisitSessionData) => {
-      it('should redirect to the prisoner search page when there are missing bits of prisoner or visitRestriction data', () => {
+      it('should redirect to the prisoner search page when there are missing bits of prisoner data', () => {
         req.session.visitSessionData = testData
 
         sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
@@ -99,7 +98,7 @@ describe('sessionCheckMiddleware', () => {
       })
     })
 
-    it('should not redirect when there are no bits of missing prisoner and visitRestriction data at stage 1', () => {
+    it('should not redirect when there are no bits of missing prisoner data at stage 1', () => {
       req.session.visitSessionData = {
         prisoner: {
           name: 'abc',
@@ -107,7 +106,6 @@ describe('sessionCheckMiddleware', () => {
           dateOfBirth: '12 May 1977',
           location: 'abc',
         },
-        visitRestriction: 'OPEN',
       }
 
       sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
@@ -116,8 +114,11 @@ describe('sessionCheckMiddleware', () => {
     })
   })
 
-  describe('visitors data missing', () => {
+  describe('visitors and visit restriction data missing', () => {
     ;[
+      {
+        prisoner: prisonerData,
+      },
       {
         prisoner: prisonerData,
         visitRestriction,
@@ -128,7 +129,7 @@ describe('sessionCheckMiddleware', () => {
         visitors: [],
       },
     ].forEach((testData: VisitSessionData) => {
-      it('should redirect to the prisoner profile when there is missing visitor data', () => {
+      it('should redirect to the prisoner profile when there is missing visitor or visit restriction data', () => {
         req.session.visitSessionData = testData
 
         sessionCheckMiddleware({ stage: 2 })(req as Request, mockResponse as Response, next)

--- a/server/middleware/sessionCheckMiddleware.ts
+++ b/server/middleware/sessionCheckMiddleware.ts
@@ -14,13 +14,15 @@ export default function sessionCheckMiddleware({ stage }: { stage: number }): Re
       !visitSessionData.prisoner.name ||
       !isValidPrisonerNumber(visitSessionData.prisoner.offenderNo || '') ||
       !visitSessionData.prisoner.dateOfBirth ||
-      !visitSessionData.prisoner.location ||
-      !visitSessionData.visitRestriction
+      !visitSessionData.prisoner.location
     ) {
       return res.redirect('/search/prisoner/?error=missing-prisoner')
     }
 
-    if (stage > 1 && (!visitSessionData.visitors || visitSessionData.visitors.length === 0)) {
+    if (
+      stage > 1 &&
+      (!visitSessionData.visitors || visitSessionData.visitors.length === 0 || !visitSessionData.visitRestriction)
+    ) {
       return res.redirect(`/prisoner/${visitSessionData.prisoner.offenderNo}?error=missing-visitors`)
     }
 

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -499,6 +499,7 @@ describe('POST /book-a-visit/select-visitors', () => {
         expect(adultVisitors.adults).toEqual(returnAdult)
         expect(visitSessionData.visitors).toEqual(returnAdult)
         expect(visitSessionData.visitRestriction).toBe('OPEN')
+        expect(visitSessionData.closedVisitReason).toBe(undefined)
       })
   })
 
@@ -542,6 +543,7 @@ describe('POST /book-a-visit/select-visitors', () => {
         expect(adultVisitors.adults).toEqual(returnAdult)
         expect(visitSessionData.visitors).toEqual(returnAdult)
         expect(visitSessionData.visitRestriction).toBe('CLOSED')
+        expect(visitSessionData.closedVisitReason).toBe('visitor')
       })
   })
 
@@ -854,6 +856,7 @@ describe('/book-a-visit/select-date-and-time', () => {
           expect($('h1').text().trim()).toBe('Select date and time of visit')
           expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
           expect($('[data-test="visit-restriction"]').text()).toBe('Open')
+          expect($('[data-test="closed-visit-reason"]').length).toBe(0)
           expect($('input[name="visit-date-and-time"]').length).toBe(5)
           expect($('input[name="visit-date-and-time"]:checked').length).toBe(0)
           expect($('.govuk-accordion__section--expanded').length).toBe(0)

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -447,7 +447,13 @@ describe('POST /book-a-visit/select-visitors', () => {
           adult: true,
           relationshipDescription: 'Friend',
           address: 'Not entered',
-          restrictions: [],
+          restrictions: [
+            {
+              restrictionType: 'CLOSED',
+              restrictionTypeDescription: 'Closed',
+              startDate: '2022-01-01',
+            },
+          ],
           banned: false,
         },
       ],
@@ -470,7 +476,7 @@ describe('POST /book-a-visit/select-visitors', () => {
     } as SessionData)
   })
 
-  it('should save to session and redirect to the select date and time page if an adult is selected', () => {
+  it('should save to session and redirect to the select date and time page if an adult is selected (OPEN visit)', () => {
     const returnAdult: VisitorListItem[] = [
       {
         address: '1st listed address',
@@ -492,6 +498,50 @@ describe('POST /book-a-visit/select-visitors', () => {
       .expect(() => {
         expect(adultVisitors.adults).toEqual(returnAdult)
         expect(visitSessionData.visitors).toEqual(returnAdult)
+        expect(visitSessionData.visitRestriction).toBe('OPEN')
+      })
+  })
+
+  it('should save to session and redirect to the select date and time page if an adult with CLOSED restriction is selected (CLOSED visit)', () => {
+    const returnAdult: VisitorListItem[] = [
+      {
+        address: '1st listed address',
+        adult: true,
+        dateOfBirth: '1986-07-28',
+        name: 'Bob Smith',
+        personId: 4322,
+        relationshipDescription: 'Brother',
+        restrictions: [],
+        banned: false,
+      },
+      {
+        address: 'Not entered',
+        adult: true,
+        dateOfBirth: '1978-05-25',
+        name: 'John Jones',
+        personId: 4326,
+        relationshipDescription: 'Friend',
+        restrictions: [
+          {
+            restrictionType: 'CLOSED',
+            restrictionTypeDescription: 'Closed',
+            startDate: '2022-01-01',
+          },
+        ],
+        banned: false,
+      },
+    ]
+
+    return request(sessionApp)
+      .post('/book-a-visit/select-visitors')
+      .send('visitors=4322')
+      .send('visitors=4326')
+      .expect(302)
+      .expect('location', '/book-a-visit/select-date-and-time')
+      .expect(() => {
+        expect(adultVisitors.adults).toEqual(returnAdult)
+        expect(visitSessionData.visitors).toEqual(returnAdult)
+        expect(visitSessionData.visitRestriction).toBe('CLOSED')
       })
   })
 
@@ -526,6 +576,7 @@ describe('POST /book-a-visit/select-visitors', () => {
       .expect(() => {
         expect(adultVisitors.adults).toEqual([returnAdult])
         expect(visitSessionData.visitors).toEqual([returnAdult, returnChild])
+        expect(visitSessionData.visitRestriction).toBe('OPEN')
       })
   })
 
@@ -575,6 +626,7 @@ describe('POST /book-a-visit/select-visitors', () => {
       .expect(() => {
         expect(adultVisitors.adults).toEqual([returnAdult])
         expect(visitSessionData.visitors).toEqual([returnAdult])
+        expect(visitSessionData.visitRestriction).toBe('OPEN')
       })
   })
 

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -124,6 +124,8 @@ export default function routes(
       }, false)
       visitSessionData.visitRestriction = closedVisitVisitors ? 'CLOSED' : 'OPEN'
 
+      visitSessionData.closedVisitReason = closedVisitVisitors ? 'visitor' : undefined
+
       return res.redirect('/book-a-visit/select-date-and-time')
     }
   )
@@ -159,6 +161,7 @@ export default function routes(
         errors: req.flash('errors'),
         visitRestriction: visitSessionData.visitRestriction,
         prisonerName: visitSessionData.prisoner.name,
+        closedVisitReason: visitSessionData.closedVisitReason,
         slotsList,
         timeOfDay,
         dayOfTheWeek,

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -112,13 +112,17 @@ export default function routes(
 
         return adultVisitors
       }, [])
+      visitSessionData.visitors = selectedVisitors
 
       if (!req.session.adultVisitors) {
         req.session.adultVisitors = { adults: [] }
       }
       req.session.adultVisitors.adults = adults
 
-      visitSessionData.visitors = selectedVisitors
+      const closedVisitVisitors = selectedVisitors.reduce((closedVisit, visitor) => {
+        return closedVisit || visitor.restrictions.some(restriction => restriction.restrictionType === 'CLOSED')
+      }, false)
+      visitSessionData.visitRestriction = closedVisitVisitors ? 'CLOSED' : 'OPEN'
 
       return res.redirect('/book-a-visit/select-date-and-time')
     }

--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -286,7 +286,7 @@ describe('POST /prisoner/A1234BC', () => {
     prisonerProfileService.getPrisonerAndVisitBalances.mockResolvedValue({ inmateDetail, visitBalances })
   })
 
-  it('should set up visitSessionData (with default OPEN visit) and redirect to select visitors page', () => {
+  it('should set up visitSessionData and redirect to select visitors page', () => {
     return request(app)
       .post('/prisoner/A1234BC')
       .expect(302)
@@ -302,7 +302,6 @@ describe('POST /prisoner/A1234BC', () => {
             dateOfBirth: '2 April 1975',
             location: '1-1-C-028, HMP Hewell',
           },
-          visitRestriction: 'OPEN',
         })
       })
   })
@@ -314,7 +313,6 @@ describe('POST /prisoner/A1234BC', () => {
       dateOfBirth: '5 May 1980',
       location: 'a cell, HMP Prison',
     }
-    visitSessionData.visitRestriction = 'CLOSED'
 
     return request(app)
       .post('/prisoner/A1234BC')
@@ -330,7 +328,6 @@ describe('POST /prisoner/A1234BC', () => {
             dateOfBirth: '2 April 1975',
             location: '1-1-C-028, HMP Hewell',
           },
-          visitRestriction: 'OPEN',
         })
       })
   })

--- a/server/routes/prisoner.ts
+++ b/server/routes/prisoner.ts
@@ -64,9 +64,6 @@ export default function routes(
         : '',
     }
 
-    // default to an OPEN visit; later checks in journey could change this to CLOSED
-    visitSessionData.visitRestriction = 'OPEN'
-
     req.session.visitSessionData = visitSessionData
 
     return res.redirect('/book-a-visit/select-visitors')

--- a/server/views/pages/dateAndTime.njk
+++ b/server/views/pages/dateAndTime.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/accordion/macro.njk" import govukAccordion %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
 {% set pageHeaderTitle = "Select date and time of visit" %}
 {% set pageTitle %}
@@ -45,6 +47,24 @@
     <br>Time slots with prisoner non-associations are not shown.
     {% endif %}
     </p>
+
+    {% if closedVisitReason == 'visitor' %}
+      {% set closedVisitReasonHtml %}
+        {{ govukWarningText({
+          classes: "govuk-!-margin-bottom-0",
+          html: '<span class="govuk-!-font-size-24">Closed visit as a visitor has a closed visit restriction.</span>',
+          iconFallbackText: "Warning",
+          attributes: {
+            "data-test": "closed-visit-reason"
+          }
+        }) }}
+      {% endset %}
+
+      {{ mojBanner({
+        classes: "govuk-!-padding-left-4",
+        html: closedVisitReasonHtml
+      }) }}
+    {% endif %}
 
     {% if slotsList | length %}
     <form action="/book-a-visit/select-date-and-time" method="GET" novalidate>

--- a/server/views/pages/dateAndTime.test.ts
+++ b/server/views/pages/dateAndTime.test.ts
@@ -97,6 +97,7 @@ describe('Views - Date and time of visit', () => {
 
     expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
     expect($('[data-test="visit-restriction"]').text()).toBe('Open')
+    expect($('[data-test="closed-visit-reason"]').length).toBe(0)
 
     expect($('[data-test="month"]').eq(0).text()).toBe('February 2022')
     expect($('#slots-month-February2022-heading-1').text().trim()).toBe('Monday 14 February')
@@ -119,5 +120,21 @@ describe('Views - Date and time of visit', () => {
     expect($('label[for="5"]').text()).toContain('Fully booked')
     expect($('#5').attr('disabled')).toBe('disabled')
     expect($('[data-test="submit"]').text().trim()).toBe('Continue')
+  })
+
+  it('should display information banner for closed visit due to visitor restriction', () => {
+    viewContext = {
+      prisonerName: 'John Smith',
+      visitRestriction: 'CLOSED',
+      closedVisitReason: 'visitor',
+      slotsList: {},
+    }
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+    expect($('[data-test="visit-restriction"]').text()).toBe('Closed')
+    expect($('[data-test="closed-visit-reason"]').text()).toContain(
+      'Closed visit as a visitor has a closed visit restriction'
+    )
   })
 })


### PR DESCRIPTION
If a visitor with a CLOSED restriction is selected:
* set the `visitRestriction` in the session to be `CLOSED`
* set the reason for closed visits in the session to be `visitor`
* show an information banner on the visit date/time picker page to explain why only closed visits are being shown.

(Previously the `visitRestriction` was set to a default of `OPEN` at the start of the session; this is now set at the next stage in the journey when visitors are selected so there is a small refactor of the session validation code.)