### PR TITLE
VB-1196: Date picker: turn off autocomplete

### DIFF
--- a/server/views/pages/visits/summary.njk
+++ b/server/views/pages/visits/summary.njk
@@ -44,7 +44,24 @@
                 namePrefix: "date-picker",
                 hint: {
                   text: "Enter a date"
-                }
+                },
+                items: [
+                  {
+                    name: "day",
+                    classes: "govuk-input--width-2",
+                    autocomplete: "off"
+                  },
+                  {
+                    name: "month",
+                    classes: "govuk-input--width-2",
+                    autocomplete: "off"
+                  },
+                  {
+                    name: "year",
+                    classes: "govuk-input--width-4",
+                    autocomplete: "off"
+                  }
+                ]
               }) }}
               {{ govukButton({
                 text: "View",


### PR DESCRIPTION
Set `autocomplete` to `off` on the date picker on the 'View visits by date' page.