### PR TITLE
client-level, normalisation of tests

### DIFF
--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -75,7 +75,7 @@ describe('hmppsAuthClient', () => {
       const output = await hmppsAuthClient.getSystemClientToken(username)
 
       expect(output).toEqual(token.access_token)
-      expect(tokenStore.setToken).toBeCalledWith('Bob', token.access_token, 240)
+      expect(tokenStore.setToken).toHaveBeenCalledWith('Bob', token.access_token, 240)
     })
 
     it('should return token from HMPPS Auth without username', async () => {
@@ -90,7 +90,7 @@ describe('hmppsAuthClient', () => {
       const output = await hmppsAuthClient.getSystemClientToken()
 
       expect(output).toEqual(token.access_token)
-      expect(tokenStore.setToken).toBeCalledWith('%ANONYMOUS%', token.access_token, 240)
+      expect(tokenStore.setToken).toHaveBeenCalledWith('%ANONYMOUS%', token.access_token, 240)
     })
   })
 })


### PR DESCRIPTION
Client tests
Did some normalisation of the jest functions being used
toBeCalledTimes ->  toHaveBeenCalledTimes
toBeCalledWith -> toHaveBeenCalledWith
