### PR TITLE
VB-811: Option to choose open/closed visit type for prisoners with 'closed' restriction

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -1,4 +1,4 @@
-import { InmateDetail, VisitBalances } from '../data/prisonApiTypes'
+import { InmateDetail, OffenderRestriction, VisitBalances } from '../data/prisonApiTypes'
 import { Visit, VisitorSupport } from '../data/visitSchedulerApiTypes'
 
 export type PrisonerDetailsItem = {
@@ -177,6 +177,7 @@ export type VisitSessionData = {
     offenderNo: string
     dateOfBirth: string
     location: string
+    restrictions?: OffenderRestriction[]
   }
   visit?: VisitSlot
   visitRestriction?: Visit['visitRestriction']

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -173,6 +173,7 @@ describe('GET /book-a-visit/select-visitors', () => {
         expect($('.test-restrictions-comment1').text().trim()).toBe('string')
         expect($('.test-restrictions-start-date1').text().trim()).toBe('15 March 2022')
         expect($('.test-restrictions-end-date1').text().trim()).toBe('15 March 2022')
+        expect(visitSessionData.prisoner.restrictions).toEqual(restrictions)
       })
   })
 
@@ -205,6 +206,7 @@ describe('GET /book-a-visit/select-visitors', () => {
         expect($('.test-restrictions-comment1').text().trim()).toBe('string')
         expect($('.test-restrictions-start-date1').text().trim()).toBe('Not entered')
         expect($('.test-restrictions-end-date1').text().trim()).toBe('Not entered')
+        expect(visitSessionData.prisoner.restrictions).toEqual(restrictions)
       })
   })
 
@@ -227,6 +229,7 @@ describe('GET /book-a-visit/select-visitors', () => {
         expect($('.test-restrictions-comment1').text().trim()).toBe('')
         expect($('.test-restrictions-start-date1').text().trim()).toBe('')
         expect($('.test-restrictions-end-date1').text().trim()).toBe('')
+        expect(visitSessionData.prisoner.restrictions).toEqual([])
       })
   })
 
@@ -265,6 +268,7 @@ describe('GET /book-a-visit/select-visitors', () => {
         expect($('[data-test="submit"]').text().trim()).toBe('Continue')
 
         expect(visitorList.visitors).toEqual(returnData)
+        expect(visitSessionData.prisoner.restrictions).toEqual(restrictions)
       })
   })
 

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -595,7 +595,7 @@ describe('POST /book-a-visit/select-visitors', () => {
       })
   })
 
