### PR TITLE
Tests for GOV.UK Notify integration

### DIFF
--- a/server/data/notificationsApiClient.test.ts
+++ b/server/data/notificationsApiClient.test.ts
@@ -1,0 +1,55 @@
+import config from '../config'
+import NotificationsApiClient, { notificationsApiClientBuilder } from './notificationsApiClient'
+
+const mockSendSms = jest.fn()
+
+jest.mock('notifications-node-client', () => {
+  return {
+    NotifyClient: jest.fn().mockImplementation(() => {
+      return { sendSms: mockSendSms }
+    }),
+  }
+})
+
+describe('GOV.UK Notify client', () => {
+  let notificationsApiClient: NotificationsApiClient
+
+  beforeEach(() => {
+    notificationsApiClient = notificationsApiClientBuilder()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('sendSms', () => {
+    const confirmationDetails = {
+      phoneNumber: '07123456789',
+      prisonName: 'Hewell',
+      visitTime: '10:00am',
+      visitDay: 'Monday',
+      visitDate: '1 August 2022',
+      reference: 'ab-cd-ef-gh',
+    }
+
+    it('should call notifications client sendSms() with the correct booking confirmation parameters', async () => {
+      await notificationsApiClient.sendSms(confirmationDetails)
+
+      expect(mockSendSms).toHaveBeenCalledTimes(1)
+      expect(mockSendSms).toHaveBeenCalledWith(
+        config.apis.notifications.templates.bookingConfirmation,
+        confirmationDetails.phoneNumber,
+        {
+          personalisation: {
+            prison: confirmationDetails.prisonName,
+            time: confirmationDetails.visitTime,
+            dayofweek: confirmationDetails.visitDay,
+            date: confirmationDetails.visitDate,
+            'ref number': confirmationDetails.reference,
+          },
+          reference: confirmationDetails.reference,
+        },
+      )
+    })
+  })
+})

--- a/server/services/notificationsService.test.ts
+++ b/server/services/notificationsService.test.ts
@@ -1,0 +1,49 @@
+import NotificationsApiClient from '../data/notificationsApiClient'
+import NotificationsService from './notificationsService'
+
+jest.mock('../data/notificationsApiClient')
+
+const notificationsApiClient = new NotificationsApiClient() as jest.Mocked<NotificationsApiClient>
+
+describe('Notifications service', () => {
+  let notificationsApiClientBuilder: () => NotificationsApiClient
+  let notificationsService: NotificationsService
+
+  beforeEach(() => {
+    notificationsApiClientBuilder = jest.fn().mockReturnValue(notificationsApiClient)
+    notificationsService = new NotificationsService(notificationsApiClientBuilder)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('sendSms', () => {
+    const visitDetails = {
+      phoneNumber: '07123456789',
+      prisonName: 'Hewell',
+      visit: {
+        id: '1',
+        startTimestamp: '2022-02-14T10:00:00',
+        endTimestamp: '2022-02-14T11:00:00',
+        availableTables: 15,
+        visitRoomName: 'room name',
+      },
+      reference: 'ab-cd-ef-gh',
+    }
+
+    it('should call the notifications client with the confirmation and visit details', async () => {
+      await notificationsService.sendSms(visitDetails)
+
+      expect(notificationsApiClient.sendSms).toHaveBeenCalledTimes(1)
+      expect(notificationsApiClient.sendSms).toHaveBeenCalledWith({
+        phoneNumber: visitDetails.phoneNumber,
+        prisonName: visitDetails.prisonName,
+        visitTime: '10:00am',
+        visitDay: 'Monday',
+        visitDate: '14 February 2022',
+        reference: visitDetails.reference,
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add tests to cover GOV.UK notify API client and service.