### PR TITLE
VB-1208: Add support for new change booked visit endpoint

### DIFF
--- a/server/@types/visit-scheduler-api.d.ts
+++ b/server/@types/visit-scheduler-api.d.ts
@@ -108,7 +108,7 @@ export interface components {
        * @example RESERVED
        * @enum {string}
        */
-      visitStatus?: 'RESERVED' | 'BOOKED' | 'CANCELLED'
+      visitStatus?: 'RESERVED' | 'CHANGING' | 'BOOKED' | 'CANCELLED'
       /**
        * @description Visit Restriction
        * @example OPEN
@@ -204,7 +204,7 @@ export interface components {
        * @example RESERVED
        * @enum {string}
        */
-      visitStatus: 'RESERVED' | 'BOOKED' | 'CANCELLED'
+      visitStatus: 'RESERVED' | 'CHANGING' | 'BOOKED' | 'CANCELLED'
       /**
        * @description Outcome Status
        * @example VISITOR_CANCELLED
@@ -355,7 +355,7 @@ export interface components {
        */
       text?: string
     }
-    ChangeReservedVisitSlotRequestDto: {
+    ChangeVisitSlotRequestDto: {
       /**
        * @description Visit Restriction
        * @example OPEN
@@ -386,8 +386,8 @@ export interface components {
       messageAttributes?: {
         [key: string]: components['schemas']['MessageAttributeValue']
       }
-      md5OfBody?: string
       md5OfMessageAttributes?: string
+      md5OfBody?: string
     }
     MessageAttributeValue: {
       stringValue?: string
@@ -649,7 +649,7 @@ export interface components {
        * @example RESERVED
        * @enum {string}
        */
-      visitStatus: 'RESERVED' | 'BOOKED' | 'CANCELLED'
+      visitStatus: 'RESERVED' | 'CHANGING' | 'BOOKED' | 'CANCELLED'
       /**
        * @description Outcome Status
        * @default NOT_RECORDED
@@ -709,11 +709,11 @@ export interface components {
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
-      first?: boolean
-      last?: boolean
       pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      first?: boolean
+      last?: boolean
       empty?: boolean
     }
     PageableObject: {
@@ -721,9 +721,9 @@ export interface components {
       offset?: number
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
-      pageSize?: number
-      /** Format: int32 */
       pageNumber?: number
+      /** Format: int32 */
+      pageSize?: number
       paged?: boolean
       unpaged?: boolean
     }
@@ -1077,7 +1077,7 @@ export interface operations {
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['ChangeReservedVisitSlotRequestDto']
+        'application/json': components['schemas']['ChangeVisitSlotRequestDto']
       }
     }
   }
