### PR TITLE
VB-1033: Don't sent audit event if empty search

### DIFF
--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -109,7 +109,7 @@ describe('Prisoner search page', () => {
           .expect(res => {
             expect(res.text).toContain('Search for a prisoner')
             expect(res.text).toContain('You must enter at least 2 characters')
-            expect(auditService.prisonerSearch).toBeCalledWith('', 'HEI', undefined, undefined)
+            expect(auditService.prisonerSearch).not.toHaveBeenCalled()
             expect(prisonerSearchService.getPrisoners).not.toBeCalled()
           })
       })
@@ -267,6 +267,30 @@ describe('Prisoner search page', () => {
             expect(res.text).toContain('id="search-results-true"')
             expect(res.text).toContain('<p class="moj-pagination__results">')
           })
+      })
+
+      describe('GET /search/prisoner-visit/results?search=', () => {
+        it('should render prisoner results page with no results with no search term', () => {
+          getPrisonersReturnData = {
+            results: [],
+            numberOfResults: 0,
+            numberOfPages: 0,
+            next: 0,
+            previous: 0,
+          }
+
+          prisonerSearchService.getPrisoners.mockResolvedValue(getPrisonersReturnData)
+
+          return request(app)
+            .get('/search/prisoner-visit/results?search=')
+            .expect('Content-Type', /html/)
+            .expect(res => {
+              expect(res.text).toContain('Search for a prisoner')
+              expect(res.text).toContain('You must enter at least 2 characters')
+              expect(auditService.prisonerSearch).not.toHaveBeenCalled()
+              expect(prisonerSearchService.getPrisoners).not.toBeCalled()
+            })
+        })
       })
     })
   })

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -47,13 +47,17 @@ export default function routes(
     const validationErrors = validatePrisonerSearch(search)
     const errors = validationErrors ? [validationErrors] : []
     const hasValidationErrors = errors.length > 0
+
     const { results, numberOfPages, numberOfResults, next, previous } = hasValidationErrors
       ? { results: 0, numberOfPages: 0, numberOfResults: 0, next: 0, previous: 0 }
       : await prisonerSearchService.getPrisoners(search, res.locals.user?.username, parsedPage, isVisit)
 
+    if (!hasValidationErrors) {
+      await auditService.prisonerSearch(search, 'HEI', res.locals.user?.username, res.locals.appInsightsOperationId)
+    }
+
     const currentPageMax = parsedPage * pageSize
     const to = numberOfResults < currentPageMax ? numberOfResults : currentPageMax
-    await auditService.prisonerSearch(search, 'HEI', res.locals.user?.username, res.locals.appInsightsOperationId)
 
     const pageLinks = getResultsPagingLinks({
       pagesToShow: config.apis.prisonerSearch.pagesLinksToShow,


### PR DESCRIPTION
Empty search requests were no longer calling the search API but **were** still logging an audit event. This change only logs audit events for valid search terms (i.e. currently 2 characters or more).