### PR TITLE
VB-1070: Add more details of visit to user audit

### DIFF
--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -1334,6 +1334,9 @@ describe('/book-a-visit/select-date-and-time', () => {
             'A1234BC',
             'HEI',
             ['4323'],
+            '2022-02-14T11:59:00',
+            '2022-02-14T12:59:00',
+            'OPEN',
             undefined,
             undefined,
           )
@@ -1378,6 +1381,9 @@ describe('/book-a-visit/select-date-and-time', () => {
             'A1234BC',
             'HEI',
             ['4323'],
+            '2022-02-14T12:00:00',
+            '2022-02-14T13:05:00',
+            'OPEN',
             undefined,
             undefined,
           )
@@ -2286,6 +2292,9 @@ describe('/book-a-visit/check-your-booking', () => {
             visitSessionData.prisoner.offenderNo,
             'HEI',
             [visitSessionData.visitors[0].personId.toString()],
+            '2022-03-12T09:30:00',
+            '2022-03-12T10:30:00',
+            'OPEN',
             undefined,
             undefined,
           )

--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -1329,7 +1329,14 @@ describe('/book-a-visit/select-date-and-time', () => {
           })
           expect(visitSessionsService.createVisit).toHaveBeenCalledTimes(1)
           expect(auditService.reservedVisit).toHaveBeenCalledTimes(1)
-          expect(auditService.reservedVisit).toHaveBeenCalledWith('2a-bc-3d-ef', 'A1234BC', 'HEI', undefined, undefined)
+          expect(auditService.reservedVisit).toHaveBeenCalledWith(
+            '2a-bc-3d-ef',
+            'A1234BC',
+            'HEI',
+            ['4323'],
+            undefined,
+            undefined,
+          )
           expect(visitSessionsService.updateVisit).not.toHaveBeenCalled()
           expect(visitSessionData.visitReference).toEqual('2a-bc-3d-ef')
           expect(visitSessionData.visitStatus).toEqual('RESERVED')
@@ -1366,7 +1373,14 @@ describe('/book-a-visit/select-date-and-time', () => {
           })
           expect(visitSessionsService.createVisit).not.toHaveBeenCalled()
           expect(auditService.reservedVisit).toHaveBeenCalledTimes(1)
-          expect(auditService.reservedVisit).toHaveBeenCalledWith('3b-cd-4f-fg', 'A1234BC', 'HEI', undefined, undefined)
+          expect(auditService.reservedVisit).toHaveBeenCalledWith(
+            '3b-cd-4f-fg',
+            'A1234BC',
+            'HEI',
+            ['4323'],
+            undefined,
+            undefined,
+          )
           expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
           expect(visitSessionsService.updateVisit.mock.calls[0][0].visitData.visitReference).toBe('3b-cd-4f-fg')
         })

--- a/server/routes/visitJourney/checkYourBooking.ts
+++ b/server/routes/visitJourney/checkYourBooking.ts
@@ -53,6 +53,9 @@ export default class CheckYourBooking {
         sessionData.prisoner.offenderNo,
         'HEI',
         sessionData.visitors.map(visitor => visitor.personId.toString()),
+        sessionData.visit.startTimestamp,
+        sessionData.visit.endTimestamp,
+        sessionData.visitRestriction,
         res.locals.user?.username,
         res.locals.appInsightsOperationId,
       )

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -124,6 +124,9 @@ export default class DateAndTime {
       sessionData.prisoner.offenderNo,
       'HEI',
       sessionData.visitors.map(visitor => visitor.personId.toString()),
+      sessionData.visit.startTimestamp,
+      sessionData.visit.endTimestamp,
+      sessionData.visitRestriction,
       res.locals.user?.username,
       res.locals.appInsightsOperationId,
     )

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -123,6 +123,7 @@ export default class DateAndTime {
       sessionData.visitReference,
       sessionData.prisoner.offenderNo,
       'HEI',
+      sessionData.visitors.map(visitor => visitor.personId.toString()),
       res.locals.user?.username,
       res.locals.appInsightsOperationId,
     )

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -68,7 +68,7 @@ describe('Audit service', () => {
   })
 
   it('sends a visit reserved audit message', async () => {
-    await auditService.reservedVisit('ab-cd-ef-gh', 'A1234BC', 'HEI', 'username', 'operation-id')
+    await auditService.reservedVisit('ab-cd-ef-gh', 'A1234BC', 'HEI', ['abc123', 'bcd321'], 'username', 'operation-id')
 
     expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
     expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
@@ -79,7 +79,8 @@ describe('Audit service', () => {
           operationId: 'operation-id',
           who: 'username',
           service: 'book-a-prison-visit-staff-ui',
-          details: '{"visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI"}',
+          details:
+            '{"visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI","visitorIds":["abc123","bcd321"]}',
         }),
         QueueUrl,
       },

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -68,7 +68,17 @@ describe('Audit service', () => {
   })
 
   it('sends a visit reserved audit message', async () => {
-    await auditService.reservedVisit('ab-cd-ef-gh', 'A1234BC', 'HEI', ['abc123', 'bcd321'], 'username', 'operation-id')
+    await auditService.reservedVisit(
+      'ab-cd-ef-gh',
+      'A1234BC',
+      'HEI',
+      ['abc123', 'bcd321'],
+      '2022-08-24T11:00:00',
+      '2022-08-24T12:00:00',
+      'OPEN',
+      'username',
+      'operation-id',
+    )
 
     expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
     expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
@@ -80,7 +90,8 @@ describe('Audit service', () => {
           who: 'username',
           service: 'book-a-prison-visit-staff-ui',
           details:
-            '{"visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI","visitorIds":["abc123","bcd321"]}',
+            '{"visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI","visitorIds":["abc123","bcd321"],' +
+            '"startTimestamp":"2022-08-24T11:00:00","endTimestamp":"2022-08-24T12:00:00","visitRestriction":"OPEN"}',
         }),
         QueueUrl,
       },
@@ -88,7 +99,17 @@ describe('Audit service', () => {
   })
 
   it('sends a visit booked audit message', async () => {
-    await auditService.bookedVisit('ab-cd-ef-gh', 'A1234BC', 'HEI', ['abc123', 'bcd321'], 'username', 'operation-id')
+    await auditService.bookedVisit(
+      'ab-cd-ef-gh',
+      'A1234BC',
+      'HEI',
+      ['abc123', 'bcd321'],
+      '2022-08-24T11:00:00',
+      '2022-08-24T12:00:00',
+      'OPEN',
+      'username',
+      'operation-id',
+    )
 
     expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
     expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
@@ -100,7 +121,8 @@ describe('Audit service', () => {
           who: 'username',
           service: 'book-a-prison-visit-staff-ui',
           details:
-            '{"visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI","visitorIds":["abc123","bcd321"]}',
+            '{"visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI","visitorIds":["abc123","bcd321"],' +
+            '"startTimestamp":"2022-08-24T11:00:00","endTimestamp":"2022-08-24T12:00:00","visitRestriction":"OPEN"}',
         }),
         QueueUrl,
       },

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -50,6 +50,7 @@ export default class AuditService {
     visitReference: string,
     prisonerId: string,
     prisonId: string,
+    visitorIds: string[],
     username: string,
     operationId: string,
   ) {
@@ -61,6 +62,7 @@ export default class AuditService {
         visitReference,
         prisonerId,
         prisonId,
+        visitorIds,
       },
     })
   }

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -51,6 +51,9 @@ export default class AuditService {
     prisonerId: string,
     prisonId: string,
     visitorIds: string[],
+    startTimestamp: string,
+    endTimestamp: string,
+    visitRestriction: Visit['visitRestriction'],
     username: string,
     operationId: string,
   ) {
@@ -63,6 +66,9 @@ export default class AuditService {
         prisonerId,
         prisonId,
         visitorIds,
+        startTimestamp,
+        endTimestamp,
+        visitRestriction,
       },
     })
   }
@@ -72,6 +78,9 @@ export default class AuditService {
     prisonerId: string,
     prisonId: string,
     visitorIds: string[],
+    startTimestamp: string,
+    endTimestamp: string,
+    visitRestriction: Visit['visitRestriction'],
     username: string,
     operationId: string,
   ) {
@@ -84,6 +93,9 @@ export default class AuditService {
         prisonerId,
         prisonId,
         visitorIds,
+        startTimestamp,
+        endTimestamp,
+        visitRestriction,
       },
     })
   }


### PR DESCRIPTION
For the `RESERVED_VISIT` and `BOOKED_VISIT` audit messages, this change adds additional data to these:
* `visitorIds` (array of visitor IDs)
* `startTimestamp` of the visit
* `endTimestamp` of the visit
* `visitRestriction` (i.e. `OPEN` or `CLOSED`
