### PR TITLE
Prevent button double clicks

### DIFF
--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -131,9 +131,9 @@ export default function routes(
       visitSessionData.visitRestriction = closedVisitVisitors ? 'CLOSED' : 'OPEN'
       visitSessionData.closedVisitReason = closedVisitVisitors ? 'visitor' : undefined
 
-      const closedVisitPrisoner = visitSessionData.prisoner.restrictions.some(restriction => {
-        return restriction.restrictionType === 'CLOSED'
-      })
+      const closedVisitPrisoner = visitSessionData.prisoner.restrictions.some(
+        restriction => restriction.restrictionType === 'CLOSED',
+      )
 
       return !closedVisitVisitors && closedVisitPrisoner
         ? res.redirect('/book-a-visit/visit-type')

--- a/server/views/pages/additionalSupport.njk
+++ b/server/views/pages/additionalSupport.njk
@@ -100,7 +100,8 @@
             }) }}
             
             {{ govukButton({
-              text: "Continue"
+              text: "Continue",
+              preventDoubleClick: true
             }) }} 
         </form>
     </div>

--- a/server/views/pages/checkYourBooking.njk
+++ b/server/views/pages/checkYourBooking.njk
@@ -159,7 +159,8 @@
         <form action="/book-a-visit/check-your-booking" method="POST" novalidate>
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
             {{ govukButton({
-                text: "Submit booking"
+                text: "Submit booking",
+                preventDoubleClick: true
             }) }}
         </form>
     </div>

--- a/server/views/pages/confirmation.njk
+++ b/server/views/pages/confirmation.njk
@@ -39,7 +39,8 @@
         {{ govukButton({
             classes: "govuk-!-margin-top-3, govuk-!-margin-bottom-6",
             text: "Manage prison visits",
-            href: "/"
+            href: "/",
+            preventDoubleClick: true
         }) }}
     </div>
 </div>

--- a/server/views/pages/dateAndTime.njk
+++ b/server/views/pages/dateAndTime.njk
@@ -146,7 +146,8 @@
           }) }}
       
           {{ govukButton({
-            text: "Apply filters"
+            text: "Apply filters",
+            preventDoubleClick: true
           }) }} 
         </div>
       </div>
@@ -239,7 +240,8 @@
     
     {{ govukButton({
       text: "Continue",
-      attributes: { "data-test": "submit" }
+      attributes: { "data-test": "submit" },
+      preventDoubleClick: true
     }) }} 
     </form>
 

--- a/server/views/pages/mainContact.njk
+++ b/server/views/pages/mainContact.njk
@@ -84,7 +84,8 @@
                 errorMessage: errors | findError('phoneNumber')
             }) }}
             {{ govukButton({
-                text: "Continue"
+                text: "Continue",
+                preventDoubleClick: true
             }) }} 
         </form>
     </div>

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -100,7 +100,8 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         {{ govukButton({
           text: "Book a prison visit",
-          attributes: { "data-test": "book-a-visit" }
+          attributes: { "data-test": "book-a-visit" },
+          preventDoubleClick: true
         }) }}
       </form>
 

--- a/server/views/pages/prisoner/visits.njk
+++ b/server/views/pages/prisoner/visits.njk
@@ -64,7 +64,8 @@
           text: "Go to manage prison visits",
           classes: "govuk-!-margin-top-3",
           href: "/",
-          attributes: { "data-test": "go-to-start" }
+          attributes: { "data-test": "go-to-start" },
+          preventDoubleClick: true
         }) }}
       {% endif %}
     </div>

--- a/server/views/pages/visit/cancel.njk
+++ b/server/views/pages/visit/cancel.njk
@@ -69,7 +69,8 @@
           text: "Cancel booking",
           attributes: {
             "data-test": "cancel-booking"
-          }
+          },
+          preventDoubleClick: true
         }) }} 
       </form>
     </div>

--- a/server/views/pages/visit/cancelConfirmation.njk
+++ b/server/views/pages/visit/cancelConfirmation.njk
@@ -27,7 +27,8 @@
       text: "Go to manage prison visits",
       classes: "govuk-!-margin-top-3",
       href: "/",
-      attributes: { "data-test": "go-to-start" }
+      attributes: { "data-test": "go-to-start" },
+      preventDoubleClick: true
     }) }}
   </div>
 </div>

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -67,7 +67,8 @@
         text: "Cancel booking",
         classes: "govuk-!-margin-top-5",
         href: "/visit/" + visit.reference + "/cancel",
-        attributes: { "data-test": "cancel-visit" }
+        attributes: { "data-test": "cancel-visit" },
+        preventDoubleClick: true
       }) }}
 
       {% set visitorRows = [] %}

--- a/server/views/pages/visitType.njk
+++ b/server/views/pages/visitType.njk
@@ -133,7 +133,8 @@
           text: "Continue",
           attributes: {
             "data-test": "submit"
-          }
+          },
+          preventDoubleClick: true
         }) }} 
       </form>
     </div>

--- a/server/views/pages/visitors.njk
+++ b/server/views/pages/visitors.njk
@@ -146,7 +146,8 @@
         </div>
         {{ govukButton({
           text: "Continue",
-          attributes: { "data-test": "submit" }
+          attributes: { "data-test": "submit" },
+          preventDoubleClick: true
         }) }} 
       </form>
     {% else %}

--- a/server/views/pages/visits/summary.njk
+++ b/server/views/pages/visits/summary.njk
@@ -47,7 +47,8 @@
                 }
               }) }}
               {{ govukButton({
-                text: "View"
+                text: "View",
+                preventDoubleClick: true
               }) }}
             </form>
           </div>
@@ -67,22 +68,26 @@
       <h3 class="govuk-heading-s">Visitor list</h3>
       <div class="govuk-button-group">
         {{ govukButton({
-            text: "Download CSV"
+            text: "Download CSV",
+            preventDoubleClick: true
         }) }}
         {{ govukButton({
             text: "Print",
-            classes: "govuk-button--secondary"
+            classes: "govuk-button--secondary",
+            preventDoubleClick: true
         }) }}
       </div>
 
       <h3 class="govuk-heading-s">Prisoner list</h3>
       <div class="govuk-button-group">
         {{ govukButton({
-            text: "Download CSV"
+            text: "Download CSV",
+            preventDoubleClick: true
         }) }}
         {{ govukButton({
             text: "Print",
-            classes: "govuk-button--secondary"
+            classes: "govuk-button--secondary",
+            preventDoubleClick: true
         }) }}
       </div>
     </div>

--- a/server/views/partials/searchForPrisonerHeader.njk
+++ b/server/views/partials/searchForPrisonerHeader.njk
@@ -21,7 +21,8 @@
 
                 {{ govukButton({
                     classes: "moj-search__button",
-                    text: "Search"
+                    text: "Search",
+                    preventDoubleClick: true
                 }) }}
 
             </form>

--- a/server/views/partials/searchForVisitHeader.njk
+++ b/server/views/partials/searchForVisitHeader.njk
@@ -63,7 +63,8 @@
 
                 {{ govukButton({
                     text: "Search",
-                    classes: "bapv-visit-search__button"
+                    classes: "bapv-visit-search__button",
+                    preventDoubleClick: true
                 }) }}
                 </div>
 


### PR DESCRIPTION
Adding `preventDoubleClick: true` to existing button components (in advance of putting more buttons in for the dead-end journey points). Saw some double clicking going on while observing user research; figured we may as well add this attribute. 