### PR TITLE
VB-597: Select visitors: handle only banned/child dead-end

### DIFF
--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -396,6 +396,50 @@ describe('GET /book-a-visit/select-visitors', () => {
         expect($('[data-test="back-to-start"]').length).toBe(1)
       })
   })
+
+  it('should show back to start rather than continue button if only child or banned visitors listed', () => {
+    returnData = [
+      {
+        personId: 4322,
+        name: 'Bob Smith',
+        dateOfBirth: undefined,
+        adult: undefined,
+        relationshipDescription: 'Brother',
+        address: '1st listed address',
+        restrictions: [
+          {
+            restrictionType: 'BAN',
+            restrictionTypeDescription: 'Banned',
+            startDate: '2022-01-01',
+          },
+        ],
+        banned: true,
+      },
+      {
+        personId: 4324,
+        name: 'Anne Smith',
+        dateOfBirth: '2018-03-02',
+        adult: false,
+        relationshipDescription: 'Niece',
+        address: 'Not entered',
+        restrictions: [],
+        banned: false,
+      },
+    ]
+    prisonerVisitorsService.getVisitors.mockResolvedValue(returnData)
+
+    return request(sessionApp)
+      .get('/book-a-visit/select-visitors')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('h1').text().trim()).toBe('Select visitors from the prisoner’s approved visitor list')
+        expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+        expect($('input[name="visitors"]').length).toBe(2)
+        expect($('[data-test="submit"]').length).toBe(0)
+        expect($('[data-test="back-to-start"]').length).toBe(1)
+      })
+  })
 })
 
 describe('POST /book-a-visit/select-visitors', () => {

--- a/server/views/pages/visitors.njk
+++ b/server/views/pages/visitors.njk
@@ -10,8 +10,16 @@
 {% set backLinkHref = "/prisoner/" + offenderNo %}
 
 {% set visitors = [] %}
+{% set eligibleVisitorsCount = 0 %}
 
 {% for visitor in visitorList %}
+
+  {# Count adult visitors who aren't banned; at least one needed to continue.
+     Will include those with no DoB set (i.e. 'visitor.adult' == undefined).  #}
+  {% if visitor.banned == false and visitor.adult != false  %}
+    {% set eligibleVisitorsCount = eligibleVisitorsCount + 1 %}
+  {% endif %}
+
   {% set checkbox -%}
   <div class="govuk-checkboxes__item">
     <input class="govuk-checkboxes__input" id="visitor-{{ visitor.personId }}" name="visitors" type="checkbox" value="{{ visitor.personId }}"
@@ -143,11 +151,17 @@
           rows: visitors
         }) }}
         </div>
-        {{ govukButton({
-          text: "Continue",
-          attributes: { "data-test": "submit" },
-          preventDoubleClick: true
-        }) }} 
+
+        {% if eligibleVisitorsCount > 0 %}
+          {{ govukButton({
+            text: "Continue",
+            attributes: { "data-test": "submit" },
+            preventDoubleClick: true
+          }) }}
+        {% else %}
+          {% include "partials/backToStartButton.njk" %}
+        {% endif %}
+
       </form>
     {% else %}
     <p>There are no approved visitors for this prisoner. A booking cannot be made at this time.</p>


### PR DESCRIPTION
This fixes a journey 'dead-end' on the Select Visitors page where a booking can't proceed if only banned or child visitors are listed. Instead of showing the Continue button, the back-to-start button is displayed.