### PR TITLE
Add test coverage, include in build artifacts and document

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,8 @@ jobs:
           path: test_results
       - store_artifacts:
           path: test_results/unit-test-reports.html
+      - store_artifacts:
+          path: test_results/jest/coverage
 
   integration_test:
     executor:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ The template project has implemented some scheduled checks to ensure that key de
 If these are not desired in the cloned project, remove references to `check_outdated` job from `.circleci/config.yml`
 
 
+## Test Coverage Reports
+We use jest code coverage to report on test coverage and produce reports for the unit tests.
+
+### Where are the code coverage reports?
+In the [CircleCI builds](https://app.circleci.com/pipelines/github/ministryofjustice/book-a-prison-visit-staff-ui) find a `unit_test` job and click on the `ARTIFACTS` tab.
+
+The unit test coverage report can be found at `test_results/jest/coverage/lcov-report/index.html`.
+
 ## Imported types
 
 Some TypeScript types are imported via the Open API (Swagger) docs, e.g. from the Visit Scheduler, Prisoner Contact Registry, Prison API, etc.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "int-test": "cypress run --config video=false",
     "int-test-single": "cypress run --config video=false --spec ",
     "int-test-ui": "cypress open",
-    "clean": "rm -rf dist build node_modules stylesheets coverage"
+    "clean": "rm -rf dist build node_modules stylesheets"
   },
   "engines": {
     "node": "^16",
@@ -41,9 +41,11 @@
         "isolatedModules": true
       }
     },
+    "collectCoverage": true,
     "collectCoverageFrom": [
       "server/**/*.{ts,js,jsx,mjs}"
     ],
+    "coverageDirectory": "test_results/jest/coverage",
     "testMatch": [
       "<rootDir>/(server|job)/**/?(*.)(cy|test).{ts,js,jsx,mjs}"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,14 @@
     "typeRoots": ["./server/@types", "./node_modules/@types"],
     "lib": ["es5", "es2015.promise"]
   },
-  "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist", "coverage", "cypress.config.ts"],
+  "exclude": [
+    "node_modules",
+    "assets/**/*.js",
+    "integration_tests",
+    "dist",
+    "coverage",
+    "test_results",
+    "cypress.config.ts"
+  ],
   "include": ["**/*.js", "**/*.ts"]
 }


### PR DESCRIPTION
Run test coverage report by default (only seems to add a couple of seconds). Include the reports in build artefacts on CIrcleCI for reference. Document where to find these.