### PR TITLE
Update config for ts-jest v29

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,12 @@
   },
   "jest": {
     "preset": "ts-jest",
-    "globals": {
-      "ts-jest": {
-        "isolatedModules": true
-      }
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest", {
+          "isolatedModules": true
+        }
+      ]
     },
     "collectCoverage": true,
     "collectCoverageFrom": [


### PR DESCRIPTION
Recent update of `ts-jest` from 28 to 29 broke recent speed improvements for tests. Issue seems to be deprecation of way config is specified (https://github.com/kulshekhar/ts-jest/blob/main/CHANGELOG.md#2900-2022-09-08).

This moves config to the new syntax (https://kulshekhar.github.io/ts-jest/docs/getting-started/options).