### PR TITLE
vb-1172-disable-update-and-cancel-on-unavailable

### DIFF
--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -206,6 +206,7 @@ describe('GET /visit/:reference', () => {
       } as SessionData,
     })
   })
+
   it('should not display button block if visit status is cancelled/superseded', () => {
     visit.visitStatus = 'CANCELLED'
     return request(app)
@@ -217,6 +218,7 @@ describe('GET /visit/:reference', () => {
         expect($('[data-test="cancel-visit"]').attr('href')).toBe(undefined)
       })
   })
+
   it('should display button block if visit status is booked', () => {
     visit.visitStatus = 'BOOKED'
     return request(app)
@@ -228,6 +230,7 @@ describe('GET /visit/:reference', () => {
         expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
       })
   })
+
   it('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
     return request(app)
       .get('/visit/ab-cd-ef-gh')

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -155,6 +155,7 @@ describe('GET /visit/:reference', () => {
     createdTimestamp: '2022-02-14T10:00:00',
     modifiedTimestamp: '2022-02-14T10:05:00',
   }
+
   const visitors: VisitorListItem[] = [
     {
       personId: 4321,
@@ -205,7 +206,28 @@ describe('GET /visit/:reference', () => {
       } as SessionData,
     })
   })
-
+  it('should not display button block if visit status is cancelled/superseded', () => {
+    visit.visitStatus = 'CANCELLED'
+    return request(app)
+      .get('/visit/ab-cd-ef-gh')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-test="cancel-visit"]').attr('href')).toBe(undefined)
+      })
+  })
+  it('should display button block if visit status is booked', () => {
+    visit.visitStatus = 'BOOKED'
+    return request(app)
+      .get('/visit/ab-cd-ef-gh')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
+      })
+  })
   it('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
     return request(app)
       .get('/visit/ab-cd-ef-gh')

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -2120,7 +2120,7 @@ describe('/visit/:reference/update/check-your-booking', () => {
             reference: visitSessionData.previousVisitReference,
             outcome: <OutcomeDto>{
               outcomeStatus: 'SUPERSEDED_CANCELLATION',
-              text: `Superseded by ${visitSessionData.visitReference}`,
+              text: visitSessionData.visitReference,
             },
           })
           expect(auditService.cancelledVisit).toHaveBeenCalledWith(

--- a/server/routes/visitJourney/checkYourBooking.ts
+++ b/server/routes/visitJourney/checkYourBooking.ts
@@ -72,7 +72,7 @@ export default class CheckYourBooking {
       if (isUpdate) {
         const outcome: OutcomeDto = {
           outcomeStatus: 'SUPERSEDED_CANCELLATION',
-          text: `Superseded by ${visitSessionData.visitReference}`,
+          text: visitSessionData.visitReference,
         }
 
         await this.visitSessionsService.cancelVisit({
@@ -85,7 +85,7 @@ export default class CheckYourBooking {
           visitSessionData.previousVisitReference,
           visitSessionData.prisoner.offenderNo,
           'HEI',
-          `${outcome.outcomeStatus}: ${outcome.text}`,
+          `${outcome.outcomeStatus}: Superseded by ${outcome.text}`,
           res.locals.user?.username,
           res.locals.appInsightsOperationId,
         )

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -85,6 +85,7 @@
           }) }}
         </div>
       {% else %}
+      
         {% if visit.outcomeStatus === 'SUPERSEDED_CANCELLATION' %}
           <h2 class="govuk-heading-m">This visit has been {{ visit.visitNotes[0].text}} </h2>
         {% else %}

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -62,27 +62,36 @@
           <span data-test="visit-phone">{{ visit.visitContact.telephone | formatTelephone }}</span>
         </li>
       </ul>
-
-      <div class="govuk-button-group">
-        {% set cancelButtonClasses = 'govuk-!-margin-top-5' %}
-        {% if updateJourneyEnabled %}
-          {% set cancelButtonClasses = 'govuk-!-margin-top-5 govuk-button--secondary' %}
+      
+      {% if visit.visitStatus === "BOOKED" %}
+        <div class="govuk-button-group">
+          {% set cancelButtonClasses = 'govuk-!-margin-top-5' %}
+          {% if updateJourneyEnabled %}
+            {% set cancelButtonClasses = 'govuk-!-margin-top-5 govuk-button--secondary' %}
+            {{ govukButton({
+              text: "Update booking",
+              classes: "govuk-!-margin-top-5",
+              href: "/visit/" + visit.reference + "/update/select-visitors",
+              attributes: { "data-test": "update-visit" },
+              preventDoubleClick: true
+            }) }}
+          {% endif %}
           {{ govukButton({
-            text: "Update booking",
-            classes: "govuk-!-margin-top-5",
-            href: "/visit/" + visit.reference + "/update/select-visitors",
-            attributes: { "data-test": "update-visit" },
+            text: "Cancel booking",
+            classes: cancelButtonClasses,
+            href: "/visit/" + visit.reference + "/cancel",
+            attributes: { "data-test": "cancel-visit" },
             preventDoubleClick: true
           }) }}
+        </div>
+      {% else %}
+        {% if visit.outcomeStatus === 'SUPERSEDED_CANCELLATION' %}
+          <h2 class="govuk-heading-m">This visit has been {{ visit.visitNotes[0].text}} </h2>
+        {% else %}
+          <h2 class="govuk-heading-m">This visit has visit status: {{ visit.visitStatus | capitalize }}</h1>
         {% endif %}
-        {{ govukButton({
-          text: "Cancel booking",
-          classes: cancelButtonClasses,
-          href: "/visit/" + visit.reference + "/cancel",
-          attributes: { "data-test": "cancel-visit" },
-          preventDoubleClick: true
-        }) }}
-      </div>
+
+      {% endif %}
 
       {% set visitorRows = [] %}
       {% for visitor in visitors %}

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "components/visitors.njk" import visitorDateOfBirth, visitorRestrictions %}
 
+
 {% set pageHeaderTitle = "Booking details" %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle + " - " + visit.reference %}
 {% if fromVisitSearch %}
@@ -62,12 +63,13 @@
           <span data-test="visit-phone">{{ visit.visitContact.telephone | formatTelephone }}</span>
         </li>
       </ul>
-      
-      {% if visit.visitStatus === "BOOKED" %}
-        <div class="govuk-button-group">
-          {% set cancelButtonClasses = 'govuk-!-margin-top-5' %}
-          {% if updateJourneyEnabled %}
-            {% set cancelButtonClasses = 'govuk-!-margin-top-5 govuk-button--secondary' %}
+
+      <div class="govuk-button-group">
+        {% set cancelButtonClasses = 'govuk-!-margin-top-5' %}
+        {% if updateJourneyEnabled %}
+          {% set cancelButtonClasses = 'govuk-!-margin-top-5 govuk-button--secondary' %}
+
+          {% if visit.visitStatus === 'BOOKED' %}
             {{ govukButton({
               text: "Update booking",
               classes: "govuk-!-margin-top-5",
@@ -75,7 +77,18 @@
               attributes: { "data-test": "update-visit" },
               preventDoubleClick: true
             }) }}
+          {% else %}
+            {{ govukButton({
+              text: "Update booking",
+              classes: "govuk-!-margin-top-5",
+              attributes: { "data-test": "update-visit" },
+              preventDoubleClick: true,
+              disabled: true
+            }) }}
           {% endif %}
+        {% endif %}
+
+        {% if visit.visitStatus === 'BOOKED' %}
           {{ govukButton({
             text: "Cancel booking",
             classes: cancelButtonClasses,
@@ -83,15 +96,34 @@
             attributes: { "data-test": "cancel-visit" },
             preventDoubleClick: true
           }) }}
-        </div>
-      {% else %}
-      
-        {% if visit.outcomeStatus === 'SUPERSEDED_CANCELLATION' %}
-          <h2 class="govuk-heading-m">This visit has been {{ visit.visitNotes[0].text}} </h2>
         {% else %}
-          <h2 class="govuk-heading-m">This visit has visit status: {{ visit.visitStatus | capitalize }}</h1>
+          {{ govukButton({
+            text: "Cancel booking",
+            classes: cancelButtonClasses,
+            attributes: { "data-test": "cancel-visit" },
+            preventDoubleClick: true,
+            disabled: true
+          }) }}
         {% endif %}
 
+      </div>
+        
+      {% if visit.visitStatus !== "BOOKED" %}
+        {% if visit.outcomeStatus === 'SUPERSEDED_CANCELLATION' %}
+          {%- for visitNote in visit.visitNotes %}
+            {% if visitNote.type == 'VISIT_OUTCOMES' %}
+              <p>This visit has been Superseded by: <a href="../{{visitNote.text}}">{{ visitNote.text }}</a> </p>
+            {% endif %}
+          {% endfor %}     
+        {% else %}
+          {% set status = visit.outcomeStatus.split("_") %}
+            <p>This visit has visit status: {{ status[0] | capitalize }} {{status[1] | lower }}
+          {%- for visitNote in visit.visitNotes %}
+            {% if visitNote.type == "VISIT_OUTCOMES" %}
+              <br>Cancellation reason: {{ visitNote.text }} </p>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
       {% endif %}
 
       {% set visitorRows = [] %}


### PR DESCRIPTION
## Description
Disable the buttons on the visit summary page when a visit has been superseded or cancelled already.
This work may be replaced when a design has been made but this ticket works for MVP.

On Superseded it displays the visit reference number for the new visit also links to the new visit and gives the new visit reference