### PR TITLE
VB-1113: Cancel previous visit when confirming updated visit

### DIFF
--- a/server/routes/bookAVisit.test.ts
+++ b/server/routes/bookAVisit.test.ts
@@ -2222,6 +2222,7 @@ describe('/book-a-visit/check-your-booking', () => {
           expect($('.test-additional-support').text()).toContain('Portable induction loop for people with hearing aids')
           expect($('.test-main-contact-name').text()).toContain('abc')
           expect($('.test-main-contact-number').text()).toContain('0123 456 7890')
+          expect($('form').prop('action')).toBe('/book-a-visit/check-your-booking')
         })
     })
 
@@ -2244,6 +2245,7 @@ describe('/book-a-visit/check-your-booking', () => {
           expect($('.test-additional-support').text()).toContain('None')
           expect($('.test-main-contact-name').text()).toContain('abc')
           expect($('.test-main-contact-number').text()).toContain('0123 456 7890')
+          expect($('form').prop('action')).toBe('/book-a-visit/check-your-booking')
         })
     })
   })
@@ -2285,6 +2287,7 @@ describe('/book-a-visit/check-your-booking', () => {
         .expect('location', '/book-a-visit/confirmation')
         .expect(() => {
           expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
+          expect(visitSessionsService.cancelVisit).not.toHaveBeenCalled()
           expect(visitSessionData.visitStatus).toBe('BOOKED')
           expect(auditService.bookedVisit).toHaveBeenCalledTimes(1)
           expect(auditService.bookedVisit).toHaveBeenCalledWith(
@@ -2319,6 +2322,7 @@ describe('/book-a-visit/check-your-booking', () => {
         .expect('location', '/book-a-visit/confirmation')
         .expect(() => {
           expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
+          expect(visitSessionsService.cancelVisit).not.toHaveBeenCalled()
           expect(visitSessionData.visitStatus).toBe('BOOKED')
           expect(auditService.bookedVisit).toHaveBeenCalledTimes(1)
           expect(notificationsService.sendBookingSms).toHaveBeenCalledTimes(1)
@@ -2334,6 +2338,7 @@ describe('/book-a-visit/check-your-booking', () => {
         .expect('location', '/book-a-visit/confirmation')
         .expect(() => {
           expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
+          expect(visitSessionsService.cancelVisit).not.toHaveBeenCalled()
           expect(visitSessionData.visitStatus).toBe('BOOKED')
           expect(auditService.bookedVisit).toHaveBeenCalledTimes(1)
           expect(notificationsService.sendBookingSms).not.toHaveBeenCalled()
@@ -2357,8 +2362,10 @@ describe('/book-a-visit/check-your-booking', () => {
           expect($('.test-visit-date').text()).toContain('Saturday 12 March 2022')
           expect($('.test-visit-time').text()).toContain('9:30am to 10:30am')
           expect($('.test-visit-type').text()).toContain('Open')
+          expect($('form').prop('action')).toBe('/book-a-visit/check-your-booking')
 
           expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
+          expect(visitSessionsService.cancelVisit).not.toHaveBeenCalled()
           expect(visitSessionData.visitStatus).toBe('RESERVED')
           expect(auditService.bookedVisit).not.toHaveBeenCalled()
           expect(notificationsService.sendBookingSms).not.toHaveBeenCalled()

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -70,7 +70,6 @@ export default function routes(
   )
 
   get('/check-your-booking', sessionCheckMiddleware({ stage: 5 }), (req, res) => checkYourBooking.get(req, res))
-
   post('/check-your-booking', sessionCheckMiddleware({ stage: 5 }), (req, res) => checkYourBooking.post(req, res))
 
   get('/confirmation', sessionCheckMiddleware({ stage: 6 }), (req, res) => confirmation.get(req, res))

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -7,7 +7,7 @@ import VisitSessionsService from '../services/visitSessionsService'
 import AuditService from '../services/auditService'
 import PrisonerVisitorsService from '../services/prisonerVisitorsService'
 import { appWithAllRoutes, flashProvider } from './testutils/appSetup'
-import { OutcomeDto, Visit } from '../data/visitSchedulerApiTypes'
+import { OutcomeDto, SupportType, Visit } from '../data/visitSchedulerApiTypes'
 import { VisitorListItem, VisitSessionData, VisitSlotList } from '../@types/bapv'
 import { Prisoner } from '../data/prisonerOffenderSearchTypes'
 import config from '../config'
@@ -54,6 +54,29 @@ jest.mock('./visitorUtils', () => {
     }),
   }
 })
+
+const availableSupportTypes: SupportType[] = [
+  {
+    type: 'WHEELCHAIR',
+    description: 'Wheelchair ramp',
+  },
+  {
+    type: 'INDUCTION_LOOP',
+    description: 'Portable induction loop for people with hearing aids',
+  },
+  {
+    type: 'BSL_INTERPRETER',
+    description: 'British Sign Language (BSL) Interpreter',
+  },
+  {
+    type: 'MASK_EXEMPT',
+    description: 'Face covering exemption',
+  },
+  {
+    type: 'OTHER',
+    description: 'Other',
+  },
+]
 
 beforeEach(() => {
   flashData = { errors: [], formValues: [] }
@@ -1830,6 +1853,253 @@ describe('/visit/:reference/update/select-date-and-time', () => {
           ])
           expect(flashProvider).toHaveBeenCalledWith('formValues', { 'visit-date-and-time': '5' })
           expect(auditService.reservedVisit).not.toHaveBeenCalled()
+        })
+    })
+  })
+})
+
+describe('/visit/:reference/update/check-your-booking', () => {
+  beforeEach(() => {
+    visitSessionData = {
+      prisoner: {
+        name: 'prisoner name',
+        offenderNo: 'A1234BC',
+        dateOfBirth: '25 May 1988',
+        location: 'location place',
+      },
+      visitRestriction: 'OPEN',
+      visit: {
+        id: 'visitId',
+        startTimestamp: '2022-03-12T09:30:00',
+        endTimestamp: '2022-03-12T10:30:00',
+        availableTables: 1,
+        visitRoomName: 'room name',
+        visitRestriction: 'OPEN',
+      },
+      visitors: [
+        {
+          personId: 123,
+          name: 'name last',
+          relationshipDescription: 'relate',
+          restrictions: [
+            {
+              restrictionType: 'AVS',
+              restrictionTypeDescription: 'AVS desc',
+              startDate: '123',
+              expiryDate: '456',
+              globalRestriction: false,
+              comment: 'comment',
+            },
+          ],
+          address: '123 Street,<br>Test Town,<br>S1 2QZ',
+          banned: false,
+        },
+      ],
+      visitorSupport: [{ type: 'WHEELCHAIR' }, { type: 'INDUCTION_LOOP' }],
+      mainContact: {
+        phoneNumber: '0123 456 7890',
+        contactName: 'abc',
+      },
+      visitReference: 'ab-cd-ef-gh',
+      previousVisitReference: 'zy-xw-vu-ts',
+      visitStatus: 'RESERVED',
+    }
+
+    sessionApp = appWithAllRoutes({
+      systemTokenOverride: systemToken,
+      sessionData: {
+        availableSupportTypes,
+        visitSessionData,
+      } as SessionData,
+    })
+  })
+
+  describe('GET /visit/{:reference}/update/check-your-booking', () => {
+    it('should render all data from the session', () => {
+      return request(sessionApp)
+        .get(`/visit/${visitSessionData.previousVisitReference}/update/check-your-booking`)
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text().trim()).toBe('Check the visit details before booking')
+          expect($('.test-prisoner-name').text()).toContain('prisoner name')
+          expect($('.test-visit-date').text()).toContain('Saturday 12 March 2022')
+          expect($('.test-visit-time').text()).toContain('9:30am to 10:30am')
+          expect($('.test-visit-type').text()).toContain('Open')
+          expect($('.test-visitor-name1').text()).toContain('name last (relate of the prisoner)')
+          expect($('.test-visitor-address1').text()).toContain('123 Street, Test Town, S1 2QZ')
+          expect($('.test-additional-support').text()).toContain('Wheelchair ramp')
+          expect($('.test-additional-support').text()).toContain('Portable induction loop for people with hearing aids')
+          expect($('.test-main-contact-name').text()).toContain('abc')
+          expect($('.test-main-contact-number').text()).toContain('0123 456 7890')
+          expect($('form').prop('action')).toBe(
+            `/visit/${visitSessionData.previousVisitReference}/update/check-your-booking`,
+          )
+        })
+    })
+
+    it('should render all data from the session with a message for no selected additional support options', () => {
+      visitSessionData.visitorSupport = []
+
+      return request(sessionApp)
+        .get(`/visit/${visitSessionData.previousVisitReference}/update/check-your-booking`)
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text().trim()).toBe('Check the visit details before booking')
+          expect($('.test-prisoner-name').text()).toContain('prisoner name')
+          expect($('.test-visit-date').text()).toContain('Saturday 12 March 2022')
+          expect($('.test-visit-time').text()).toContain('9:30am to 10:30am')
+          expect($('.test-visit-type').text()).toContain('Open')
+          expect($('.test-visitor-name1').text()).toContain('name last (relate of the prisoner)')
+          expect($('.test-visitor-address1').text()).toContain('123 Street, Test Town, S1 2QZ')
+          expect($('.test-additional-support').text()).toContain('None')
+          expect($('.test-main-contact-name').text()).toContain('abc')
+          expect($('.test-main-contact-number').text()).toContain('0123 456 7890')
+          expect($('form').prop('action')).toBe(
+            `/visit/${visitSessionData.previousVisitReference}/update/check-your-booking`,
+          )
+        })
+    })
+  })
+
+  describe('POST /visit/{:reference}/update/check-your-booking', () => {
+    const notificationsService = new NotificationsService(null) as jest.Mocked<NotificationsService>
+
+    beforeEach(() => {
+      const bookedVisit: Partial<Visit> = { reference: visitSessionData.visitReference, visitStatus: 'BOOKED' }
+
+      visitSessionsService.updateVisit = jest.fn().mockResolvedValue(bookedVisit)
+      notificationsService.sendBookingSms = jest.fn().mockResolvedValue({})
+
+      sessionApp = appWithAllRoutes({
+        auditServiceOverride: auditService,
+        notificationsServiceOverride: notificationsService,
+        visitSessionsServiceOverride: visitSessionsService,
+        systemTokenOverride: systemToken,
+        sessionData: {
+          availableSupportTypes,
+          visitSessionData,
+        } as SessionData,
+      })
+    })
+
+    it('should book visit, record audit event, send SMS (notifications enabled) and redirect to confirmation page', () => {
+      config.apis.notifications.enabled = true
+
+      return request(sessionApp)
+        .post(`/visit/${visitSessionData.previousVisitReference}/update/check-your-booking`)
+        .expect(302)
+        .expect('location', `/visit/${visitSessionData.previousVisitReference}/update/confirmation`)
+        .expect(() => {
+          expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
+          expect(visitSessionsService.cancelVisit).toHaveBeenCalledWith({
+            username: undefined,
+            reference: visitSessionData.previousVisitReference,
+            outcome: <OutcomeDto>{
+              outcomeStatus: 'SUPERSEDED_CANCELLATION',
+              text: `Superseded by ${visitSessionData.visitReference}`,
+            },
+          })
+          expect(visitSessionData.visitStatus).toBe('BOOKED')
+          expect(auditService.bookedVisit).toHaveBeenCalledTimes(1)
+          expect(auditService.bookedVisit).toHaveBeenCalledWith(
+            visitSessionData.visitReference,
+            visitSessionData.prisoner.offenderNo,
+            'HEI',
+            [visitSessionData.visitors[0].personId.toString()],
+            '2022-03-12T09:30:00',
+            '2022-03-12T10:30:00',
+            'OPEN',
+            undefined,
+            undefined,
+          )
+          expect(notificationsService.sendBookingSms).toHaveBeenCalledTimes(1)
+          expect(notificationsService.sendBookingSms).toHaveBeenCalledWith({
+            phoneNumber: '01234567890',
+            visit: visitSessionData.visit,
+            prisonName: 'Hewell (HMP)',
+            reference: visitSessionData.visitReference,
+          })
+        })
+    })
+
+    it('should handle SMS sending failure', () => {
+      config.apis.notifications.enabled = true
+
+      notificationsService.sendBookingSms.mockRejectedValue({})
+
+      return request(sessionApp)
+        .post(`/visit/${visitSessionData.previousVisitReference}/update/check-your-booking`)
+        .expect(302)
+        .expect('location', `/visit/${visitSessionData.previousVisitReference}/update/confirmation`)
+        .expect(() => {
+          expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
+          expect(visitSessionsService.cancelVisit).toHaveBeenCalledWith({
+            username: undefined,
+            reference: visitSessionData.previousVisitReference,
+            outcome: <OutcomeDto>{
+              outcomeStatus: 'SUPERSEDED_CANCELLATION',
+              text: `Superseded by ${visitSessionData.visitReference}`,
+            },
+          })
+          expect(visitSessionData.visitStatus).toBe('BOOKED')
+          expect(auditService.bookedVisit).toHaveBeenCalledTimes(1)
+          expect(notificationsService.sendBookingSms).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    it('should NOT send SMS if notifications disabled', () => {
+      config.apis.notifications.enabled = false
+
+      return request(sessionApp)
+        .post(`/visit/${visitSessionData.previousVisitReference}/update/check-your-booking`)
+        .expect(302)
+        .expect('location', `/visit/${visitSessionData.previousVisitReference}/update/confirmation`)
+        .expect(() => {
+          expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
+          expect(visitSessionsService.cancelVisit).toHaveBeenCalledWith({
+            username: undefined,
+            reference: visitSessionData.previousVisitReference,
+            outcome: <OutcomeDto>{
+              outcomeStatus: 'SUPERSEDED_CANCELLATION',
+              text: `Superseded by ${visitSessionData.visitReference}`,
+            },
+          })
+          expect(visitSessionData.visitStatus).toBe('BOOKED')
+          expect(auditService.bookedVisit).toHaveBeenCalledTimes(1)
+          expect(notificationsService.sendBookingSms).not.toHaveBeenCalled()
+        })
+    })
+
+    it('should handle booking failure, display error message and NOT record audit event nor send SMS', () => {
+      config.apis.notifications.enabled = true
+
+      visitSessionsService.updateVisit.mockRejectedValue({})
+
+      return request(sessionApp)
+        .post(`/visit/${visitSessionData.previousVisitReference}/update/check-your-booking`)
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text().trim()).toBe('Check the visit details before booking')
+          expect($('.govuk-error-summary__body').text()).toContain('Failed to make this reservation')
+          expect($('.test-prisoner-name').text()).toContain('prisoner name')
+          expect($('.test-visit-date').text()).toContain('Saturday 12 March 2022')
+          expect($('.test-visit-time').text()).toContain('9:30am to 10:30am')
+          expect($('.test-visit-type').text()).toContain('Open')
+          expect($('form').prop('action')).toBe(
+            `/visit/${visitSessionData.previousVisitReference}/update/check-your-booking`,
+          )
+
+          expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
+          expect(visitSessionsService.cancelVisit).not.toHaveBeenCalled()
+          expect(visitSessionData.visitStatus).toBe('RESERVED')
+          expect(auditService.bookedVisit).not.toHaveBeenCalled()
+          expect(notificationsService.sendBookingSms).not.toHaveBeenCalled()
         })
     })
   })

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -1986,7 +1986,7 @@ describe('/visit/:reference/update/check-your-booking', () => {
       })
     })
 
-    it('should book visit, record audit event, send SMS (notifications enabled) and redirect to confirmation page', () => {
+    it('should book new visit, cancel previous one, record audit events, send SMS (notifications enabled) and redirect to confirmation page', () => {
       config.apis.notifications.enabled = true
 
       return request(sessionApp)
@@ -1995,14 +1995,6 @@ describe('/visit/:reference/update/check-your-booking', () => {
         .expect('location', `/visit/${visitSessionData.previousVisitReference}/update/confirmation`)
         .expect(() => {
           expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
-          expect(visitSessionsService.cancelVisit).toHaveBeenCalledWith({
-            username: undefined,
-            reference: visitSessionData.previousVisitReference,
-            outcome: <OutcomeDto>{
-              outcomeStatus: 'SUPERSEDED_CANCELLATION',
-              text: `Superseded by ${visitSessionData.visitReference}`,
-            },
-          })
           expect(visitSessionData.visitStatus).toBe('BOOKED')
           expect(auditService.bookedVisit).toHaveBeenCalledTimes(1)
           expect(auditService.bookedVisit).toHaveBeenCalledWith(
@@ -2013,6 +2005,22 @@ describe('/visit/:reference/update/check-your-booking', () => {
             '2022-03-12T09:30:00',
             '2022-03-12T10:30:00',
             'OPEN',
+            undefined,
+            undefined,
+          )
+          expect(visitSessionsService.cancelVisit).toHaveBeenCalledWith({
+            username: undefined,
+            reference: visitSessionData.previousVisitReference,
+            outcome: <OutcomeDto>{
+              outcomeStatus: 'SUPERSEDED_CANCELLATION',
+              text: `Superseded by ${visitSessionData.visitReference}`,
+            },
+          })
+          expect(auditService.cancelledVisit).toHaveBeenCalledWith(
+            visitSessionData.previousVisitReference,
+            visitSessionData.prisoner.offenderNo,
+            'HEI',
+            `SUPERSEDED_CANCELLATION: Superseded by ${visitSessionData.visitReference}`,
             undefined,
             undefined,
           )
@@ -2037,16 +2045,10 @@ describe('/visit/:reference/update/check-your-booking', () => {
         .expect('location', `/visit/${visitSessionData.previousVisitReference}/update/confirmation`)
         .expect(() => {
           expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
-          expect(visitSessionsService.cancelVisit).toHaveBeenCalledWith({
-            username: undefined,
-            reference: visitSessionData.previousVisitReference,
-            outcome: <OutcomeDto>{
-              outcomeStatus: 'SUPERSEDED_CANCELLATION',
-              text: `Superseded by ${visitSessionData.visitReference}`,
-            },
-          })
           expect(visitSessionData.visitStatus).toBe('BOOKED')
           expect(auditService.bookedVisit).toHaveBeenCalledTimes(1)
+          expect(visitSessionsService.cancelVisit).toHaveBeenCalledTimes(1)
+          expect(auditService.cancelledVisit).toHaveBeenCalledTimes(1)
           expect(notificationsService.sendBookingSms).toHaveBeenCalledTimes(1)
         })
     })
@@ -2060,16 +2062,10 @@ describe('/visit/:reference/update/check-your-booking', () => {
         .expect('location', `/visit/${visitSessionData.previousVisitReference}/update/confirmation`)
         .expect(() => {
           expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
-          expect(visitSessionsService.cancelVisit).toHaveBeenCalledWith({
-            username: undefined,
-            reference: visitSessionData.previousVisitReference,
-            outcome: <OutcomeDto>{
-              outcomeStatus: 'SUPERSEDED_CANCELLATION',
-              text: `Superseded by ${visitSessionData.visitReference}`,
-            },
-          })
           expect(visitSessionData.visitStatus).toBe('BOOKED')
           expect(auditService.bookedVisit).toHaveBeenCalledTimes(1)
+          expect(visitSessionsService.cancelVisit).toHaveBeenCalledTimes(1)
+          expect(auditService.cancelledVisit).toHaveBeenCalledTimes(1)
           expect(notificationsService.sendBookingSms).not.toHaveBeenCalled()
         })
     })
@@ -2096,9 +2092,10 @@ describe('/visit/:reference/update/check-your-booking', () => {
           )
 
           expect(visitSessionsService.updateVisit).toHaveBeenCalledTimes(1)
-          expect(visitSessionsService.cancelVisit).not.toHaveBeenCalled()
           expect(visitSessionData.visitStatus).toBe('RESERVED')
           expect(auditService.bookedVisit).not.toHaveBeenCalled()
+          expect(visitSessionsService.cancelVisit).not.toHaveBeenCalled()
+          expect(auditService.cancelledVisit).not.toHaveBeenCalled()
           expect(notificationsService.sendBookingSms).not.toHaveBeenCalled()
         })
     })

--- a/server/routes/visitJourney/checkYourBooking.ts
+++ b/server/routes/visitJourney/checkYourBooking.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from 'express'
 import logger from '../../../logger'
 import config from '../../config'
+import { OutcomeDto } from '../../data/visitSchedulerApiTypes'
 import AuditService from '../../services/auditService'
 import NotificationsService from '../../services/notificationsService'
 import VisitSessionsService from '../../services/visitSessionsService'
@@ -67,6 +68,28 @@ export default class CheckYourBooking {
         res.locals.user?.username,
         res.locals.appInsightsOperationId,
       )
+
+      if (isUpdate) {
+        const outcome: OutcomeDto = {
+          outcomeStatus: 'SUPERSEDED_CANCELLATION',
+          text: `Superseded by ${visitSessionData.visitReference}`,
+        }
+
+        await this.visitSessionsService.cancelVisit({
+          username: res.locals.user?.username,
+          reference: visitSessionData.previousVisitReference,
+          outcome,
+        })
+
+        await this.auditService.cancelledVisit(
+          visitSessionData.previousVisitReference,
+          visitSessionData.prisoner.offenderNo,
+          'HEI',
+          `${outcome.outcomeStatus}: ${outcome.text}`,
+          res.locals.user?.username,
+          res.locals.appInsightsOperationId,
+        )
+      }
 
       if (config.apis.notifications.enabled) {
         try {

--- a/server/routes/visitJourney/checkYourBooking.ts
+++ b/server/routes/visitJourney/checkYourBooking.ts
@@ -50,14 +50,14 @@ export default class CheckYourBooking {
     try {
       const bookedVisit = await this.visitSessionsService.updateVisit({
         username: res.locals.user?.username,
-        visitData: req.session.visitSessionData,
+        visitData: visitSessionData,
         visitStatus: 'BOOKED',
       })
 
-      req.session.visitSessionData.visitStatus = bookedVisit.visitStatus
+      visitSessionData.visitStatus = bookedVisit.visitStatus
 
       await this.auditService.bookedVisit(
-        req.session.visitSessionData.visitReference,
+        visitSessionData.visitReference,
         visitSessionData.prisoner.offenderNo,
         'HEI',
         visitSessionData.visitors.map(visitor => visitor.personId.toString()),


### PR DESCRIPTION
Once visit details are checked by user and confirmed:
* new visit is `BOOKED`
* previous visit is cancelled with the status `SUPERSEDED_CANCELLATION` and a text reference to the new visit's reference
* SMS for new, booked visit remains the same
* User audit logs both the booking of the new visit and the cancellation of the previous one