### PR TITLE
VB-1116: Update visit routes - add session and URL validation

### DIFF
--- a/server/middleware/sessionCheckMiddleware.test.ts
+++ b/server/middleware/sessionCheckMiddleware.test.ts
@@ -45,6 +45,7 @@ describe('sessionCheckMiddleware', () => {
 
   beforeEach(() => {
     req = {
+      params: {},
       session: {
         regenerate: jest.fn(),
         destroy: jest.fn(),
@@ -65,6 +66,34 @@ describe('sessionCheckMiddleware', () => {
     sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
 
     expect(mockResponse.redirect).toHaveBeenCalledWith('/search/prisoner/?error=missing-session')
+  })
+
+  describe('visit reference in URL (e.g. /visit/:reference/update/select-visitors)', () => {
+    it('should redirect to start page if visit reference in URL does not match that in visitSessionData', () => {
+      req.params.reference = 'ab-cd-ef-gh'
+      req.session.visitSessionData = { visitReference: 'bb-cc-dd-ee-ff' } as VisitSessionData
+
+      sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
+
+      expect(mockResponse.redirect).toHaveBeenCalledWith('/?error=reference-mismatch')
+    })
+
+    it('should not redirect if visit reference in URL matches that in visitSessionData', () => {
+      req.params.reference = 'ab-cd-ef-gh'
+      req.session.visitSessionData = {
+        prisoner: {
+          name: 'abc',
+          offenderNo: 'A1234BC',
+          dateOfBirth: '12 May 1977',
+          location: 'abc',
+        },
+        visitReference: 'ab-cd-ef-gh',
+      } as VisitSessionData
+
+      sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
+
+      expect(mockResponse.redirect).not.toHaveBeenCalled()
+    })
   })
 
   describe('prisoner data missing', () => {

--- a/server/middleware/sessionCheckMiddleware.ts
+++ b/server/middleware/sessionCheckMiddleware.ts
@@ -4,9 +4,14 @@ import { isValidPrisonerNumber } from '../routes/validationChecks'
 export default function sessionCheckMiddleware({ stage }: { stage: number }): RequestHandler {
   return (req, res, next) => {
     const { visitSessionData } = req.session
+    const { reference } = req.params
 
     if (!visitSessionData) {
       return res.redirect('/search/prisoner/?error=missing-session')
+    }
+
+    if (reference && visitSessionData.visitReference !== reference) {
+      return res.redirect('/?error=reference-mismatch')
     }
 
     if (

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -24,6 +24,7 @@ import AdditionalSupport from './visitJourney/additionalSupport'
 import CheckYourBooking from './visitJourney/checkYourBooking'
 import Confirmation from './visitJourney/confirmation'
 import MainContact from './visitJourney/mainContact'
+import sessionCheckMiddleware from '../middleware/sessionCheckMiddleware'
 
 export default function routes(
   router: Router,
@@ -142,24 +143,34 @@ export default function routes(
   const checkYourBooking = new CheckYourBooking('update', visitSessionsService, auditService, notificationsService)
   const confirmation = new Confirmation('update')
 
-  get('/:reference/update/select-visitors', updateJourneyCheckMiddleware, checkVisitReferenceMiddleware, (req, res) =>
-    selectVisitors.get(req, res),
+  get(
+    '/:reference/update/select-visitors',
+    updateJourneyCheckMiddleware,
+    checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 1 }),
+    (req, res) => selectVisitors.get(req, res),
   )
   post(
     '/:reference/update/select-visitors',
     updateJourneyCheckMiddleware,
     checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 1 }),
     selectVisitors.validate(),
     (req, res) => selectVisitors.post(req, res),
   )
 
-  get('/:reference/update/visit-type', updateJourneyCheckMiddleware, checkVisitReferenceMiddleware, (req, res) =>
-    visitType.get(req, res),
+  get(
+    '/:reference/update/visit-type',
+    updateJourneyCheckMiddleware,
+    checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 2 }),
+    (req, res) => visitType.get(req, res),
   )
   post(
     '/:reference/update/visit-type',
     updateJourneyCheckMiddleware,
     checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 2 }),
     visitType.validate(),
     (req, res) => visitType.post(req, res),
   )
@@ -168,6 +179,7 @@ export default function routes(
     '/:reference/update/select-date-and-time',
     updateJourneyCheckMiddleware,
     checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 2 }),
     ...dateAndTime.validateGet(),
     (req, res) => dateAndTime.get(req, res),
   )
@@ -175,6 +187,7 @@ export default function routes(
     '/:reference/update/select-date-and-time',
     updateJourneyCheckMiddleware,
     checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 2 }),
     dateAndTime.validate(),
     (req, res) => dateAndTime.post(req, res),
   )
@@ -183,12 +196,14 @@ export default function routes(
     '/:reference/update/additional-support',
     updateJourneyCheckMiddleware,
     checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 3 }),
     (req, res) => additionalSupport.get(req, res),
   )
   post(
     '/:reference/update/additional-support',
     updateJourneyCheckMiddleware,
     checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 3 }),
     ...additionalSupport.validate(),
     (req, res) => additionalSupport.post(req, res),
   )
@@ -197,12 +212,14 @@ export default function routes(
     '/:reference/update/select-main-contact',
     updateJourneyCheckMiddleware,
     checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 4 }),
     (req, res) => mainContact.get(req, res),
   )
   post(
     '/:reference/update/select-main-contact',
     updateJourneyCheckMiddleware,
     checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 4 }),
     ...mainContact.validate(),
     (req, res) => mainContact.post(req, res),
   )
@@ -211,16 +228,24 @@ export default function routes(
     '/:reference/update/check-your-booking',
     updateJourneyCheckMiddleware,
     checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 5 }),
     (req, res) => checkYourBooking.get(req, res),
   )
   post(
     '/:reference/update/check-your-booking',
     updateJourneyCheckMiddleware,
     checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 5 }),
     (req, res) => checkYourBooking.post(req, res),
   )
 
-  get('/:reference/update/confirmation', updateJourneyCheckMiddleware, (req, res) => confirmation.get(req, res))
+  get(
+    '/:reference/update/confirmation',
+    updateJourneyCheckMiddleware,
+    checkVisitReferenceMiddleware,
+    sessionCheckMiddleware({ stage: 6 }),
+    (req, res) => confirmation.get(req, res),
+  )
 
   get('/:reference/cancel', async (req, res) => {
     const reference = getVisitReference(req)

--- a/server/routes/visitJourney/dateAndTime.test.ts
+++ b/server/routes/visitJourney/dateAndTime.test.ts
@@ -146,6 +146,7 @@ beforeEach(() => {
         banned: false,
       },
     ],
+    visitReference: 'ab-cd-ef-gh',
   }
 })
 


### PR DESCRIPTION
This chang:
* adds the existing `sessionCheckMiddleware` to the update visit routes (works without change now that the journey is effectively the same for book and update)
* adds an additional check to ensure that the visit reference in the URL (if present) matches that in the `visitSessionData`