### PR TITLE
Just use visit ref for SUPERSEDED_CANCELLATION reason text

### DIFF
--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -2120,7 +2120,7 @@ describe('/visit/:reference/update/check-your-booking', () => {
             reference: visitSessionData.previousVisitReference,
             outcome: <OutcomeDto>{
               outcomeStatus: 'SUPERSEDED_CANCELLATION',
-              text: `Superseded by ${visitSessionData.visitReference}`,
+              text: visitSessionData.visitReference,
             },
           })
           expect(auditService.cancelledVisit).toHaveBeenCalledWith(

--- a/server/routes/visitJourney/checkYourBooking.ts
+++ b/server/routes/visitJourney/checkYourBooking.ts
@@ -72,7 +72,7 @@ export default class CheckYourBooking {
       if (isUpdate) {
         const outcome: OutcomeDto = {
           outcomeStatus: 'SUPERSEDED_CANCELLATION',
-          text: `Superseded by ${visitSessionData.visitReference}`,
+          text: visitSessionData.visitReference,
         }
 
         await this.visitSessionsService.cancelVisit({
@@ -85,7 +85,7 @@ export default class CheckYourBooking {
           visitSessionData.previousVisitReference,
           visitSessionData.prisoner.offenderNo,
           'HEI',
-          `${outcome.outcomeStatus}: ${outcome.text}`,
+          `${outcome.outcomeStatus}: Superseded by ${outcome.text}`,
           res.locals.user?.username,
           res.locals.appInsightsOperationId,
         )


### PR DESCRIPTION
Change the recorded outcome status to be simply the visit reference so it can be more easily processed, e.g. to be re-used to form a URL. Message to the user audit log is unchanged. 