### PR TITLE
VB-1112 Reserve new slot on update

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "lint-staged": {
     "*.{ts,js,css}": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --fix --max-warnings 0"
     ],
     "*.json": [
       "prettier --write"

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -194,6 +194,7 @@ export type VisitSessionData = {
     contactName?: string
   }
   visitReference?: string
+  previousVisitReference?: string
   visitStatus?: Visit['visitStatus']
 }
 

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -15,7 +15,6 @@ declare module 'express-session' {
     timeOfDay: string
     dayOfTheWeek: string
     visitSessionData: VisitSessionData
-    updateVisitSessionData: VisitSessionData
   }
 }
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -63,14 +63,13 @@ function appSetup({
     cookie: new Cookie(),
     returnTo: '',
     nowInMinutes: 0,
+    availableSupportTypes: [],
     visitorList: { visitors: [] as VisitorListItem[] },
     adultVisitors: { adults: [] as VisitorListItem[] },
     slotsList: {} as VisitSlotList,
     timeOfDay: '',
     dayOfTheWeek: '',
     visitSessionData: {} as VisitSessionData,
-    updateVisitSessionData: {} as VisitSessionData,
-    availableSupportTypes: [],
   },
 }: {
   prisonerSearchServiceOverride: PrisonerSearchService

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -108,11 +108,12 @@ export default function routes(
         phoneNumber: visit.visitContact.telephone,
         contactName: visit.visitContact.name,
       },
-      visitReference: visit.reference,
       visitStatus: visit.visitStatus,
+      // reference of visit to be updated - as updated visit will get a new reference
+      previousVisitReference: visit.reference,
     }
 
