### PR TITLE
VB-1072: Clear session after visit cancellation

### DIFF
--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -2100,6 +2100,8 @@ describe('GET /visit/cancelled', () => {
         expect($('h1').text().trim()).toBe('Booking cancelled')
         expect($('[data-test="visit-details"]').text().trim()).toBe('10:15am to 11am on Wednesday 9 February 2022')
         expect($('[data-test="go-to-start"]').length).toBe(1)
+
+        expect(clearSession).toHaveBeenCalledTimes(1)
       })
   })
 })

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -47,6 +47,8 @@ export default function routes(
     )
 
   get('/cancelled', async (req, res) => {
+    clearSession(req)
+
     return res.render('pages/visit/cancelConfirmation', {
       startTimestamp: req.flash('startTimestamp')?.[0],
       endTimestamp: req.flash('endTimestamp')?.[0],


### PR DESCRIPTION
Now that viewing booking summary populates session, ensure this is cleared once a visit is cancelled.