### PR TITLE
VB-1180: Give accordions unique ID to stop session based selection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.1'
 services:
 
-  redis:
+  redis-bapv:
     image: 'bitnami/redis:5.0'
     networks:
       - hmpps
-    container_name: redis 
+    container_name: redis-bapv
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:
@@ -28,11 +28,11 @@ services:
     build: .
     networks:
       - hmpps
-    depends_on: [redis]
+    depends_on: [redis-bapv]
     ports:
       - "3000:3000"
     environment:
-      - REDIS_HOST=redis
+      - REDIS_HOST=redis-bapv
       - HMPPS_AUTH_EXTERNAL_URL=http://localhost:9090/auth
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
       - NOMIS_AUTH_EXTERNAL_URL=http://localhost:9090/auth

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express'
 import { body, query, ValidationChain, validationResult } from 'express-validator'
+import { v4 as uuidv4 } from 'uuid'
 import { VisitSlot } from '../../@types/bapv'
 import AuditService from '../../services/auditService'
 import VisitSessionsService from '../../services/visitSessionsService'
@@ -73,6 +74,7 @@ export default class DateAndTime {
     req.session.dayOfTheWeek = dayOfTheWeek
 
     res.render('pages/bookAVisit/dateAndTime', {
+      accordionId: uuidv4(),
       errors: req.flash('errors'),
       visitRestriction: visitSessionData.visitRestriction,
       prisonerName: visitSessionData.prisoner.name,

--- a/server/views/pages/bookAVisit/dateAndTime.njk
+++ b/server/views/pages/bookAVisit/dateAndTime.njk
@@ -244,7 +244,7 @@
       {% endfor -%}
 
       {{- govukAccordion({
-        id: "slots-month-" + (month | replace(" ", "")),
+        id: "slots-month-" + (month | replace(" ", "")) + "-" + accordionId,
         headingLevel: 3,
         items: accordion
       }) }}

--- a/server/views/pages/bookAVisit/dateAndTime.test.ts
+++ b/server/views/pages/bookAVisit/dateAndTime.test.ts
@@ -28,6 +28,7 @@ describe('Views - Date and time of visit', () => {
 
   it('should display date and time picker for two months with morning and afternoon slots', () => {
     viewContext = {
+      accordionId: 'thisAccordion',
       prisonerName: 'John Smith',
       visitRestriction: 'OPEN',
       slotsList: <VisitSlotList>{
@@ -143,8 +144,8 @@ describe('Views - Date and time of visit', () => {
     expect($('[data-test="closed-visit-reason"]').length).toBe(0)
 
     expect($('[data-test="month"]').eq(0).text()).toBe('February 2022')
-    expect($('#slots-month-February2022-heading-1').text().trim()).toBe('Monday 14 February')
-    expect($('#slots-month-February2022-content-1 h3').eq(0).text()).toBe('Morning')
+    expect($('#slots-month-February2022-thisAccordion-heading-1').text().trim()).toBe('Monday 14 February')
+    expect($('#slots-month-February2022-thisAccordion-content-1 h3').eq(0).text()).toBe('Morning')
     expect($('label[for="1"]').text()).toContain('10am to 11am')
     expect($('label[for="1"]').text()).toContain('15 tables available')
     expect($('label[for="2"]').text()).toContain('11:59am to 12:59pm')
@@ -152,16 +153,16 @@ describe('Views - Date and time of visit', () => {
     expect($('label[for="3"]').text()).toContain('12pm to 1:05pm')
     expect($('label[for="3"]').text()).toContain('Prisoner has a visit')
     expect($('#3').attr('disabled')).toBe('disabled')
-    expect($('#slots-month-February2022-content-1 .bapv-afternoon-slots > h3').text()).toBe('Afternoon')
-    expect($('#slots-month-February2022-heading-2').text().trim()).toBe('Tuesday 15 February')
+    expect($('#slots-month-February2022-thisAccordion-content-1 .bapv-afternoon-slots > h3').text()).toBe('Afternoon')
+    expect($('#slots-month-February2022-thisAccordion-heading-2').text().trim()).toBe('Tuesday 15 February')
     expect($('#4').prop('checked')).toBe(true)
     expect($('.govuk-accordion__section--expanded').length).toBe(1)
     expect($('.govuk-accordion__section--expanded #4').length).toBe(1)
 
     expect($('[data-test="month"]').eq(1).text()).toBe('March 2022')
-    expect($('#slots-month-March2022-heading-1').text().trim()).toBe('Tuesday 1 March')
-    expect($('#slots-month-March2022-content-1 .bapv-morning-slots > h3').text()).toBe('Morning')
-    expect($('#slots-month-March2022-content-1 .bapv-afternoon-slots > h3').eq(1).length).toBe(0) // no afternoon slots
+    expect($('#slots-month-March2022-thisAccordion-heading-1').text().trim()).toBe('Tuesday 1 March')
+    expect($('#slots-month-March2022-thisAccordion-content-1 .bapv-morning-slots > h3').text()).toBe('Morning')
+    expect($('#slots-month-March2022-thisAccordion-content-1 .bapv-afternoon-slots > h3').eq(1).length).toBe(0) // no afternoon slots
     expect($('label[for="5"]').text()).toContain('9:30am to 10:30am')
     expect($('label[for="5"]').text()).toContain('Fully booked (30 of 30 tables booked)')
     // correctly display overbooking


### PR DESCRIPTION
There is no way to stop the accordion component using sessions to remember what was open and closed, it overrides the values of `expanded` as that is already set correctly but ignored if an option was previously opened.

ID values can be 512Kb long, used uuid to ensure uniqueness.

Bad Paul, but the `docker-compose` having a common name of `redis` is causing no end of issues for me locally with other projects doing the same.