-  it('should save to session and redirect open/closed visit choice if prisoner has CLOSED restriction and visitor not CLOSED', () => {
+  it('should save to session and redirect to open/closed visit choice if prisoner has CLOSED restriction and visitor not CLOSED', () => {
     visitSessionData.prisoner.restrictions = [
       {
         restrictionId: 12345,
@@ -811,6 +811,130 @@ describe('POST /book-a-visit/select-visitors', () => {
   })
 })
 
+describe('/book-a-visit/visit-type', () => {
+  beforeEach(() => {
+    visitSessionData = {
+      prisoner: {
+        name: 'prisoner name',
+        offenderNo: 'A1234BC',
+        dateOfBirth: '25 May 1988',
+        location: 'location place',
+        restrictions: [
+          {
+            restrictionId: 12345,
+            restrictionType: 'CLOSED',
+            restrictionTypeDescription: 'Closed',
+            startDate: '2022-05-16',
+            comment: 'some comment text',
+            active: true,
+          },
+        ],
+      },
+      visitRestriction: 'OPEN',
+      visitors: [
+        {
+          address: '1st listed address',
+          adult: true,
+          dateOfBirth: '1986-07-28',
+          name: 'Bob Smith',
+          personId: 4322,
+          relationshipDescription: 'Brother',
+          restrictions: [],
+          banned: false,
+        },
+      ],
+    }
+
+    sessionApp = appWithAllRoutes(null, null, null, null, systemToken, false, {
+      visitSessionData,
+    } as SessionData)
+  })
+
+  describe('GET /book-a-visit/visit-type', () => {
+    it('should render the open/closed visit type page with prisoner restrictions and visitor list', () => {
+      return request(sessionApp)
+        .get('/book-a-visit/visit-type')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text().trim()).toBe("Check the prisoner's closed visit restrictions")
+          expect($('[data-test="restriction-type-1"]').text().trim()).toBe('Closed')
+          expect($('[data-test="restriction-comment-1"]').text().trim()).toBe('some comment text')
+          expect($('[data-test="restriction-start-1"]').text().trim()).toBe('16 May 2022')
+          expect($('[data-test="restriction-end-1"]').text().trim()).toBe('Not entered')
+          expect($('.test-visitor-key-1').text().trim()).toBe('Visitor 1')
+          expect($('.test-visitor-value-1').text().trim()).toBe('Bob Smith (brother of the prisoner)')
+          expect($('[data-test="visit-type-open"]').prop('checked')).toBe(false)
+          expect($('[data-test="visit-type-closed"]').prop('checked')).toBe(false)
+        })
+    })
+
+    it('should render the open/closed visit type page with form validation errors', () => {
+      flashData.errors = [
+        {
+          msg: 'No visit type selected',
+          param: 'visitType',
+          location: 'body',
+        },
+      ]
+
+      return request(sessionApp)
+        .get('/book-a-visit/visit-type')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text().trim()).toBe("Check the prisoner's closed visit restrictions")
+          expect($('.govuk-error-summary__body').text()).toContain('No visit type selected')
+          expect($('#visitType-error').text()).toContain('No visit type selected')
+          expect($('[data-test="visit-type-open"]').prop('checked')).toBe(false)
+          expect($('[data-test="visit-type-closed"]').prop('checked')).toBe(false)
+          expect(flashProvider).toHaveBeenCalledWith('errors')
+          expect(flashProvider).toHaveBeenCalledTimes(1)
+        })
+    })
+  })
+
+  describe('POST /book-a-visit/visit-type', () => {
+    it('should set validation errors in flash and redirect if visit type not selected', () => {
+      return request(sessionApp)
+        .post('/book-a-visit/visit-type')
+        .expect(302)
+        .expect('location', '/book-a-visit/visit-type')
+        .expect(() => {
+          expect(flashProvider).toHaveBeenCalledWith('errors', [
+            { location: 'body', msg: 'No visit type selected', param: 'visitType', value: undefined },
+          ])
+        })
+    })
+
+    it('should set visit type to OPEN when selected and redirect to select date/time', () => {
+      return request(sessionApp)
+        .post('/book-a-visit/visit-type')
+        .send('visitType=OPEN')
+        .expect(302)
+        .expect('location', '/book-a-visit/select-date-and-time')
+        .expect(() => {
+          expect(visitSessionData.visitRestriction).toBe('OPEN')
+          expect(visitSessionData.closedVisitReason).toBe(undefined)
+        })
+    })
+
+    it('should set visit type to CLOSED when selected and redirect to select date/time', () => {
+      return request(sessionApp)
+        .post('/book-a-visit/visit-type')
+        .send('visitType=CLOSED')
+        .expect(302)
+        .expect('location', '/book-a-visit/select-date-and-time')
+        .expect(() => {
+          expect(visitSessionData.visitRestriction).toBe('CLOSED')
+          expect(visitSessionData.closedVisitReason).toBe('prisoner')
+        })
+    })
+  })
+})
+
 describe('/book-a-visit/select-date-and-time', () => {
   const slotsList: VisitSlotList = {
     'February 2022': [
@@ -946,6 +1070,44 @@ describe('/book-a-visit/select-date-and-time', () => {
           expect($('input[name="visit-date-and-time"]:checked').length).toBe(0)
           expect($('.govuk-accordion__section--expanded').length).toBe(0)
           expect($('[data-test="submit"]').text().trim()).toBe('Continue')
+        })
+    })
+
+    it('should render the available sessions list with closed visit reason (visitor)', () => {
+      visitSessionData.visitRestriction = 'CLOSED'
+      visitSessionData.closedVisitReason = 'visitor'
+
+      return request(sessionApp)
+        .get('/book-a-visit/select-date-and-time')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text().trim()).toBe('Select date and time of visit')
+          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+          expect($('[data-test="visit-restriction"]').text()).toBe('Closed')
+          expect($('[data-test="closed-visit-reason"]').text()).toContain(
+            'Closed visit as a visitor has a closed visit restriction.'
+          )
+        })
+    })
+
+    it('should render the available sessions list with closed visit reason (prisoner)', () => {
+      visitSessionData.visitRestriction = 'CLOSED'
+      visitSessionData.closedVisitReason = 'prisoner'
+
+      return request(sessionApp)
+        .get('/book-a-visit/select-date-and-time')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text().trim()).toBe('Select date and time of visit')
+          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+          expect($('[data-test="visit-restriction"]').text()).toBe('Closed')
+          expect($('[data-test="closed-visit-reason"]').text()).toContain(
+            'Closed visit as the prisoner has a closed visit restriction.'
+          )
         })
     })
 

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -146,7 +146,10 @@ export default function routes(
       restriction => restriction.restrictionType === 'CLOSED'
     )
 