-    req.session.updateVisitSessionData = Object.assign(req.session.updateVisitSessionData ?? {}, visitSessionData)
+    req.session.visitSessionData = Object.assign(req.session.visitSessionData ?? {}, visitSessionData)
 
     return res.render('pages/visit/summary', {
       prisoner,

--- a/server/routes/visitJourney/confirmation.ts
+++ b/server/routes/visitJourney/confirmation.ts
@@ -6,17 +6,17 @@ export default class Confirmation {
 
   async get(req: Request, res: Response): Promise<void> {
     const isUpdate = this.mode === 'update'
-    const sessionData = req.session[isUpdate ? 'updateVisitSessionData' : 'visitSessionData']
+    const { visitSessionData } = req.session
 
-    res.locals.prisoner = sessionData.prisoner
-    res.locals.visit = sessionData.visit
-    res.locals.visitRestriction = sessionData.visitRestriction
-    res.locals.visitors = sessionData.visitors
-    res.locals.mainContact = sessionData.mainContact
-    res.locals.visitReference = sessionData.visitReference
+    res.locals.prisoner = visitSessionData.prisoner
+    res.locals.visit = visitSessionData.visit
+    res.locals.visitRestriction = visitSessionData.visitRestriction
+    res.locals.visitors = visitSessionData.visitors
+    res.locals.mainContact = visitSessionData.mainContact
+    res.locals.visitReference = visitSessionData.visitReference
     res.locals.additionalSupport = getSupportTypeDescriptions(
       req.session.availableSupportTypes,
-      sessionData.visitorSupport,
+      visitSessionData.visitorSupport,
     )
 
     clearSession(req)

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -108,6 +108,7 @@ export default class DateAndTime {
       await this.visitSessionsService.updateVisit({
         username: res.locals.user?.username,
         visitData: sessionData,
+        visitStatus: 'RESERVED',
       })
     } else {
       const { reference, visitStatus } = await this.visitSessionsService.createVisit({

--- a/server/routes/visitJourney/visitType.test.ts
+++ b/server/routes/visitJourney/visitType.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../services/auditService')
 let sessionApp: Express
 const systemToken = async (user: string): Promise<string> => `${user}-token-1`
 let flashData: Record<string, string[] | Record<string, string>[]>
-let updateVisitSessionData: VisitSessionData
+let visitSessionData: VisitSessionData
 
 const auditService = new AuditService() as jest.Mocked<AuditService>
 
@@ -20,7 +20,7 @@ jest.mock('../visitorUtils', () => {
   return {
     ...visitorUtils,
     clearSession: jest.fn((req: Express.Request) => {
-      req.session.updateVisitSessionData = updateVisitSessionData as VisitSessionData
+      req.session.visitSessionData = visitSessionData as VisitSessionData
     }),
   }
 })
@@ -40,7 +40,7 @@ describe.skip('/visit/:reference/update/visit-type', () => {
   const visitReference = 'ab-cd-ef-gh'
 
   beforeEach(() => {
-    updateVisitSessionData = {
+    visitSessionData = {
       prisoner: {
         name: 'prisoner name',
         offenderNo: 'A1234BC',
@@ -77,7 +77,7 @@ describe.skip('/visit/:reference/update/visit-type', () => {
       auditServiceOverride: auditService,
       systemTokenOverride: systemToken,
       sessionData: {
-        updateVisitSessionData,
+        visitSessionData,
       } as SessionData,
     })
   })
@@ -148,13 +148,13 @@ describe.skip('/visit/:reference/update/visit-type', () => {
         .expect(302)
         .expect('location', `/visit/${visitReference}/update/select-date-and-time`)
         .expect(() => {
-          expect(updateVisitSessionData.visitRestriction).toBe('OPEN')
-          expect(updateVisitSessionData.closedVisitReason).toBe(undefined)
+          expect(visitSessionData.visitRestriction).toBe('OPEN')
+          expect(visitSessionData.closedVisitReason).toBe(undefined)
           expect(auditService.visitRestrictionSelected).toHaveBeenCalledTimes(1)
           expect(auditService.visitRestrictionSelected).toHaveBeenCalledWith(
-            updateVisitSessionData.prisoner.offenderNo,
+            visitSessionData.prisoner.offenderNo,
             'OPEN',
-            [updateVisitSessionData.visitors[0].personId.toString()],
+            [visitSessionData.visitors[0].personId.toString()],
             undefined,
             undefined,
           )
@@ -168,13 +168,13 @@ describe.skip('/visit/:reference/update/visit-type', () => {
         .expect(302)
         .expect('location', `/visit/${visitReference}/update/select-date-and-time`)
         .expect(() => {
-          expect(updateVisitSessionData.visitRestriction).toBe('CLOSED')
-          expect(updateVisitSessionData.closedVisitReason).toBe('prisoner')
+          expect(visitSessionData.visitRestriction).toBe('CLOSED')
+          expect(visitSessionData.closedVisitReason).toBe('prisoner')
           expect(auditService.visitRestrictionSelected).toHaveBeenCalledTimes(1)
           expect(auditService.visitRestrictionSelected).toHaveBeenCalledWith(
-            updateVisitSessionData.prisoner.offenderNo,
+            visitSessionData.prisoner.offenderNo,
             'CLOSED',
-            [updateVisitSessionData.visitors[0].personId.toString()],
+            [visitSessionData.visitors[0].personId.toString()],
             undefined,
             undefined,
           )

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -1,6 +1,6 @@
 import { Request } from 'express'
 import { Session, SessionData } from 'express-session'
-import { VisitSessionData, VisitSlotList } from '../@types/bapv'
+import { VisitSlotList } from '../@types/bapv'
 import { clearSession, getFlashFormValues, getSelectedSlot } from './visitorUtils'
 
 const slotsList: VisitSlotList = {
@@ -142,12 +142,11 @@ describe('clearSession', () => {
     timeOfDay: 'morning',
     dayOfTheWeek: '1',
     visitSessionData: { prisoner: undefined },
-    updateVisitSessionData: {} as VisitSessionData,
   }
 
   req.session = sessionData as Session & SessionData
 
-  it('should clear only booking journey related data from the session', () => {
+  it('should clear specified booking data from the session', () => {
     clearSession(req as Request)
 
     expect(req.session).toStrictEqual(<Session & Partial<SessionData>>{

--- a/server/routes/visitorUtils.ts
+++ b/server/routes/visitorUtils.ts
@@ -48,7 +48,6 @@ export const clearSession = (req: Request): void => {
     'timeOfDay',
     'dayOfTheWeek',
     'visitSessionData',
-    'updateVisitSessionData',
   ].forEach(sessionItem => {
     delete req.session[sessionItem]
   })

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -743,6 +743,7 @@ describe('Visit sessions service', () => {
           contactName: 'John Smith',
         },
         visitReference: 'ab-cd-ef-gh',
+        visitStatus: 'RESERVED',
       }
       const visit: Visit = {
         reference: 'ab-cd-ef-gh',
@@ -771,7 +772,11 @@ describe('Visit sessions service', () => {
 
       visitSchedulerApiClient.updateVisit.mockResolvedValue(visit)
       whereaboutsApiClient.getEvents.mockResolvedValue([])
-      const result = await visitSessionsService.updateVisit({ username: 'user', visitData: visitSessionData })
+      const result = await visitSessionsService.updateVisit({
+        username: 'user',
+        visitData: visitSessionData,
+        visitStatus: 'RESERVED',
+      })
 
       expect(visitSchedulerApiClient.updateVisit).toHaveBeenCalledTimes(1)
       expect(result).toEqual(<Visit>{

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -174,11 +174,11 @@ export default class VisitSessionsService {
   async updateVisit({
     username,
     visitData,
-    visitStatus = 'RESERVED',
+    visitStatus,
   }: {
     username: string
     visitData: VisitSessionData
-    visitStatus?: string
+    visitStatus: Visit['visitStatus']
   }): Promise<Visit> {
     const token = await this.systemToken(username)
     const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)

--- a/server/views/pages/bookAVisit/dateAndTime.njk
+++ b/server/views/pages/bookAVisit/dateAndTime.njk
@@ -21,7 +21,7 @@
     {%- set tableText %}
       {% if (doubleBooked and not checked) -%}
         Prisoner has a visit
-      {%- elseif slot.availableTables === 0 -%}
+      {%- elseif slot.availableTables <= 0 -%}
         Fully booked
       {%- else -%}
         {{ slot.availableTables }} table{{ "s" if slot.availableTables > 1 }} available
@@ -34,7 +34,7 @@
         " to " + slot.endTimestamp | formatTime + "</strong><br>" + tableText + "</p>",
       id: slot.id,
       checked: checked,
-      disabled: slot.availableTables === 0 or (doubleBooked and not checked)
+      disabled: slot.availableTables <= 0 or (doubleBooked and not checked)
     }), radios) %}
   {% endfor %}
 {% endmacro %}

--- a/server/views/pages/visit/additionalSupport.njk
+++ b/server/views/pages/visit/additionalSupport.njk
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         {% include "partials/errorSummary.njk" %}
-        <form action="/visit/{{ reference }}/update/additional-support" method="POST" novalidate>
+        <form action="/visit/{{ previousReference }}/update/additional-support" method="POST" novalidate>
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
             {% set otherSupportHtml %}

--- a/server/views/pages/visit/dateAndTime.njk
+++ b/server/views/pages/visit/dateAndTime.njk
@@ -21,7 +21,7 @@
     {%- set tableText %}
       {% if (doubleBooked and not checked) -%}
         Prisoner has a visit
-      {%- elseif slot.availableTables === 0 -%}
+      {%- elseif slot.availableTables <= 0 -%}
         Fully booked
       {%- else -%}
         {{ slot.availableTables }} table{{ "s" if slot.availableTables > 1 }} available
@@ -34,7 +34,7 @@
         " to " + slot.endTimestamp | formatTime + "</strong><br>" + tableText + "</p>",
       id: slot.id,
       checked: checked,
-      disabled: slot.availableTables === 0 or (doubleBooked and not checked)
+      disabled: slot.availableTables <= 0 or (doubleBooked and not checked)
     }), radios) %}
   {% endfor %}
 {% endmacro %}
@@ -79,7 +79,7 @@
       }) }}
     {% endif %}
 
-    <form action="/visit/{{ reference }}/update/select-date-and-time" method="GET" novalidate>
+    <form action="/visit/{{ previousReference }}/update/select-date-and-time" method="GET" novalidate>
       <div class="bapv-visit-date-time-filter">
         <h3 class="govuk-heading-s">Filter time slots</h3>
         <div class="govuk-button-group">
@@ -165,7 +165,7 @@
 
     {% if slotsPresent %}
 
-    <form action="/visit/{{ reference }}/update/select-date-and-time" method="POST" novalidate>
+    <form action="/visit/{{ previousReference }}/update/select-date-and-time" method="POST" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {% for month, days in slotsList %}
       <h2 class="govuk-heading-m" data-test="month">{{ month }}</h2>

--- a/server/views/pages/visit/visitType.njk
+++ b/server/views/pages/visit/visitType.njk
@@ -19,7 +19,7 @@
       {% include "partials/errorSummary.njk" %}
       <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
 
-      <form action="/visit/{{ reference }}/update/visit-type" method="POST" novalidate>
+      <form action="/visit/{{ previousReference }}/update/visit-type" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
 

--- a/server/views/pages/visit/visitors.njk
+++ b/server/views/pages/visit/visitors.njk
@@ -122,7 +122,7 @@
 
       <p>Add up to 3 visitors with a maximum of 2 adults.</p>
 
-      <form action="/visit/{{ reference }}/update/select-visitors" method="POST" novalidate>
+      <form action="/visit/{{ previousReference }}/update/select-visitors" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         <div class="govuk-form-group{% if errors | length %} govuk-form-group--error{% endif %}">


### PR DESCRIPTION
This change ensures that for an update visit journey a new visit is created each time, with the existing visit untouched. (Future work will 'swap' these over by booking the new one and cancelling the previous one.)

Most changes relate to refactoring to simplify by removing separate storing of old/new visit details in session.

To do in subsequent changes for this ticket:
* sort issues with table count showing negative values in some update scenarios
* tests for new visit creation