### PR TITLE
vb-1169, incorporated booked endpoint into search by reference

### DIFF
--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -47,7 +47,7 @@ describe('visitSchedulerApiClient', () => {
     })
   })
 
-  describe('getVisit', () => {
+  describe('getBookedVisit', () => {
     it('should return a single matching Visit from the Visit Scheduler API for a valid reference', async () => {
       const reference = 'ab-cd-ef-gh'
       const result: Visit = {
@@ -77,11 +77,11 @@ describe('visitSchedulerApiClient', () => {
       }
 
       fakeVisitSchedulerApi
-        .get(`/visits/${reference}`)
+        .get(`/visits/booked/${reference}`)
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, result)
 
-      const output = await client.getVisit(reference)
+      const output = await client.getBookedVisit(reference)
 
       expect(output).toEqual(result)
     })

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -33,6 +33,10 @@ class VisitSchedulerApiClient {
     return this.restclient.get({ path: `/visits/${reference}` })
   }
 
+  getBookedVisit(reference: string): Promise<Visit> {
+    return this.restclient.get({ path: `/visits/booked/${reference}` })
+  }
+
   getUpcomingVisits(offenderNo: string, startTimestamp?: string): Promise<Visit[]> {
     return this.restclient.get({
       path: '/visits',

--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -38,7 +38,7 @@ let getPrisonersReturnData: {
 }
 
 let getPrisonerReturnData: Prisoner
-let getVisit: VisitInformation
+let getBookedVisit: VisitInformation
 
 beforeEach(() => {
   app = appWithAllRoutes({
@@ -317,7 +317,7 @@ describe('Booking search page', () => {
       }
 
       prisonerSearchService.getPrisonerById.mockResolvedValue(getPrisonerReturnData)
-      visitSessionsService.getVisit.mockImplementation(() => {
+      visitSessionsService.getBookedVisit.mockImplementation(() => {
         throw createError(404, 'Not found')
       })
 
@@ -340,7 +340,7 @@ describe('Booking search page', () => {
         lastName: 'Smith',
         restrictedPatient: false,
       }
-      getVisit = {
+      getBookedVisit = {
         reference: 'as-sd-df-fg',
         prisonNumber: 'A1234BC',
         prisonerName: 'Smith, Ted',
@@ -350,7 +350,7 @@ describe('Booking search page', () => {
       }
 
       prisonerSearchService.getPrisonerById.mockResolvedValue(getPrisonerReturnData)
-      visitSessionsService.getVisit.mockResolvedValue(getVisit)
+      visitSessionsService.getBookedVisit.mockResolvedValue(getBookedVisit)
 
       return request(app)
         .get('/search/visit/results?searchBlock1=ab&searchBlock2=bc&searchBlock3=cd&searchBlock4=de')

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -120,7 +120,7 @@ export default function routes(
 
     if (errors.length === 0) {
       try {
-        visit = await visitSessionsService.getVisit({ reference: search, username: res.locals.user?.username })
+        visit = await visitSessionsService.getBookedVisit({ reference: search, username: res.locals.user?.username })
         const prisonerDetails = await prisonerSearchService.getPrisonerById(
           visit.prisonNumber,
           res.locals.user?.username,

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -216,6 +216,16 @@ export default class VisitSessionsService {
     return this.buildVisitInformation(visit)
   }
 
+  async getBookedVisit({ username, reference }: { username: string; reference: string }): Promise<VisitInformation> {
+    const token = await this.systemToken(username)
+    const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
+
+    logger.info(`Get visit ${reference}`)
+    const visit = await visitSchedulerApiClient.getBookedVisit(reference)
+
+    return this.buildVisitInformation(visit)
+  }
+
   async getUpcomingVisits({
     username,
     offenderNo,


### PR DESCRIPTION
## Description
Added getBookedVisits endpoint, only shows booked visits instead of all visits.
Changed search to now use getBookedVisits endpoint, as being able to search for a visit and then change that visit after it has been cancelled or superseded causes errors.


Linked to VB-1168