-    res.render('pages/visitType', { restrictions: closedRestrictions })
+    res.render('pages/visitType', {
+      restrictions: closedRestrictions,
+      visitors: visitSessionData.visitors,
+    })
   })
 
   get(

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -139,6 +139,16 @@ export default function routes(
     }
   )
 
+  get('/visit-type', sessionCheckMiddleware({ stage: 2 }), async (req, res) => {
+    const { visitSessionData } = req.session
+
+    const closedRestrictions = visitSessionData.prisoner.restrictions.filter(
+      restriction => restriction.restrictionType === 'CLOSED'
+    )
+
+    res.render('pages/visitType', { restrictions: closedRestrictions })
+  })
+
   get(
     '/select-date-and-time',
     sessionCheckMiddleware({ stage: 2 }),

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -167,7 +167,7 @@ export default function routes(
       }
 
       visitSessionData.visitRestriction = req.body.visitType
-      visitSessionData.closedVisitReason = 'prisoner'
+      visitSessionData.closedVisitReason = req.body.visitType === 'CLOSED' ? 'prisoner' : undefined
 
       return res.redirect('/book-a-visit/select-date-and-time')
     }

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -125,8 +125,15 @@ export default function routes(
         return closedVisit || visitor.restrictions.some(restriction => restriction.restrictionType === 'CLOSED')
       }, false)
       visitSessionData.visitRestriction = closedVisitVisitors ? 'CLOSED' : 'OPEN'
-
       visitSessionData.closedVisitReason = closedVisitVisitors ? 'visitor' : undefined
+
+      const closedVisitPrisoner = visitSessionData.prisoner.restrictions.reduce((closedVisit, restriction) => {
+        return closedVisit || restriction.restrictionType === 'CLOSED'
+      }, false)
+
+      if (!closedVisitVisitors && closedVisitPrisoner) {
+        return res.redirect('/book-a-visit/visit-type')
+      }
 
       return res.redirect('/book-a-visit/select-date-and-time')
     }

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -147,10 +147,31 @@ export default function routes(
     )
 
     res.render('pages/visitType', {
+      errors: req.flash('errors'),
       restrictions: closedRestrictions,
       visitors: visitSessionData.visitors,
     })
   })
