### PR TITLE
VB-543: Incorporate non-associations into date picker page

### DIFF
--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -252,11 +252,12 @@ describe('visitSchedulerApiClient', () => {
         .get('/visit-sessions')
         .query({
           prisonId: 'HEI',
+          prisonerId: 'A1234BC',
         })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, results)
 
-      const output = await client.getVisitSessions()
+      const output = await client.getVisitSessions('A1234BC')
 
       expect(output).toEqual(results)
     })

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -73,11 +73,12 @@ class VisitSchedulerApiClient {
     })
   }
 
-  getVisitSessions(): Promise<VisitSession[]> {
+  getVisitSessions(offenderNo: string): Promise<VisitSession[]> {
     return this.restclient.get({
       path: '/visit-sessions',
       query: new URLSearchParams({
         prisonId: this.prisonId,
+        prisonerId: offenderNo,
         // 'min' and 'max' params omitted, so using API default between 2 and 28 days from now
       }).toString(),
     })

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -80,6 +80,7 @@ describe('Visit sessions service', () => {
       })
 
       expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC')
       expect(results).toEqual({})
     })
 
@@ -130,6 +131,7 @@ describe('Visit sessions service', () => {
         })
 
         expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+        expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC')
         expect(whereaboutsApiClient.getEvents).toHaveBeenCalledTimes(1)
         expect(results).toEqual(<VisitSlotList>{
           'February 2022': [
@@ -187,6 +189,7 @@ describe('Visit sessions service', () => {
         })
 
         expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+        expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC')
         expect(whereaboutsApiClient.getEvents).toHaveBeenCalledTimes(1)
         expect(results).toEqual(<VisitSlotList>{
           'February 2022': [
@@ -222,6 +225,7 @@ describe('Visit sessions service', () => {
         })
 
         expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+        expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC')
         expect(whereaboutsApiClient.getEvents).toHaveBeenCalledTimes(1)
         expect(results).toEqual(<VisitSlotList>{
           'February 2022': [
@@ -274,6 +278,7 @@ describe('Visit sessions service', () => {
       })
 
       expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC')
       expect(results).toEqual(<VisitSlotList>{
         'February 2022': [
           {
@@ -372,6 +377,7 @@ describe('Visit sessions service', () => {
       })
 
       expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC')
       expect(results).toEqual(<VisitSlotList>{
         'February 2022': [
           {
@@ -478,6 +484,7 @@ describe('Visit sessions service', () => {
       })
 
       expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC')
       expect(results).toEqual(<VisitSlotList>{
         'February 2022': [
           {
@@ -529,6 +536,7 @@ describe('Visit sessions service', () => {
       })
 
       expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC')
       expect(results).toEqual(<VisitSlotList>{
         'February 2022': [
           {
@@ -572,6 +580,7 @@ describe('Visit sessions service', () => {
       })
 
       expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC')
       expect(results).toEqual(<VisitSlotList>{
         'February 2022': [
           {
@@ -623,6 +632,7 @@ describe('Visit sessions service', () => {
       })
 
       expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC')
       expect(results).toEqual(<VisitSlotList>{})
     })
   })

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -58,7 +58,7 @@ export default class VisitSessionsService {
     const token = await this.systemToken(username)
     const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
     const whereaboutsApiClient = this.whereaboutsApiClientBuilder(token)
-    const visitSessions = await visitSchedulerApiClient.getVisitSessions()
+    const visitSessions = await visitSchedulerApiClient.getVisitSessions(offenderNo)
 
     let earliestStartTime: Date = new Date()
     let latestEndTime: Date = new Date()


### PR DESCRIPTION
Slots that shouldn't be available because of non-associations can be filtered out of the available list by passing `prisonerId` to the visit scheduler when requesting the list of available slots.