### PR TITLE
Date/time picker: always show day and time filter and tweak text

### DIFF
--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -1159,7 +1159,7 @@ describe('/book-a-visit/select-date-and-time', () => {
           const $ = cheerio.load(res.text)
           expect($('h1').text().trim()).toBe('Select date and time of visit')
           expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
-          expect($('#main-content').text()).toContain('There are no visit time slots for the next 28 days.')
+          expect($('#main-content').text()).toContain('There are no available slots for this prisoner.')
           expect($('input[name="visit-date-and-time"]').length).toBe(0)
           expect($('[data-test="submit"]').length).toBe(0)
           expect($('[data-test="back-to-start"]').length).toBe(1)

--- a/server/views/pages/dateAndTime.njk
+++ b/server/views/pages/dateAndTime.njk
@@ -42,10 +42,8 @@
 
     <p class="bapv-extraspacing"><strong>Prisoner name:</strong> <span data-test="prisoner-name">{{ prisonerName }}</span>
     <br><strong>Visit type:</strong> <span data-test="visit-restriction">{{ visitRestriction | capitalize }}</span>
-    {% if slotsList | length %}
     <br>Showing visit time slots for the next 28 days.
     <br>Time slots with prisoner non-associations are not shown.
-    {% endif %}
     </p>
 
     {% if visitRestriction == 'CLOSED' and closedVisitReason %}
@@ -68,7 +66,6 @@
       }) }}
     {% endif %}
 
-    {% if slotsList | length %}
     <form action="/book-a-visit/select-date-and-time" method="GET" novalidate>
       <div class="bapv-visit-date-time-filter">
         <h3 class="govuk-heading-s">Filter time slots</h3>
@@ -153,6 +150,7 @@
       </div>
     </form>
 
+    {% if slotsList | length %}
     <form action="/book-a-visit/select-date-and-time" method="POST" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {% for month, days in slotsList %}
@@ -246,7 +244,7 @@
     </form>
 
     {% else %}
-    <p>There are no visit time slots for the next 28 days.</p>
+    <p>There are no available slots for this prisoner. A booking cannot be made at this time.</p>
 
     {% include "partials/backToStartButton.njk" %}
     {% endif %}

--- a/server/views/pages/dateAndTime.test.ts
+++ b/server/views/pages/dateAndTime.test.ts
@@ -19,7 +19,7 @@ describe('Views - Date and time of visit', () => {
   it('should display message, back to start button and no accordion when no visit slots', () => {
     viewContext = {}
     const $ = cheerio.load(compiledTemplate.render(viewContext))
-    expect($('main p').text()).toContain('There are no visit time slots for the next 28 days.')
+    expect($('main p').text()).toContain('There are no available slots for this prisoner.')
     expect($('.govuk-accordion').length).toBe(0)
     expect($('[data-test="submit"]').length).toBe(0)
     expect($('[data-test="back-to-start"]').length).toBe(1)


### PR DESCRIPTION
Previously, day/time filter wasn't shown if no slots available - creating a 'dead-end'. This change makes it always display.