### PR TITLE
VB-1034: disallow double booking

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -1,5 +1,5 @@
 import { InmateDetail, OffenderRestriction, VisitBalances } from '../data/prisonApiTypes'
-import { Visit, VisitorSupport } from '../data/visitSchedulerApiTypes'
+import { Visit, VisitorSupport, VisitSession } from '../data/visitSchedulerApiTypes'
 
 export type PrisonerDetailsItem = {
   html?: string
@@ -140,6 +140,7 @@ export type VisitSlot = {
   endTimestamp: string
   availableTables: number
   visitRoomName: string
+  sessionConflicts?: VisitSession['sessionConflicts']
 }
 
 export type PrisonerEvent = {

--- a/server/@types/visit-scheduler-api.d.ts
+++ b/server/@types/visit-scheduler-api.d.ts
@@ -90,7 +90,7 @@ export interface components {
        * @description Visit Type
        * @example SOCIAL
        */
-      visitType?: 'SOCIAL' | 'OFFICIAL' | 'FAMILY'
+      visitType?: 'SOCIAL'
       /**
        * @description Visit Status
        * @example RESERVED
@@ -173,7 +173,7 @@ export interface components {
        * @description Visit Type
        * @example SOCIAL
        */
-      visitType: 'SOCIAL' | 'OFFICIAL' | 'FAMILY'
+      visitType: 'SOCIAL'
       /**
        * @description Visit Status
        * @example RESERVED
@@ -256,8 +256,8 @@ export interface components {
       messageAttributes?: {
         [key: string]: components['schemas']['MessageAttributeValue']
       }
-      md5OfMessageAttributes?: string
       md5OfBody?: string
+      md5OfMessageAttributes?: string
     }
     MessageAttributeValue: {
       stringValue?: string
@@ -323,7 +323,7 @@ export interface components {
        * @description Visit Type
        * @example SOCIAL
        */
-      visitType: 'SOCIAL' | 'OFFICIAL' | 'FAMILY'
+      visitType: 'SOCIAL'
       /**
        * @description Visit Status
        * @example RESERVED
@@ -360,28 +360,26 @@ export interface components {
       endTime: components['schemas']['LocalTime']
       /**
        * Format: date
-       * @description The start date of the session template
+       * @description The start of the Validity period for the session template
        * @example 2019-12-02
        */
-      startDate: string
+      validFromDate: string
       /**
        * Format: date
-       * @description The expiry date of the session template
+       * @description The end of the Validity period for the session template
        * @example 2019-12-02
        */
-      expiryDate?: string
+      validToDate?: string
       /**
        * @description visit type
        * @example SOCIAL
        */
-      visitType: 'SOCIAL' | 'OFFICIAL' | 'FAMILY'
+      visitType: 'SOCIAL'
       /**
        * @description visit room
        * @example A1
        */
       visitRoom: string
-      /** @description frequency */
-      frequency: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'SINGLE'
       /**
        * Format: int32
        * @description closed capacity
@@ -394,6 +392,11 @@ export interface components {
        * @example 50
        */
       openCapacity: number
+      /**
+       * @description day of week for visit
+       * @example MONDAY
+       */
+      dayOfWeek: 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY'
     }
     /**
      * @description The end time of the generated visit session(s)
@@ -425,31 +428,26 @@ export interface components {
       endTime: components['schemas']['LocalTime']
       /**
        * Format: date
-       * @description The start date of the session template
+       * @description The start of the Validity period for the session template
        * @example 2019-12-02
        */
-      startDate: string
+      validFromDate: string
       /**
        * Format: date
-       * @description The expiry date of the session template
+       * @description The end of the Validity period for the session template
        * @example 2019-12-02
        */
-      expiryDate?: string
+      validToDate?: string
       /**
        * @description visit type
        * @example SOCIAL
        */
-      visitType: 'SOCIAL' | 'OFFICIAL' | 'FAMILY'
+      visitType: 'SOCIAL'
       /**
        * @description visit room
        * @example A1
        */
       visitRoom: string
-      /**
-       * @description frequency
-       * @example A1
-       */
-      frequency: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'SINGLE'
       /**
        * Format: int32
        * @description closed capacity
@@ -462,6 +460,11 @@ export interface components {
        * @example 50
        */
       openCapacity: number
+      /**
+       * @description day of week fpr visit
+       * @example MONDAY
+       */
+      dayOfWeek?: 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY'
     }
     /** @description Contact associated with the visit */
     CreateLegacyContactOnVisitRequestDto: {
@@ -508,7 +511,7 @@ export interface components {
        * @description Visit Type
        * @example SOCIAL
        */
-      visitType: 'SOCIAL' | 'OFFICIAL' | 'FAMILY'
+      visitType: 'SOCIAL'
       /**
        * @description Visit Status
        * @example RESERVED
@@ -603,9 +606,9 @@ export interface components {
       sort?: components['schemas']['Sort']
       last?: boolean
       first?: boolean
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     PageableObject: {
@@ -614,10 +617,10 @@ export interface components {
       sort?: components['schemas']['Sort']
       /** Format: int32 */
       pageSize?: number
-      paged?: boolean
-      unpaged?: boolean
       /** Format: int32 */
       pageNumber?: number
+      paged?: boolean
+      unpaged?: boolean
     }
     Sort: {
       empty?: boolean
@@ -654,7 +657,7 @@ export interface components {
        * @description The type of visits taking place within this session
        * @example SOCIAL
        */
-      visitType: 'SOCIAL' | 'OFFICIAL' | 'FAMILY'
+      visitType: 'SOCIAL'
       /**
        * @description The prison id
        * @example LEI
@@ -694,6 +697,8 @@ export interface components {
        * @description The end timestamp for this visit session
        */
       endTimestamp: string
+      /** @description Session conflicts */
+      sessionConflicts?: ('NON_ASSOCIATION' | 'DOUBLE_BOOKED')[]
     }
     DlqMessage: {
       body: { [key: string]: { [key: string]: unknown } }

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -1040,6 +1040,8 @@ describe('/book-a-visit/select-date-and-time', () => {
               endTimestamp: '2022-02-14T11:00:00',
               availableTables: 15,
               visitRoomName: 'room name',
+              // representing a pre-existing visit that is BOOKED
+              sessionConflicts: ['DOUBLE_BOOKED'],
             },
             {
               id: '2',
@@ -1056,6 +1058,8 @@ describe('/book-a-visit/select-date-and-time', () => {
               endTimestamp: '2022-02-14T13:05:00',
               availableTables: 5,
               visitRoomName: 'room name',
+              // representing the RESERVED visit being handled in this session
+              sessionConflicts: ['DOUBLE_BOOKED'],
             },
           ],
         },
@@ -1161,6 +1165,10 @@ describe('/book-a-visit/select-date-and-time', () => {
           expect($('input[name="visit-date-and-time"]').length).toBe(5)
           expect($('input[name="visit-date-and-time"]:checked').length).toBe(0)
           expect($('.govuk-accordion__section--expanded').length).toBe(0)
+
+          expect($('label[for="1"]').text()).toContain('Prisoner has a visit')
+          expect($('#1').attr('disabled')).toBe('disabled')
+
           expect($('[data-test="submit"]').text().trim()).toBe('Continue')
         })
     })
@@ -1344,6 +1352,8 @@ describe('/book-a-visit/select-date-and-time', () => {
             endTimestamp: '2022-02-14T13:05:00',
             availableTables: 5,
             visitRoomName: 'room name',
+            // representing the RESERVED visit being handled in this session
+            sessionConflicts: ['DOUBLE_BOOKED'],
           })
           expect(visitSessionsService.createVisit).not.toHaveBeenCalled()
           expect(auditService.reservedVisit).toBeCalledTimes(1)

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -95,6 +95,7 @@ export default class VisitSessionsService {
                 ? visitSession.openVisitCapacity - visitSession.openVisitBookedCount
                 : visitSession.closedVisitCapacity - visitSession.closedVisitBookedCount,
             visitRoomName: visitSession.visitRoomName,
+            sessionConflicts: visitSession.sessionConflicts,
           }
 
           // Maybe this needs doing below, twice since technically this may not be pushed

--- a/server/views/pages/dateAndTime.njk
+++ b/server/views/pages/dateAndTime.njk
@@ -14,13 +14,19 @@
 
 {% macro buildSlotsRadioItems(slotsList, radios) %}
   {% for slot in slotsList %}
-    {% set tableText %}
-      {% if slot.availableTables === 0 %}Fully booked{% endif %}
-      {% if slot.availableTables === 1 %}1 table available{% endif %}
-      {% if slot.availableTables > 1 %}{{ slot.availableTables }} tables available{% endif %}
-    {% endset %}
 
+    {%- set doubleBooked = slot.sessionConflicts and "DOUBLE_BOOKED" in slot.sessionConflicts %}
     {%- set checked = true if formValues['visit-date-and-time'] and formValues['visit-date-and-time'] == slot.id else false %}
+
+    {%- set tableText %}
+      {% if (doubleBooked and not checked) -%}
+        Prisoner has a visit
+      {%- elseif slot.availableTables === 0 -%}
+        Fully booked
+      {%- else -%}
+        {{ slot.availableTables }} table{{ "s" if slot.availableTables > 1 }} available
+      {%- endif %}
+    {% endset %}
 
     {%- set radios = (radios.push({
       value: slot.id,
@@ -28,7 +34,7 @@
         " to " + slot.endTimestamp | formatTime + "</strong><br>" + tableText + "</p>",
       id: slot.id,
       checked: checked,
-      disabled: slot.availableTables === 0
+      disabled: slot.availableTables === 0 or (doubleBooked and not checked)
     }), radios) %}
   {% endfor %}
 {% endmacro %}

--- a/server/views/pages/dateAndTime.test.ts
+++ b/server/views/pages/dateAndTime.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import * as cheerio from 'cheerio'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../utils/nunjucksSetup'
+import { VisitSlotList } from '../../@types/bapv'
 
 const template = fs.readFileSync('server/views/pages/dateAndTime.njk')
 
@@ -29,10 +30,14 @@ describe('Views - Date and time of visit', () => {
     viewContext = {
       prisonerName: 'John Smith',
       visitRestriction: 'OPEN',
-      slotsList: {
+      slotsList: <VisitSlotList>{
         'February 2022': [
           {
             date: 'Monday 14 February',
+            prisonerEvents: {
+              morning: [],
+              afternoon: [],
+            },
             slots: {
               morning: [
                 {
@@ -40,12 +45,14 @@ describe('Views - Date and time of visit', () => {
                   startTimestamp: '2022-02-14T10:00:00',
                   endTimestamp: '2022-02-14T11:00:00',
                   availableTables: 15,
+                  visitRoomName: 'room name',
                 },
                 {
                   id: '2',
                   startTimestamp: '2022-02-14T11:59:00',
                   endTimestamp: '2022-02-14T12:59:00',
                   availableTables: 1,
+                  visitRoomName: 'room name',
                 },
               ],
               afternoon: [
@@ -54,12 +61,19 @@ describe('Views - Date and time of visit', () => {
                   startTimestamp: '2022-02-14T12:00:00',
                   endTimestamp: '2022-02-14T13:05:00',
                   availableTables: 5,
+                  visitRoomName: 'room name',
+                  // representing a pre-existing visit that is BOOKED
+                  sessionConflicts: ['DOUBLE_BOOKED'],
                 },
               ],
             },
           },
           {
             date: 'Tuesday 15 February',
+            prisonerEvents: {
+              morning: [],
+              afternoon: [],
+            },
             slots: {
               morning: [],
               afternoon: [
@@ -68,6 +82,9 @@ describe('Views - Date and time of visit', () => {
                   startTimestamp: '2022-02-15T16:00:00',
                   endTimestamp: '2022-02-15T17:00:00',
                   availableTables: 12,
+                  visitRoomName: 'room name',
+                  // representing the RESERVED visit being handled in this session
+                  sessionConflicts: ['DOUBLE_BOOKED'],
                 },
               ],
             },
@@ -76,6 +93,10 @@ describe('Views - Date and time of visit', () => {
         'March 2022': [
           {
             date: 'Tuesday 1 March',
+            prisonerEvents: {
+              morning: [],
+              afternoon: [],
+            },
             slots: {
               morning: [
                 {
@@ -83,6 +104,7 @@ describe('Views - Date and time of visit', () => {
                   startTimestamp: '2022-03-01T09:30:00',
                   endTimestamp: '2022-03-01T10:30:00',
                   availableTables: 0,
+                  visitRoomName: 'room name',
                 },
               ],
               afternoon: [],
@@ -107,6 +129,9 @@ describe('Views - Date and time of visit', () => {
     expect($('label[for="1"]').text()).toContain('15 tables available')
     expect($('label[for="2"]').text()).toContain('11:59am to 12:59pm')
     expect($('label[for="2"]').text()).toContain('1 table available')
+    expect($('label[for="3"]').text()).toContain('12pm to 1:05pm')
+    expect($('label[for="3"]').text()).toContain('Prisoner has a visit')
+    expect($('#3').attr('disabled')).toBe('disabled')
     expect($('#slots-month-February2022-content-1 .bapv-afternoon-slots > h3').text()).toBe('Afternoon')
     expect($('#slots-month-February2022-heading-2').text().trim()).toBe('Tuesday 15 February')
     expect($('#4').prop('checked')).toBe(true)


### PR DESCRIPTION
Incorporates the `sessionConflicts` information from the visit scheduler to disable slots flagged as a `DOUBLE_BOOKING`, meaning that the prisoner already has a visit at this time.

The `DOUBLE_BOOKING` flag is also set once a visit is `RESERVED` so it checks whether the slot flagged is the one being managed by the current journey, in which case it is not disabled.