### PR TITLE
Remove duplicate call to contact registry on prisoner profile

### DIFF
--- a/server/services/prisonerProfileService.test.ts
+++ b/server/services/prisonerProfileService.test.ts
@@ -135,6 +135,7 @@ describe('Prisoner profile service', () => {
       expect(prisonApiClient.getBookings).toHaveBeenCalledTimes(1)
       expect(prisonApiClient.getOffender).toHaveBeenCalledTimes(1)
       expect(prisonApiClient.getVisitBalances).toHaveBeenCalledTimes(1)
+      expect(prisonerContactRegistryApiClient.getPrisonerSocialContacts).toHaveBeenCalledTimes(1)
       expect(results).toEqual({
         displayName: 'Smith, John',
         displayDob: '12 October 1980',
@@ -207,6 +208,7 @@ describe('Prisoner profile service', () => {
       expect(prisonApiClient.getBookings).toHaveBeenCalledTimes(1)
       expect(prisonApiClient.getOffender).toHaveBeenCalledTimes(1)
       expect(prisonApiClient.getVisitBalances).not.toHaveBeenCalled()
+      expect(prisonerContactRegistryApiClient.getPrisonerSocialContacts).toHaveBeenCalledTimes(1)
       expect(results).toEqual({
         displayName: 'James, Fred',
         displayDob: '11 December 1985',
@@ -461,6 +463,7 @@ describe('Prisoner profile service', () => {
       expect(prisonApiClient.getBookings).toHaveBeenCalledTimes(1)
       expect(prisonApiClient.getOffender).toHaveBeenCalledTimes(1)
       expect(prisonApiClient.getVisitBalances).not.toHaveBeenCalled()
+      expect(prisonerContactRegistryApiClient.getPrisonerSocialContacts).toHaveBeenCalledTimes(1)
       expect(results).toEqual({
         displayName: 'James, Fred',
         displayDob: '11 December 1985',

--- a/server/services/prisonerProfileService.ts
+++ b/server/services/prisonerProfileService.ts
@@ -54,16 +54,14 @@ export default class PrisonerProfileService {
     const alerts = inmateDetail.alerts || []
     const activeAlerts: Alert[] = alerts.filter(alert => alert.active)
     const flaggedAlerts: Alert[] = activeAlerts.filter(alert => this.alertCodesToFlag.includes(alert.alertCode))
+
+    const socialContacts = await prisonerContactRegistryApiClient.getPrisonerSocialContacts(offenderNo)
     const upcomingVisits: UpcomingVisitItem[] = await this.getUpcomingVisits(
       offenderNo,
+      socialContacts,
       visitSchedulerApiClient,
-      prisonerContactRegistryApiClient,
     )
-    const pastVisits: PastVisitItem[] = await this.getPastVisits(
-      offenderNo,
-      visitSchedulerApiClient,
-      prisonerContactRegistryApiClient,
-    )
+    const pastVisits: PastVisitItem[] = await this.getPastVisits(offenderNo, socialContacts, visitSchedulerApiClient)
 
     const activeAlertsForDisplay: PrisonerAlertItem[] = activeAlerts.map(alert => {
       return [
@@ -151,15 +149,14 @@ export default class PrisonerProfileService {
 
   private async getUpcomingVisits(
     offenderNo: string,
+    socialContacts: Contact[],
     visitSchedulerApiClient: VisitSchedulerApiClient,
-    prisonerContactRegistryApiClient: PrisonerContactRegistryApiClient,
   ): Promise<UpcomingVisitItem[]> {
     const visits: Visit[] = await visitSchedulerApiClient.getUpcomingVisits(offenderNo)
-    const contacts = await prisonerContactRegistryApiClient.getPrisonerSocialContacts(offenderNo)
     const socialVisits: Visit[] = visits.filter(visit => visit.visitType === 'SOCIAL')
 
     const visitsForDisplay: UpcomingVisitItem[] = socialVisits.map(visit => {
-      const visitContactNames = this.getPrisonerSocialContacts(contacts, visit.visitors)
+      const visitContactNames = this.getPrisonerSocialContacts(socialContacts, visit.visitors)
 
       return [
         {
@@ -196,15 +193,14 @@ export default class PrisonerProfileService {
 
   private async getPastVisits(
     offenderNo: string,
+    socialContacts: Contact[],
     visitSchedulerApiClient: VisitSchedulerApiClient,
-    prisonerContactRegistryApiClient: PrisonerContactRegistryApiClient,
   ): Promise<PastVisitItem[]> {
     const visits: Visit[] = await visitSchedulerApiClient.getPastVisits(offenderNo)
-    const contacts = await prisonerContactRegistryApiClient.getPrisonerSocialContacts(offenderNo)
     const socialVisits: Visit[] = visits.filter(visit => visit.visitType === 'SOCIAL')
 
     const visitsForDisplay: PastVisitItem[] = socialVisits.map(visit => {
-      const visitContactNames = this.getPrisonerSocialContacts(contacts, visit.visitors)
+      const visitContactNames = this.getPrisonerSocialContacts(socialContacts, visit.visitors)
 
       return [
         {


### PR DESCRIPTION
Prisoner profile page was calling contact registry both during getting past visits and upcoming visits. This charge:
* adds test data to cover contact registry and visit data
* refactors to only call the contact registry once for the profile page