### PR TITLE
VB-1251: Ensure original slot can be re-selected when updating a visit

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -184,8 +184,8 @@ export type VisitSessionData = {
     previousRestrictions?: OffenderRestriction[]
   }
   visit?: VisitSlot
+  originalVisitSlot?: VisitSlot
   visitRestriction?: Visit['visitRestriction']
-  previousVisitRestriction?: Visit['visitRestriction']
   closedVisitReason?: 'prisoner' | 'visitor'
   visitors?: VisitorListItem[]
   visitorSupport?: VisitorSupport[]

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -250,6 +250,14 @@ describe('GET /visit/:reference', () => {
             visitRoomName: 'visit room',
             visitRestriction: 'OPEN',
           },
+          originalVisitSlot: {
+            id: '',
+            startTimestamp: '2022-02-09T10:00:00',
+            endTimestamp: '2022-02-09T11:15:00',
+            availableTables: 0,
+            visitRoomName: 'visit room',
+            visitRestriction: 'OPEN',
+          },
           visitRestriction: 'OPEN',
           visitors: [
             {
@@ -350,6 +358,14 @@ describe('GET /visit/:reference', () => {
             location: '1-1-C-028, Hewell (HMP)',
           },
           visit: {
+            id: '',
+            startTimestamp: '2022-02-09T10:00:00',
+            endTimestamp: '2022-02-09T11:15:00',
+            availableTables: 0,
+            visitRoomName: 'visit room',
+            visitRestriction: 'OPEN',
+          },
+          originalVisitSlot: {
             id: '',
             startTimestamp: '2022-02-09T10:00:00',
             endTimestamp: '2022-02-09T11:15:00',

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -13,7 +13,7 @@ import { clearSession, getFlashFormValues } from './visitorUtils'
 import NotificationsService from '../services/notificationsService'
 import config from '../config'
 import logger from '../../logger'
-import { VisitorListItem, VisitSessionData } from '../@types/bapv'
+import { VisitorListItem, VisitSessionData, VisitSlot } from '../@types/bapv'
 import PrisonerVisitorsService from '../services/prisonerVisitorsService'
 import SelectVisitors from './visitJourney/selectVisitors'
 import PrisonerProfileService from '../services/prisonerProfileService'
@@ -93,6 +93,15 @@ export default function routes(
 
     // clean then load session
     clearSession(req)
+    const visitSlot: VisitSlot = {
+      id: '',
+      startTimestamp: visit.startTimestamp,
+      endTimestamp: visit.endTimestamp,
+      availableTables: 0,
+      capacity: undefined,
+      visitRoomName: visit.visitRoom,
+      visitRestriction: visit.visitRestriction,
+    }
     const visitSessionData: VisitSessionData = {
       prisoner: {
         name: properCaseFullName(`${prisoner.lastName}, ${prisoner.firstName}`),
@@ -100,15 +109,8 @@ export default function routes(
         dateOfBirth: prisoner.dateOfBirth,
         location: prisonerLocation,
       },
-      visit: {
-        id: '',
-        startTimestamp: visit.startTimestamp,
-        endTimestamp: visit.endTimestamp,
-        availableTables: 0,
-        capacity: undefined,
-        visitRoomName: visit.visitRoom,
-        visitRestriction: visit.visitRestriction,
-      },
+      visit: visitSlot,
+      originalVisitSlot: visitSlot,
       visitRestriction: visit.visitRestriction,
       visitors: currentVisitors,
       visitorSupport: visit.visitorSupport,

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -41,7 +41,7 @@ export default class DateAndTime {
         matchingSlot = selectedSlot.id
       }
 
-      if (visitSessionData.visitRestriction !== visitSessionData.previousVisitRestriction) {
+      if (visitSessionData.visitRestriction !== visitSessionData.originalVisitSlot?.visitRestriction) {
         if (!selectedSlot || selectedSlot.availableTables === 0) {
           if (visitSessionData.visitRestriction === 'CLOSED') {
             restrictionChangeMessage = 'A new visit time must be selected as this is now a closed visit.'
@@ -57,6 +57,15 @@ export default class DateAndTime {
           }
         }
       }
+    }
+
+    let originalSelectedSlot
+    if (isUpdate && visitSessionData.originalVisitSlot) {
+      originalSelectedSlot = getSelectedSlotByStartTimestamp(
+        slotsList,
+        visitSessionData.originalVisitSlot.startTimestamp,
+        visitSessionData.originalVisitSlot.visitRestriction,
+      )
     }
 
     const formValues = getFlashFormValues(req)
@@ -85,6 +94,7 @@ export default class DateAndTime {
       formValues,
       slotsPresent,
       restrictionChangeMessage,
+      originalSelectedSlot,
       urlPrefix: getUrlPrefix(isUpdate, visitSessionData.visitReference),
     })
   }

--- a/server/routes/visitJourney/selectVisitors.ts
+++ b/server/routes/visitJourney/selectVisitors.ts
@@ -85,7 +85,6 @@ export default class SelectVisitors {
       return closedVisit || visitor.restrictions.some(restriction => restriction.restrictionType === 'CLOSED')
     }, false)
     const newVisitRestriction = closedVisitVisitors ? 'CLOSED' : 'OPEN'
-    visitSessionData.previousVisitRestriction = visitSessionData.visitRestriction
     visitSessionData.visitRestriction = newVisitRestriction
     visitSessionData.closedVisitReason = closedVisitVisitors ? 'visitor' : undefined
 

--- a/server/views/pages/bookAVisit/dateAndTime.njk
+++ b/server/views/pages/bookAVisit/dateAndTime.njk
@@ -15,10 +15,11 @@
 {% macro buildSlotsRadioItems(slotsList, radios) %}
   {% for slot in slotsList %}
 
-    {%- set doubleBooked = slot.sessionConflicts and "DOUBLE_BOOKED" in slot.sessionConflicts %}
+    {%- set doubleBooked = slot.id != originalSelectedSlot.id and (slot.sessionConflicts and "DOUBLE_BOOKED" in slot.sessionConflicts) %}
     {%- set checked = true if formValues['visit-date-and-time'] and formValues['visit-date-and-time'] == slot.id else false %}
 
     {%- set tableText %}
+      {# {% if (slot.id == originalSelectedSlot.id) -%}ORIGINAL SLOT {% endif %} #}
       {% if (doubleBooked and not checked) -%}
         Prisoner has a visit
       {%- elseif slot.availableTables <= 0 -%}


### PR DESCRIPTION
Previously, during an update if the slot was changed and the user went back (before confirming the updated booking) then they would be unable to re-select the original slot. This change fixes that by keeping track of the original visit slot so the relevant date/time checkbox isn't disabled.

Outstanding issues:
1. needs some more tests - coming next!
2. Awaiting confirmation of text changes to better label original/changed slots

Works without these two caveats though so putting up for review so as not to block other tickets that will be affected by these changes (e.g. VB-1079)