+
+  post(
+    '/visit-type',
+    sessionCheckMiddleware({ stage: 2 }),
+    body('visitType').isIn(['OPEN', 'CLOSED']).withMessage('No visit type selected'),
+    async (req, res) => {
+      const { visitSessionData } = req.session
+      const errors = validationResult(req)
+
+      if (!errors.isEmpty()) {
+        req.flash('errors', errors.array() as [])
+        return res.redirect(req.originalUrl)
+      }
+
+      visitSessionData.visitRestriction = req.body.visitType
+      visitSessionData.closedVisitReason = 'prisoner'
+
+      return res.redirect('/book-a-visit/select-date-and-time')
+    }
+  )
 
   get(
     '/select-date-and-time',

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -127,15 +127,13 @@ export default function routes(
       visitSessionData.visitRestriction = closedVisitVisitors ? 'CLOSED' : 'OPEN'
       visitSessionData.closedVisitReason = closedVisitVisitors ? 'visitor' : undefined
 
-      const closedVisitPrisoner = visitSessionData.prisoner.restrictions.reduce((closedVisit, restriction) => {
-        return closedVisit || restriction.restrictionType === 'CLOSED'
-      }, false)
+      const closedVisitPrisoner = visitSessionData.prisoner.restrictions.some(restriction => {
+        return restriction.restrictionType === 'CLOSED'
+      })
 
-      if (!closedVisitVisitors && closedVisitPrisoner) {
-        return res.redirect('/book-a-visit/visit-type')
-      }
-
-      return res.redirect('/book-a-visit/select-date-and-time')
+      return !closedVisitVisitors && closedVisitPrisoner
+        ? res.redirect('/book-a-visit/visit-type')
+        : res.redirect('/book-a-visit/select-date-and-time')
     }
   )
 

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -30,18 +30,20 @@ export default function routes(
   get('/select-visitors', sessionCheckMiddleware({ stage: 1 }), async (req, res) => {
     const { visitSessionData } = req.session
     const { offenderNo } = visitSessionData.prisoner
+
     const visitorList = await prisonerVisitorsService.getVisitors(offenderNo, res.locals.user?.username)
+    if (!req.session.visitorList) {
+      req.session.visitorList = { visitors: [] }
+    }
+    req.session.visitorList.visitors = visitorList
+
     const restrictions = await prisonerProfileService.getRestrictions(offenderNo, res.locals.user?.username)
+    req.session.visitSessionData.prisoner.restrictions = restrictions
 
     const formValues = getFlashFormValues(req)
     if (!Object.keys(formValues).length && visitSessionData.visitors) {
       formValues.visitors = visitSessionData.visitors.map(visitor => visitor.personId.toString())
     }
-
-    if (!req.session.visitorList) {
-      req.session.visitorList = { visitors: [] }
-    }
-    req.session.visitorList.visitors = visitorList
 
     res.render('pages/visitors', {
       errors: req.flash('errors'),

--- a/server/views/pages/dateAndTime.njk
+++ b/server/views/pages/dateAndTime.njk
@@ -48,11 +48,13 @@
     {% endif %}
     </p>
 
-    {% if closedVisitReason == 'visitor' %}
+    {% if visitRestriction == 'CLOSED' and closedVisitReason %}
       {% set closedVisitReasonHtml %}
         {{ govukWarningText({
           classes: "govuk-!-margin-bottom-0",
-          html: '<span class="govuk-!-font-size-24">Closed visit as a visitor has a closed visit restriction.</span>',
+          html: '<span class="govuk-!-font-size-24">Closed visit as ' +
+            ('a visitor' if closedVisitReason == 'visitor' else 'the prisoner') +
+            ' has a closed visit restriction.</span>',
           iconFallbackText: "Warning",
           attributes: {
             "data-test": "closed-visit-reason"

--- a/server/views/pages/visitType.njk
+++ b/server/views/pages/visitType.njk
@@ -30,19 +30,29 @@
             {% set restrictionExpiryDate %}{% if restriction.expiryDate %}{{ restriction.expiryDate | formatDate }}{% else %}Not entered{% endif %}{% endset %}
             {%- set prisonerRestrictions = (prisonerRestrictions.push([
               {
-                html: '<span class="test-restrictions-type' + loop.index + ' moj-badge moj-badge--large visitor-restriction-badge visitor-restriction-badge--' + restriction.restrictionType + '">' + restriction.restrictionTypeDescription + '</span>'
+                html: '<span class="test-restrictions-type' + loop.index + ' moj-badge moj-badge--large visitor-restriction-badge visitor-restriction-badge--' +
+                  restriction.restrictionType + '" data-test="restriction-type-' + loop.index + '">' + restriction.restrictionTypeDescription + '</span>'
               },
               {
                 text: restriction.comment,
-                classes: "test-restrictions-comment" + loop.index
+                classes: "test-restrictions-comment" + loop.index,
+                attributes: {
+                  "data-test": "restriction-comment-" + loop.index
+                }
               },
               {
                 text: restrictionStartDate,
-                classes: "test-restrictions-start-date" + loop.index
+                classes: "test-restrictions-start-date" + loop.index,
+                attributes: {
+                  "data-test": "restriction-start-" + loop.index
+                }
               },
               {
                 text: restrictionExpiryDate,
-                classes: "test-restrictions-end-date" + loop.index
+                classes: "test-restrictions-end-date" + loop.index,
+                attributes: {
+                  "data-test": "restriction-end-" + loop.index
+                }
               }
             ]), prisonerRestrictions) %}
           {% endfor %}
@@ -70,10 +80,11 @@
           {%- set visitorListItems = (visitorListItems.push(
             {
               key: {
-                classes: "govuk-!-width-one-quarter",
+                classes: "govuk-!-width-one-quarter test-visitor-key-" + loop.index,
                 text: "Visitor " + loop.index
               },
               value: {
+                classes: "test-visitor-value-" + loop.index,
                 text: visitor.name + " (" + visitor.relationshipDescription | lower + " of the prisoner)"
               }
             }

--- a/server/views/pages/visitType.njk
+++ b/server/views/pages/visitType.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageHeaderTitle = "Check the prisoner's closed visit restrictions" %}
@@ -18,7 +19,7 @@
       {% include "partials/errorSummary.njk" %}
       <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
 
-      <form action="/book-a-visit/additional-support" method="POST" novalidate>
+      <form action="/book-a-visit/visit-type" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
 
@@ -88,6 +89,33 @@
         {{ govukDetails({
           summaryText: "Show visitors on this visit",
           html: visitorListHtml
+        }) }}
+
+        {{ govukRadios({
+          name: "visitType",
+          fieldset: {
+            legend: {
+              text: "Select visit type",
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "OPEN",
+              text: "Open visit",
+              attributes: {
+                'data-test': 'visit-type-open'
+              }
+            },
+            {
+              value: "CLOSED",
+              text: "Closed visit",
+              attributes: {
+                'data-test': 'visit-type-closed'
+              }
+            }
+          ],
+          errorMessage: errors | findError('visitType')
         }) }}
 
         {{ govukButton({

--- a/server/views/pages/visitType.njk
+++ b/server/views/pages/visitType.njk
@@ -1,6 +1,8 @@
 {% extends "layout.njk" %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageHeaderTitle = "Check the prisoner's closed visit restrictions" %}
@@ -61,6 +63,32 @@
             rows: prisonerRestrictions
           }) }}
         </div>
+
+        {% set visitorListItems = [] %}
+        {% for visitor in visitors %}
+          {%- set visitorListItems = (visitorListItems.push(
+            {
+              key: {
+                classes: "govuk-!-width-one-quarter",
+                text: "Visitor " + loop.index
+              },
+              value: {
+                text: visitor.name + " (" + visitor.relationshipDescription | lower + " of the prisoner)"
+              }
+            }
+          ), visitorListItems) %}
+        {% endfor %}
+
+        {% set visitorListHtml %}
+          {{ govukSummaryList({
+            rows: visitorListItems
+          }) }}
+        {% endset %}
+
+        {{ govukDetails({
+          summaryText: "Show visitors on this visit",
+          html: visitorListHtml
+        }) }}
 
         {{ govukButton({
           text: "Continue",

--- a/server/views/pages/visitType.njk
+++ b/server/views/pages/visitType.njk
@@ -1,0 +1,74 @@
+{% extends "layout.njk" %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageHeaderTitle = "Check the prisoner's closed visit restrictions" %}
+{% set pageTitle %}
+{% if errors | length %}Error: {% endif %}{{ applicationName }} - {{ pageHeaderTitle }}
+{% endset %}
+{% set backLinkHref = "/book-a-visit/select-visitors" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      {% include "partials/errorSummary.njk" %}
+      <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
+
+      <form action="/book-a-visit/additional-support" method="POST" novalidate>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+
+        <div class="prisoner-restrictions">
+          {% set prisonerRestrictions = [] %}
+          {% for restriction in restrictions %}
+            {% set restrictionStartDate %}{% if restriction.startDate %}{{ restriction.startDate | formatDate }}{% else %}Not entered{% endif %}{% endset %}
+            {% set restrictionExpiryDate %}{% if restriction.expiryDate %}{{ restriction.expiryDate | formatDate }}{% else %}Not entered{% endif %}{% endset %}
+            {%- set prisonerRestrictions = (prisonerRestrictions.push([
+              {
+                html: '<span class="test-restrictions-type' + loop.index + ' moj-badge moj-badge--large visitor-restriction-badge visitor-restriction-badge--' + restriction.restrictionType + '">' + restriction.restrictionTypeDescription + '</span>'
+              },
+              {
+                text: restriction.comment,
+                classes: "test-restrictions-comment" + loop.index
+              },
+              {
+                text: restrictionStartDate,
+                classes: "test-restrictions-start-date" + loop.index
+              },
+              {
+                text: restrictionExpiryDate,
+                classes: "test-restrictions-end-date" + loop.index
+              }
+            ]), prisonerRestrictions) %}
+          {% endfor %}
+          {{ govukTable({
+            head: [
+              {
+                text: "Type of restriction"
+              },
+              {
+                text: "Comments"
+              },
+              {
+                text: "Date from"
+              },
+              {
+                text: "Date to"
+              }
+            ],
+            rows: prisonerRestrictions
+          }) }}
+        </div>
+
+        {{ govukButton({
+          text: "Continue",
+          attributes: {
+            "data-test": "submit"
+          }
+        }) }} 
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
If the **prisoner** has a closed restriction then, after selecting visitors, show a page to choose visit type (open/closed) before proceeding to choose visit date/time. If a closed visit is chosen the reason for this ('prisoner') is stored to display in the subsequent banner.

If the **visitor** has a closed restriction then the visit type page is not used and the visit is automatically set to CLOSED.