### PR TITLE
vb-1112, remove startUpdateVisit

### DIFF
--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -137,15 +137,6 @@ class VisitSchedulerApiClient {
     })
   }
 
-  startUpdateVisit(visitReference: string): Promise<Visit> {
-    return this.restclient.put({
-      path: `/visits/${visitReference}`,
-      data: <UpdateVisitRequestDto>{
-        visitStatus: 'RESERVED',
-      },
-    })
-  }
-
   cancelVisit(reference: string, outcome: OutcomeDto): Promise<Visit> {
     return this.restclient.patch({
       path: `/visits/${reference}/cancel`,

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -114,8 +114,6 @@ export default function routes(
 
     req.session.updateVisitSessionData = Object.assign(req.session.updateVisitSessionData ?? {}, visitSessionData)
 
-    // await visitSessionsService.startUpdateVisit({ username: res.locals.user?.username, visitReference: reference })
-
     return res.render('pages/visit/summary', {
       prisoner,
       prisonerLocation,

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -191,16 +191,6 @@ export default class VisitSessionsService {
     return visit
   }
 
-  async startUpdateVisit({ username, visitReference }: { username: string; visitReference: string }): Promise<Visit> {
-    const token = await this.systemToken(username)
-    const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
-
-    const visit = await visitSchedulerApiClient.startUpdateVisit(visitReference)
-    logger.info(`Started update journey for visit ${visit.reference}`)
-
-    return visit
-  }
-
   async cancelVisit({
     username,
     reference,


### PR DESCRIPTION
## Purpose
Remove startUpdateVisit and all of its references

## Reason
The process around update visit has changed, we will no longer be changing the previous booking to reserved as this would mean the entire booking would be lost (to housekeeping) should this visit not be re-booked