### PR TITLE
VB-1181: Fix visited link colour on tabs

### DIFF
--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -1,4 +1,4 @@
-.govuk-main-wrapper a:not(.govuk-button):visited {
+.govuk-main-wrapper a:not(.govuk-button, .govuk-tabs__tab):visited {
   color: $govuk-link-colour;
 }
 


### PR DESCRIPTION
Fix issue where links on tabs component (on prisoner profile) were showing the wrong link `:visited` colour.