@@ -1176,7 +1176,7 @@ export interface operations {
         /** Filter results by visitor (contact id) */
         nomisPersonId?: number
         /** Filter results by visit status */
-        visitStatus?: 'RESERVED' | 'BOOKED' | 'CANCELLED'
+        visitStatus?: 'RESERVED' | 'CHANGING' | 'BOOKED' | 'CANCELLED'
         /** Pagination page number, starting at zero */
         page?: number
         /** Pagination size per page */

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -101,7 +101,7 @@ class VisitSchedulerApiClient {
   }
 
   changeReservedVisit(visitSessionData: VisitSessionData): Promise<Visit> {
-    const { visitContact, mainContactId } = convertMainContactToVisitContact(visitSessionData.mainContact)
+    const { visitContact, mainContactId } = this.convertMainContactToVisitContact(visitSessionData.mainContact)
 
     return this.restclient.put({
       path: `/visits/${visitSessionData.applicationReference}/slot/change`,
@@ -126,7 +126,7 @@ class VisitSchedulerApiClient {
   }
 
   changeBookedVisit(visitSessionData: VisitSessionData): Promise<Visit> {
-    const { visitContact, mainContactId } = convertMainContactToVisitContact(visitSessionData.mainContact)
+    const { visitContact, mainContactId } = this.convertMainContactToVisitContact(visitSessionData.mainContact)
 
     return this.restclient.put({
       path: `/visits/${visitSessionData.visitReference}/change`,
@@ -156,21 +156,21 @@ class VisitSchedulerApiClient {
       data: outcome,
     })
   }
-}
 
-function convertMainContactToVisitContact(mainContact: VisitSessionData['mainContact']): {
-  visitContact: ReserveVisitSlotDto['visitContact']
-  mainContactId: number
-} {
-  const visitContact = mainContact
-    ? {
-        telephone: mainContact.phoneNumber,
-        name: mainContact.contactName ? mainContact.contactName : mainContact.contact.name,
-      }
-    : undefined
-  const mainContactId = mainContact && mainContact.contact ? mainContact.contact.personId : null
+  private convertMainContactToVisitContact(mainContact: VisitSessionData['mainContact']): {
+    visitContact: ReserveVisitSlotDto['visitContact']
+    mainContactId: number
+  } {
+    const visitContact = mainContact
+      ? {
+          telephone: mainContact.phoneNumber,
+          name: mainContact.contactName ? mainContact.contactName : mainContact.contact.name,
+        }
+      : undefined
+    const mainContactId = mainContact && mainContact.contact ? mainContact.contact.personId : null
 
-  return { visitContact, mainContactId }
+    return { visitContact, mainContactId }
+  }
 }
 
 export default VisitSchedulerApiClient

--- a/server/data/visitSchedulerApiTypes.ts
+++ b/server/data/visitSchedulerApiTypes.ts
@@ -8,7 +8,7 @@ export type Visit = components['schemas']['VisitDto']
 export type Visitor = components['schemas']['VisitorDto']
 
 export type ReserveVisitSlotDto = components['schemas']['ReserveVisitSlotDto']
-export type ChangeReservedVisitSlotRequestDto = components['schemas']['ChangeReservedVisitSlotRequestDto']
+export type ChangeVisitSlotRequestDto = components['schemas']['ChangeVisitSlotRequestDto']
 
 export type OutcomeDto = components['schemas']['OutcomeDto']
 

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -819,6 +819,92 @@ describe('Visit sessions service', () => {
     })
   })
 
+  describe('changeBookedVisit', () => {
+    it('should change an existing booked visit and return the visit data with status RESERVED/CHANGING and new applicationReference', async () => {
+      const visitSessionData: VisitSessionData = {
+        prisoner: {
+          offenderNo: 'A1234BC',
+          name: 'prisoner name',
+          dateOfBirth: '23 May 1988',
+          location: 'somewhere',
+        },
+        visit: {
+          id: 'visitId',
+          startTimestamp: '2022-02-14T10:00:00',
+          endTimestamp: '2022-02-14T11:00:00',
+          availableTables: 1,
+          capacity: 15,
+          visitRoomName: 'visit room',
+          visitRestriction: 'OPEN',
+        },
+        visitRestriction: 'OPEN',
+        visitors: [
+          {
+            personId: 123,
+            name: 'visitor name',
+            relationshipDescription: 'relationship desc',
+            restrictions: [
+              {
+                restrictionType: 'TEST',
+                restrictionTypeDescription: 'test type',
+                startDate: '10 May 2020',
+                expiryDate: '10 May 2022',
+                globalRestriction: false,
+                comment: 'comments',
+              },
+            ],
+            banned: false,
+          },
+        ],
+        visitorSupport: [{ type: 'WHEELCHAIR' }],
+        mainContact: {
+          phoneNumber: '01234 567890',
+          contactName: 'John Smith',
+        },
+        applicationReference: 'aaa-bbb-ccc',
+        visitReference: 'ab-cd-ef-gh',
+        visitStatus: 'BOOKED',
+      }
+
+      const returnedVisit: Visit = {
+        applicationReference: 'ddd-eee-fff',
+        reference: visitSessionData.visitReference,
+        prisonerId: visitSessionData.prisoner.offenderNo,
+        prisonId: 'HEI',
+        visitRoom: visitSessionData.visit.visitRoomName,
+        visitType: 'SOCIAL',
+        visitStatus: 'CHANGING',
+        visitRestriction: visitSessionData.visitRestriction,
+        startTimestamp: visitSessionData.visit.startTimestamp,
+        endTimestamp: visitSessionData.visit.endTimestamp,
+        visitNotes: [],
+        visitContact: {
+          name: 'John Smith',
+          telephone: '01234 567890',
+        },
+        visitors: [
+          {
+            nomisPersonId: 1234,
+          },
+        ],
+        visitorSupport: [{ type: 'WHEELCHAIR' }],
+        createdTimestamp: '2022-02-14T10:00:00',
+        modifiedTimestamp: '2022-02-14T10:05:00',
+      }
+
+      visitSchedulerApiClient.changeBookedVisit.mockResolvedValue(returnedVisit)
+      whereaboutsApiClient.getEvents.mockResolvedValue([])
+
+      const result = await visitSessionsService.changeBookedVisit({
+        username: 'user',
+        visitSessionData,
+      })
+
+      expect(visitSchedulerApiClient.changeBookedVisit).toHaveBeenCalledTimes(1)
+      expect(result).toEqual(returnedVisit)
+    })
+  })
+
   describe('cancelVisit', () => {
     it('should cancel a visit, giving the status code and reason', async () => {
       const expectedResult: Visit = {

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -204,6 +204,20 @@ export default class VisitSessionsService {
     return visit
   }
 
+  async changeBookedVisit({
+    username,
+    visitSessionData,
+  }: {
+    username: string
+    visitSessionData: VisitSessionData
+  }): Promise<Visit> {
+    const token = await this.systemToken(username)
+    const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
+
+    const visit = await visitSchedulerApiClient.changeBookedVisit(visitSessionData)
+    return visit
+  }
+
   async cancelVisit({
     username,
     reference,


### PR DESCRIPTION
Add support for `PUT /visits/{reference}/change`, which returns a visit with status set to either `RESERVED` (where date/time or restriction different) or `CHANGING` (any other changes) and with a new `applicationReference`.