### PR TITLE
VB-952: Handle missing prisoner data (e.g. prisoner transferred or released)

### DIFF
--- a/server/data/prisonerSearchClient.test.ts
+++ b/server/data/prisonerSearchClient.test.ts
@@ -1,7 +1,6 @@
 import nock from 'nock'
 import config from '../config'
-import PrisonerSearchClient from './prisonerSearchClient'
-import RestClient from './restClient'
+import PrisonerSearchClient, { prisonerSearchClientBuilder } from './prisonerSearchClient'
 
 describe('prisonSearchClientBuilder', () => {
   let fakePrisonerSearchApi: nock.Scope
@@ -11,8 +10,7 @@ describe('prisonSearchClientBuilder', () => {
 
   beforeEach(() => {
     fakePrisonerSearchApi = nock(config.apis.prisonerSearch.url)
-    const restClient = new RestClient('Prisoner Search REST Client', config.apis.prisonerSearch, token)
-    client = new PrisonerSearchClient(restClient)
+    client = prisonerSearchClientBuilder(token)
   })
 
   afterEach(() => {

--- a/server/data/prisonerSearchClient.test.ts
+++ b/server/data/prisonerSearchClient.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock'
 import config from '../config'
+import { Prisoner } from './prisonerOffenderSearchTypes'
 import PrisonerSearchClient, { prisonerSearchClientBuilder } from './prisonerSearchClient'
 
 describe('prisonSearchClientBuilder', () => {
@@ -65,6 +66,26 @@ describe('prisonSearchClientBuilder', () => {
         .reply(200, results)
 
       const output = await client.getPrisoner('test')
+
+      expect(output).toEqual(results)
+    })
+  })
+
+  describe('getPrisonerById', () => {
+    it('should return data for single prisoner by prisoner ID', async () => {
+      const results: Prisoner = {
+        lastName: 'FORENAME',
+        firstName: 'SURNAME',
+        prisonerNumber: 'A1234BC',
+        dateOfBirth: '2000-01-01',
+        prisonId: 'HEI',
+        prisonName: 'HMP Hewell',
+        cellLocation: '1-1-C-028',
+        restrictedPatient: false,
+      }
+      fakePrisonerSearchApi.get('/prisoner/A1234BC').matchHeader('authorization', `Bearer ${token}`).reply(200, results)
+
+      const output = await client.getPrisonerById('A1234BC')
 
       expect(output).toEqual(results)
     })

--- a/server/data/prisonerSearchClient.ts
+++ b/server/data/prisonerSearchClient.ts
@@ -43,6 +43,12 @@ class PrisonerSearchClient {
     })
   }
 
+  getPrisonerById(id: string): Promise<Prisoner> {
+    return this.restClient.get({
+      path: `/prisoner/${id}`,
+    })
+  }
+
   async getPrisonersByPrisonerNumbers(
     prisonerNumbers: string[],
     page = 0,

--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -292,7 +292,7 @@ describe('Booking search page', () => {
         restrictedPatient: false,
       }
 
-      prisonerSearchService.getPrisoner.mockResolvedValue(getPrisonerReturnData)
+      prisonerSearchService.getPrisonerById.mockResolvedValue(getPrisonerReturnData)
       visitSessionsService.getVisit.mockImplementation(() => {
         throw createError(404, 'Not found')
       })
@@ -325,7 +325,7 @@ describe('Booking search page', () => {
         visitTime: '1pm -2pm',
       }
 
-      prisonerSearchService.getPrisoner.mockResolvedValue(getPrisonerReturnData)
+      prisonerSearchService.getPrisonerById.mockResolvedValue(getPrisonerReturnData)
       visitSessionsService.getVisit.mockResolvedValue(getVisit)
 
       return request(app)

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -117,7 +117,10 @@ export default function routes(
     if (errors.length === 0) {
       try {
         visit = await visitSessionsService.getVisit({ reference: search, username: res.locals.user?.username })
-        const prisonerDetails = await prisonerSearchService.getPrisoner(visit.prisonNumber, res.locals.user?.username)
+        const prisonerDetails = await prisonerSearchService.getPrisonerById(
+          visit.prisonNumber,
+          res.locals.user?.username,
+        )
         visit.prisonerName = `${prisonerDetails.lastName}, ${prisonerDetails.firstName}`
       } catch (e) {
         if (e?.status === 404) {

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -135,7 +135,7 @@ describe('GET /visit/:reference', () => {
 
     const additionalSupport = ['Wheelchair ramp', 'custom request']
 
-    prisonerSearchService.getPrisoner.mockResolvedValue(prisoner)
+    prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
     visitSessionsService.getFullVisitDetails.mockResolvedValue({ visit, visitors, additionalSupport })
 
     return request(app)
@@ -279,7 +279,7 @@ describe('GET /visit/:reference', () => {
     const url =
       '/visit/ab-cd-ef-gh?query=startDate%3D2022-05-24%26type%3DOPEN%26time%3D3pm%2Bto%2B3%253A59pm&from=visit-search'
 
-    prisonerSearchService.getPrisoner.mockResolvedValue(prisoner)
+    prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
     visitSessionsService.getFullVisitDetails.mockResolvedValue({ visit, visitors, additionalSupport })
 
     return request(app)

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -46,98 +46,100 @@ afterEach(() => {
 })
 
 describe('GET /visit/:reference', () => {
-  it('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
-    const childBirthYear = new Date().getFullYear() - 5
+  const childBirthYear = new Date().getFullYear() - 5
 
-    const prisoner: Prisoner = {
-      firstName: 'JOHN',
-      lastName: 'SMITH',
-      prisonerNumber: 'A1234BC',
-      dateOfBirth: '1975-04-02',
-      prisonName: 'Hewell (HMP)',
-      cellLocation: '1-1-C-028',
-      restrictedPatient: false,
-    }
+  const prisoner: Prisoner = {
+    firstName: 'JOHN',
+    lastName: 'SMITH',
+    prisonerNumber: 'A1234BC',
+    dateOfBirth: '1975-04-02',
+    prisonName: 'Hewell (HMP)',
+    cellLocation: '1-1-C-028',
+    restrictedPatient: false,
+  }
 
-    const visit: Visit = {
-      reference: 'ab-cd-ef-gh',
-      prisonerId: 'A1234BC',
-      prisonId: 'HEI',
-      visitRoom: 'visit room',
-      visitType: 'SOCIAL',
-      visitStatus: 'BOOKED',
-      visitRestriction: 'OPEN',
-      startTimestamp: '2022-02-09T10:00:00',
-      endTimestamp: '2022-02-09T11:15:00',
-      visitNotes: [
-        {
-          type: 'VISIT_COMMENT',
-          text: 'Example of a visit comment',
-        },
-        {
-          type: 'VISITOR_CONCERN',
-          text: 'Example of a visitor concern',
-        },
-      ],
-      visitContact: {
-        name: 'Jeanette Smith',
-        telephone: '01234 567890',
-      },
-      visitors: [
-        {
-          nomisPersonId: 4321,
-        },
-        {
-          nomisPersonId: 4324,
-        },
-      ],
-      visitorSupport: [
-        {
-          type: 'WHEELCHAIR',
-        },
-        {
-          type: 'OTHER',
-          text: 'custom request',
-        },
-      ],
-      createdTimestamp: '2022-02-14T10:00:00',
-      modifiedTimestamp: '2022-02-14T10:05:00',
-    }
-    const visitors: VisitorListItem[] = [
+  const visit: Visit = {
+    reference: 'ab-cd-ef-gh',
+    prisonerId: 'A1234BC',
+    prisonId: 'HEI',
+    visitRoom: 'visit room',
+    visitType: 'SOCIAL',
+    visitStatus: 'BOOKED',
+    visitRestriction: 'OPEN',
+    startTimestamp: '2022-02-09T10:00:00',
+    endTimestamp: '2022-02-09T11:15:00',
+    visitNotes: [
       {
-        personId: 4321,
-        name: 'Jeanette Smith',
-        dateOfBirth: '1986-07-28',
-        adult: true,
-        relationshipDescription: 'Sister',
-        address: '123 The Street,<br>Coventry',
-        restrictions: [
-          {
-            restrictionType: 'CLOSED',
-            restrictionTypeDescription: 'Closed',
-            startDate: '2022-01-03',
-            globalRestriction: false,
-          },
-        ],
-        banned: false,
+        type: 'VISIT_COMMENT',
+        text: 'Example of a visit comment',
       },
       {
-        personId: 4324,
-        name: 'Anne Smith',
-        dateOfBirth: `${childBirthYear}-01-02`,
-        adult: false,
-        relationshipDescription: 'Niece',
-        address: 'Not entered',
-        restrictions: [],
-        banned: false,
+        type: 'VISITOR_CONCERN',
+        text: 'Example of a visitor concern',
       },
-    ]
+    ],
+    visitContact: {
+      name: 'Jeanette Smith',
+      telephone: '01234 567890',
+    },
+    visitors: [
+      {
+        nomisPersonId: 4321,
+      },
+      {
+        nomisPersonId: 4324,
+      },
+    ],
+    visitorSupport: [
+      {
+        type: 'WHEELCHAIR',
+      },
+      {
+        type: 'OTHER',
+        text: 'custom request',
+      },
+    ],
+    createdTimestamp: '2022-02-14T10:00:00',
+    modifiedTimestamp: '2022-02-14T10:05:00',
+  }
+  const visitors: VisitorListItem[] = [
+    {
+      personId: 4321,
+      name: 'Jeanette Smith',
+      dateOfBirth: '1986-07-28',
+      adult: true,
+      relationshipDescription: 'Sister',
+      address: '123 The Street,<br>Coventry',
+      restrictions: [
+        {
+          restrictionType: 'CLOSED',
+          restrictionTypeDescription: 'Closed',
+          startDate: '2022-01-03',
+          globalRestriction: false,
+        },
+      ],
+      banned: false,
+    },
+    {
+      personId: 4324,
+      name: 'Anne Smith',
+      dateOfBirth: `${childBirthYear}-01-02`,
+      adult: false,
+      relationshipDescription: 'Niece',
+      address: 'Not entered',
+      restrictions: [],
+      banned: false,
+    },
+  ]
 
-    const additionalSupport = ['Wheelchair ramp', 'custom request']
+  const additionalSupport = ['Wheelchair ramp', 'custom request']
 
+  beforeEach(() => {
     prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
     visitSessionsService.getFullVisitDetails.mockResolvedValue({ visit, visitors, additionalSupport })
+  })
 
+  it('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
     return request(app)
       .get('/visit/ab-cd-ef-gh')
       .expect(200)
@@ -189,93 +191,6 @@ describe('GET /visit/:reference', () => {
   })
 
   it('should render full booking summary page with prisoner, visit and visitor details with search back link when from visits', () => {
-    const childBirthYear = new Date().getFullYear() - 5
-
-    const prisoner: Prisoner = {
-      firstName: 'JOHN',
-      lastName: 'SMITH',
-      prisonerNumber: 'A1234BC',
-      dateOfBirth: '1975-04-02',
-      prisonName: 'Hewell (HMP)',
-      cellLocation: '1-1-C-028',
-      restrictedPatient: false,
-    }
-
-    const visit: Visit = {
-      reference: 'ab-cd-ef-gh',
-      prisonerId: 'A1234BC',
-      prisonId: 'HEI',
-      visitRoom: 'visit room',
-      visitType: 'SOCIAL',
-      visitStatus: 'BOOKED',
-      visitRestriction: 'OPEN',
-      startTimestamp: '2022-02-09T10:00:00',
-      endTimestamp: '2022-02-09T11:15:00',
-      visitNotes: [
-        {
-          type: 'VISIT_COMMENT',
-          text: 'Example of a visit comment',
-        },
-        {
-          type: 'VISITOR_CONCERN',
-          text: 'Example of a visitor concern',
-        },
-      ],
-      visitContact: {
-        name: 'Jeanette Smith',
-        telephone: '01234 567890',
-      },
-      visitors: [
-        {
-          nomisPersonId: 4321,
-        },
-        {
-          nomisPersonId: 4324,
-        },
-      ],
-      visitorSupport: [
-        {
-          type: 'WHEELCHAIR',
-        },
-        {
-          type: 'OTHER',
-          text: 'custom request',
-        },
-      ],
-      createdTimestamp: '2022-02-14T10:00:00',
-      modifiedTimestamp: '2022-02-14T10:05:00',
-    }
-    const visitors: VisitorListItem[] = [
-      {
-        personId: 4321,
-        name: 'Jeanette Smith',
-        dateOfBirth: '1986-07-28',
-        adult: true,
-        relationshipDescription: 'Sister',
-        address: '123 The Street,<br>Coventry',
-        restrictions: [
-          {
-            restrictionType: 'CLOSED',
-            restrictionTypeDescription: 'Closed',
-            startDate: '2022-01-03',
-            globalRestriction: false,
-          },
-        ],
-        banned: false,
-      },
-      {
-        personId: 4324,
-        name: 'Anne Smith',
-        dateOfBirth: `${childBirthYear}-01-02`,
-        adult: false,
-        relationshipDescription: 'Niece',
-        address: 'Not entered',
-        restrictions: [],
-        banned: false,
-      },
-    ]
-
-    const additionalSupport = ['Wheelchair ramp', 'custom request']
     const url =
       '/visit/ab-cd-ef-gh?query=startDate%3D2022-05-24%26type%3DOPEN%26time%3D3pm%2Bto%2B3%253A59pm&from=visit-search'
 

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -53,6 +53,7 @@ describe('GET /visit/:reference', () => {
     lastName: 'SMITH',
     prisonerNumber: 'A1234BC',
     dateOfBirth: '1975-04-02',
+    prisonId: 'HEI',
     prisonName: 'Hewell (HMP)',
     cellLocation: '1-1-C-028',
     restrictedPatient: false,
@@ -244,6 +245,37 @@ describe('GET /visit/:reference', () => {
           undefined,
           undefined,
         )
+      })
+  })
+
+  // Temporarily hiding any locations other than Hewell pending more work on transfer/release (see VB-907, VB-952)
+  it('should render full booking summary page with prisoner - but showing location as Unknown if not Hewell', () => {
+    const transferPrisoner: Prisoner = {
+      firstName: 'JOHN',
+      lastName: 'SMITH',
+      prisonerNumber: 'A1234BC',
+      dateOfBirth: '1975-04-02',
+      prisonId: 'TRN',
+      prisonName: 'Transfer',
+      restrictedPatient: false,
+    }
+
+    prisonerSearchService.getPrisonerById.mockResolvedValue(transferPrisoner)
+
+    return request(app)
+      .get('/visit/ab-cd-ef-gh')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('h1').text()).toBe('Booking details')
+        expect($('.govuk-back-link').attr('href')).toBe('/prisoner/A1234BC/visits')
+        expect($('[data-test="reference"]').text()).toBe('ab-cd-ef-gh')
+        // prisoner details
+        expect($('[data-test="prisoner-name"]').text()).toBe('Smith, John')
+        expect($('[data-test="prisoner-number"]').text()).toBe('A1234BC')
+        expect($('[data-test="prisoner-dob"]').text()).toBe('2 April 1975')
+        expect($('[data-test="prisoner-location"]').text()).toBe('Unknown')
       })
   })
 

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -46,6 +46,9 @@ export default function routes(
     })
 
     const prisoner: Prisoner = await prisonerSearchService.getPrisonerById(visit.prisonerId, res.locals.user?.username)
+    // Temporarily hide any locations other than Hewell pending more work on transfer/release (see VB-907, VB-952)
+    const prisonerLocation =
+      prisoner.prisonId === 'HEI' ? `${prisoner.cellLocation}, ${prisoner.prisonName}` : 'Unknown'
 
     await auditService.viewedVisitDetails(
       reference,
@@ -57,6 +60,7 @@ export default function routes(
 
     return res.render('pages/visit/summary', {
       prisoner,
+      prisonerLocation,
       visit,
       visitors,
       additionalSupport,

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -45,7 +45,7 @@ export default function routes(
       username: res.locals.user?.username,
     })
 
-    const prisoner: Prisoner = await prisonerSearchService.getPrisoner(visit.prisonerId, res.locals.user?.username)
+    const prisoner: Prisoner = await prisonerSearchService.getPrisonerById(visit.prisonerId, res.locals.user?.username)
 
     await auditService.viewedVisitDetails(
       reference,

--- a/server/services/prisonerSearchService.test.ts
+++ b/server/services/prisonerSearchService.test.ts
@@ -148,4 +148,24 @@ describe('Prisoner search service', () => {
       expect(result).toBe(prisoner.content[0])
     })
   })
+
+  describe('getPrisonerById', () => {
+    it('should return prisoner details for given prisoner ID', async () => {
+      const prisoner: Prisoner = {
+        lastName: 'FORENAME',
+        firstName: 'SURNAME',
+        prisonerNumber: 'A1234BC',
+        dateOfBirth: '2000-01-01',
+        prisonId: 'HEI',
+        prisonName: 'HMP Hewell',
+        cellLocation: '1-1-C-028',
+        restrictedPatient: false,
+      }
+
+      prisonerSearchClient.getPrisonerById.mockResolvedValue(prisoner)
+      const result = await prisonerSearchService.getPrisonerById('A1234BC', 'user')
+
+      expect(result).toBe(prisoner)
+    })
+  })
 })

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -86,6 +86,12 @@ export default class PrisonerSearchService {
     return content.length === 1 ? content[0] : null
   }
 
+  async getPrisonerById(id: string, username: string): Promise<Prisoner> {
+    const token = await this.systemToken(username)
+    const prisonerSearchClient = this.prisonerSearchClientBuilder(token)
+    return prisonerSearchClient.getPrisonerById(id)
+  }
+
   async getPrisonersByPrisonerNumbers(
     prisonerVisits: {
       prisoner: string

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -35,7 +35,7 @@
         </li>
         <li>
           <strong>Location</strong>
-          <span data-test="prisoner-location">{{ prisoner.cellLocation + ", " + prisoner.prisonName if prisoner.cellLocation else prisoner.prisonName }}</span>
+          <span data-test="prisoner-location">{{ prisonerLocation }}</span>
         </li>
       </ul>
 

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -35,7 +35,7 @@
         </li>
         <li>
           <strong>Location</strong>
-          <span data-test="prisoner-location">{{ prisoner.cellLocation + ", " + prisoner.prisonName }}</span>
+          <span data-test="prisoner-location">{{ prisoner.cellLocation + ", " + prisoner.prisonName if prisoner.cellLocation else prisoner.prisonName }}</span>
         </li>
       </ul>
 


### PR DESCRIPTION
Viewing a visit or searching by visit reference could fail if the prisoner had transferred from Hewell or been released as the API endpoints used to look up prisoner details (e.g. name) were tied down to Hewell (as a requirement of the booking journey).

This change adds the `GET /prisoner/{id}` endpoint from the `global-search-resource` in Prisoner Offender Search API and uses this to retrieve prisoner details - but **only** when viewing a visit or searching by visit reference in order to keep booking journey behaviour unchanged.

(Until further work is done on requirements regarding prisoner transfer/release, the prisoner location on the visit summary page will show **Unknown** if the prisoner is no longer at Hewell.)