### PR TITLE
Rename visit to visitSlot in visitSessionData

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -183,7 +183,7 @@ export type VisitSessionData = {
     restrictions?: OffenderRestriction[]
     previousRestrictions?: OffenderRestriction[]
   }
-  visit?: VisitSlot
+  visitSlot?: VisitSlot
   originalVisitSlot?: VisitSlot
   visitRestriction?: Visit['visitRestriction']
   closedVisitReason?: 'prisoner' | 'visitor'

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -304,7 +304,7 @@ describe('visitSchedulerApiClient', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
-        visit: {
+        visitSlot: {
           id: '1',
           startTimestamp,
           endTimestamp,
@@ -336,7 +336,7 @@ describe('visitSchedulerApiClient', () => {
         .post('/visits/slot/reserve', <ReserveVisitSlotDto>{
           prisonerId: visitSessionData.prisoner.offenderNo,
           prisonId,
-          visitRoom: visitSessionData.visit.visitRoomName,
+          visitRoom: visitSessionData.visitSlot.visitRoomName,
           visitType,
           visitRestriction,
           startTimestamp,
@@ -403,7 +403,7 @@ describe('visitSchedulerApiClient', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
-        visit: {
+        visitSlot: {
           id: '1',
           startTimestamp: result.startTimestamp,
           endTimestamp: result.endTimestamp,
@@ -448,8 +448,8 @@ describe('visitSchedulerApiClient', () => {
       fakeVisitSchedulerApi
         .put('/visits/aaa-bbb-ccc/slot/change', <ChangeVisitSlotRequestDto>{
           visitRestriction: visitSessionData.visitRestriction,
-          startTimestamp: visitSessionData.visit.startTimestamp,
-          endTimestamp: visitSessionData.visit.endTimestamp,
+          startTimestamp: visitSessionData.visitSlot.startTimestamp,
+          endTimestamp: visitSessionData.visitSlot.endTimestamp,
           visitContact,
           visitors: visitSessionData.visitors.map(visitor => {
             return {
@@ -497,7 +497,7 @@ describe('visitSchedulerApiClient', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
-        visit: {
+        visitSlot: {
           id: '1',
           startTimestamp: result.startTimestamp,
           endTimestamp: result.endTimestamp,
@@ -533,8 +533,8 @@ describe('visitSchedulerApiClient', () => {
       fakeVisitSchedulerApi
         .put('/visits/aaa-bbb-ccc/slot/change', <ChangeVisitSlotRequestDto>{
           visitRestriction: visitSessionData.visitRestriction,
-          startTimestamp: visitSessionData.visit.startTimestamp,
-          endTimestamp: visitSessionData.visit.endTimestamp,
+          startTimestamp: visitSessionData.visitSlot.startTimestamp,
+          endTimestamp: visitSessionData.visitSlot.endTimestamp,
           visitContact: undefined,
           visitors: visitSessionData.visitors.map(visitor => {
             return {
@@ -586,7 +586,7 @@ describe('visitSchedulerApiClient', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
-        visit: {
+        visitSlot: {
           id: '1',
           startTimestamp: '2022-02-14T10:00:00',
           endTimestamp: '2022-02-14T11:00:00',
@@ -621,12 +621,12 @@ describe('visitSchedulerApiClient', () => {
         reference: visitSessionData.visitReference,
         prisonerId: visitSessionData.prisoner.offenderNo,
         prisonId,
-        visitRoom: visitSessionData.visit.visitRoomName,
+        visitRoom: visitSessionData.visitSlot.visitRoomName,
         visitType,
         visitStatus: 'CHANGING',
         visitRestriction: visitSessionData.visitRestriction,
-        startTimestamp: visitSessionData.visit.startTimestamp,
-        endTimestamp: visitSessionData.visit.endTimestamp,
+        startTimestamp: visitSessionData.visitSlot.startTimestamp,
+        endTimestamp: visitSessionData.visitSlot.endTimestamp,
         visitNotes: [],
         visitContact: {
           name: 'John Smith',
@@ -647,11 +647,11 @@ describe('visitSchedulerApiClient', () => {
         .put(`/visits/${visitSessionData.visitReference}/change`, <ReserveVisitSlotDto>{
           prisonerId: visitSessionData.prisoner.offenderNo,
           prisonId,
-          visitRoom: visitSessionData.visit.visitRoomName,
+          visitRoom: visitSessionData.visitSlot.visitRoomName,
           visitType,
           visitRestriction: visitSessionData.visitRestriction,
-          startTimestamp: visitSessionData.visit.startTimestamp,
-          endTimestamp: visitSessionData.visit.endTimestamp,
+          startTimestamp: visitSessionData.visitSlot.startTimestamp,
+          endTimestamp: visitSessionData.visitSlot.endTimestamp,
           visitContact: {
             name: visitSessionData.mainContact.contactName,
             telephone: visitSessionData.mainContact.phoneNumber,

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -86,11 +86,11 @@ class VisitSchedulerApiClient {
       data: <ReserveVisitSlotDto>{
         prisonerId: visitSessionData.prisoner.offenderNo,
         prisonId: this.prisonId,
-        visitRoom: visitSessionData.visit.visitRoomName,
+        visitRoom: visitSessionData.visitSlot.visitRoomName,
         visitType: this.visitType,
         visitRestriction: visitSessionData.visitRestriction,
-        startTimestamp: visitSessionData.visit.startTimestamp,
-        endTimestamp: visitSessionData.visit.endTimestamp,
+        startTimestamp: visitSessionData.visitSlot.startTimestamp,
+        endTimestamp: visitSessionData.visitSlot.endTimestamp,
         visitors: visitSessionData.visitors.map(visitor => {
           return {
             nomisPersonId: visitor.personId,
@@ -107,8 +107,8 @@ class VisitSchedulerApiClient {
       path: `/visits/${visitSessionData.applicationReference}/slot/change`,
       data: <ChangeVisitSlotRequestDto>{
         visitRestriction: visitSessionData.visitRestriction,
-        startTimestamp: visitSessionData.visit.startTimestamp,
-        endTimestamp: visitSessionData.visit.endTimestamp,
+        startTimestamp: visitSessionData.visitSlot.startTimestamp,
+        endTimestamp: visitSessionData.visitSlot.endTimestamp,
         visitContact,
         visitors: visitSessionData.visitors.map(visitor => {
           return {
@@ -133,11 +133,11 @@ class VisitSchedulerApiClient {
       data: <ReserveVisitSlotDto>{
         prisonerId: visitSessionData.prisoner.offenderNo,
         prisonId: this.prisonId,
-        visitRoom: visitSessionData.visit.visitRoomName,
+        visitRoom: visitSessionData.visitSlot.visitRoomName,
         visitType: this.visitType,
         visitRestriction: visitSessionData.visitRestriction,
-        startTimestamp: visitSessionData.visit.startTimestamp,
-        endTimestamp: visitSessionData.visit.endTimestamp,
+        startTimestamp: visitSessionData.visitSlot.startTimestamp,
+        endTimestamp: visitSessionData.visitSlot.endTimestamp,
         visitContact,
         visitors: visitSessionData.visitors.map(visitor => {
           return {

--- a/server/middleware/sessionCheckMiddleware.test.ts
+++ b/server/middleware/sessionCheckMiddleware.test.ts
@@ -27,7 +27,7 @@ const visitorsData: VisitSessionData['visitors'] = [
     banned: false,
   },
 ]
-const visit: VisitSessionData['visit'] = {
+const visitSlot: VisitSessionData['visitSlot'] = {
   id: '1',
   startTimestamp: '123',
   endTimestamp: '123',
@@ -231,7 +231,7 @@ describe('sessionCheckMiddleware', () => {
         visitors: visitorsData,
         visitReference: 'ab-cd-ef-gh',
         visitStatus: 'RESERVED',
-        visit: {
+        visitSlot: {
           id: '1',
           availableTables: 0,
           startTimestamp: '123',
@@ -250,7 +250,7 @@ describe('sessionCheckMiddleware', () => {
       const testData: VisitSessionData = {
         prisoner: prisonerData,
         visitRestriction,
-        visit,
+        visitSlot,
         visitors: visitorsData,
       }
 
@@ -267,7 +267,7 @@ describe('sessionCheckMiddleware', () => {
       {
         prisoner: prisonerData,
         visitRestriction,
-        visit,
+        visitSlot,
         visitors: visitorsData,
         visitReference: 'ab-cd-ef-gh',
         visitStatus: 'RESERVED',
@@ -275,7 +275,7 @@ describe('sessionCheckMiddleware', () => {
       {
         prisoner: prisonerData,
         visitRestriction,
-        visit,
+        visitSlot,
         visitors: visitorsData,
         mainContact: {
           phoneNumber: '',
@@ -299,7 +299,7 @@ describe('sessionCheckMiddleware', () => {
       const testData: VisitSessionData = {
         prisoner: prisonerData,
         visitRestriction,
-        visit,
+        visitSlot,
         visitors: visitorsData,
         mainContact: {
           phoneNumber: '01234567899',

--- a/server/middleware/sessionCheckMiddleware.ts
+++ b/server/middleware/sessionCheckMiddleware.ts
@@ -33,11 +33,11 @@ export default function sessionCheckMiddleware({ stage }: { stage: number }): Re
 
     if (
       stage > 2 &&
-      (!visitSessionData.visit ||
-        !visitSessionData.visit.id ||
-        typeof visitSessionData.visit.availableTables === 'undefined' ||
-        !visitSessionData.visit.startTimestamp ||
-        !visitSessionData.visit.endTimestamp)
+      (!visitSessionData.visitSlot ||
+        !visitSessionData.visitSlot.id ||
+        typeof visitSessionData.visitSlot.availableTables === 'undefined' ||
+        !visitSessionData.visitSlot.startTimestamp ||
+        !visitSessionData.visitSlot.endTimestamp)
     ) {
       return res.redirect(`/prisoner/${visitSessionData.prisoner.offenderNo}?error=missing-visit`)
     }

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -242,7 +242,7 @@ describe('GET /visit/:reference', () => {
             dateOfBirth: '1975-04-02',
             location: '1-1-C-028, Hewell (HMP)',
           },
-          visit: {
+          visitSlot: {
             id: '',
             startTimestamp: '2022-02-09T10:00:00',
             endTimestamp: '2022-02-09T11:15:00',
@@ -357,7 +357,7 @@ describe('GET /visit/:reference', () => {
             dateOfBirth: '1975-04-02',
             location: '1-1-C-028, Hewell (HMP)',
           },
-          visit: {
+          visitSlot: {
             id: '',
             startTimestamp: '2022-02-09T10:00:00',
             endTimestamp: '2022-02-09T11:15:00',
@@ -763,7 +763,7 @@ describe('POST /visit/:reference/cancel', () => {
         expect(notificationsService.sendCancellationSms).toHaveBeenCalledTimes(1)
         expect(notificationsService.sendCancellationSms).toHaveBeenCalledWith({
           phoneNumber: cancelledVisit.visitContact.telephone,
-          visit: cancelledVisit.startTimestamp,
+          visitSlot: cancelledVisit.startTimestamp,
           prisonName: 'Hewell (HMP)',
           prisonPhoneNumber: '01234443225',
         })

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -109,7 +109,7 @@ export default function routes(
         dateOfBirth: prisoner.dateOfBirth,
         location: prisonerLocation,
       },
-      visit: visitSlot,
+      visitSlot,
       originalVisitSlot: visitSlot,
       visitRestriction: visit.visitRestriction,
       visitors: currentVisitors,
@@ -126,7 +126,7 @@ export default function routes(
     req.session.visitSessionData = Object.assign(req.session.visitSessionData ?? {}, visitSessionData)
 
     const nowTimestamp = new Date()
-    const visitStartTimestamp = new Date(visitSessionData.visit.startTimestamp)
+    const visitStartTimestamp = new Date(visitSessionData.visitSlot.startTimestamp)
     const showButtons = nowTimestamp < visitStartTimestamp
 
     return res.render('pages/visit/summary', {
@@ -304,7 +304,7 @@ export default function routes(
 
           await notificationsService.sendCancellationSms({
             phoneNumber,
-            visit: visit.startTimestamp,
+            visitSlot: visit.startTimestamp,
             prisonName: 'Hewell (HMP)',
             prisonPhoneNumber: '01234443225',
           })

--- a/server/routes/visitJourney/additionalSupport.test.ts
+++ b/server/routes/visitJourney/additionalSupport.test.ts
@@ -63,7 +63,7 @@ testJourneys.forEach(journey => {
           location: 'location place',
         },
         visitRestriction: 'OPEN',
-        visit: {
+        visitSlot: {
           id: 'visitId',
           startTimestamp: '123',
           endTimestamp: '456',
@@ -241,7 +241,7 @@ testJourneys.forEach(journey => {
           location: 'location place',
         },
         visitRestriction: 'OPEN',
-        visit: {
+        visitSlot: {
           id: 'visitId',
           startTimestamp: '123',
           endTimestamp: '456',

--- a/server/routes/visitJourney/checkYourBooking.test.ts
+++ b/server/routes/visitJourney/checkYourBooking.test.ts
@@ -72,7 +72,7 @@ testJourneys.forEach(journey => {
           location: 'location place',
         },
         visitRestriction: 'OPEN',
-        visit: {
+        visitSlot: {
           id: 'visitId',
           startTimestamp: '2022-03-12T09:30:00',
           endTimestamp: '2022-03-12T10:30:00',
@@ -249,7 +249,7 @@ testJourneys.forEach(journey => {
             expect(notificationsService[journey.isUpdate ? 'sendUpdateSms' : 'sendBookingSms']).toHaveBeenCalledTimes(1)
             expect(notificationsService[journey.isUpdate ? 'sendUpdateSms' : 'sendBookingSms']).toHaveBeenCalledWith({
               phoneNumber: '01234567890',
-              visit: visitSessionData.visit,
+              visitSlot: visitSessionData.visitSlot,
               prisonName: 'Hewell (HMP)',
               reference: visitSessionData.visitReference,
             })

--- a/server/routes/visitJourney/checkYourBooking.ts
+++ b/server/routes/visitJourney/checkYourBooking.ts
@@ -29,7 +29,7 @@ export default class CheckYourBooking {
       offenderNo,
       mainContact: visitSessionData.mainContact,
       prisoner: visitSessionData.prisoner,
-      visit: visitSessionData.visit,
+      visitSlot: visitSessionData.visitSlot,
       visitRestriction: visitSessionData.visitRestriction,
       visitors: visitSessionData.visitors,
       additionalSupport,
@@ -66,8 +66,8 @@ export default class CheckYourBooking {
         visitReference: visitSessionData.visitReference,
         prisonerId: visitSessionData.prisoner.offenderNo,
         visitorIds: visitSessionData.visitors.map(visitor => visitor.personId.toString()),
-        startTimestamp: visitSessionData.visit.startTimestamp,
-        endTimestamp: visitSessionData.visit.endTimestamp,
+        startTimestamp: visitSessionData.visitSlot.startTimestamp,
+        endTimestamp: visitSessionData.visitSlot.endTimestamp,
         visitRestriction: visitSessionData.visitRestriction,
         username: res.locals.user?.username,
         operationId: res.locals.appInsightsOperationId,
@@ -78,7 +78,7 @@ export default class CheckYourBooking {
           const phoneNumber = visitSessionData.mainContact.phoneNumber.replace(/\s/g, '')
           await this.notificationsService[`send${isUpdate ? 'Update' : 'Booking'}Sms`]({
             phoneNumber,
-            visit: visitSessionData.visit,
+            visitSlot: visitSessionData.visitSlot,
             prisonName: 'Hewell (HMP)',
             reference: visitSessionData.visitReference,
           })
@@ -98,7 +98,7 @@ export default class CheckYourBooking {
         offenderNo,
         mainContact: visitSessionData.mainContact,
         prisoner: visitSessionData.prisoner,
-        visit: visitSessionData.visit,
+        visitSlot: visitSessionData.visitSlot,
         visitRestriction: visitSessionData.visitRestriction,
         visitors: visitSessionData.visitors,
         additionalSupport,

--- a/server/routes/visitJourney/confirmation.test.ts
+++ b/server/routes/visitJourney/confirmation.test.ts
@@ -68,7 +68,7 @@ testJourneys.forEach(journey => {
           location: 'location place',
         },
         visitRestriction: 'OPEN',
-        visit: {
+        visitSlot: {
           id: 'visitId',
           startTimestamp: '2022-03-12T09:30:00',
           endTimestamp: '2022-03-12T10:30:00',
@@ -149,7 +149,7 @@ testJourneys.forEach(journey => {
             location: 'location place',
           },
           visitRestriction: 'OPEN',
-          visit: {
+          visitSlot: {
             id: 'visitId',
             startTimestamp: '2022-03-12T09:30:00',
             endTimestamp: '2022-03-12T10:30:00',

--- a/server/routes/visitJourney/confirmation.ts
+++ b/server/routes/visitJourney/confirmation.ts
@@ -10,7 +10,7 @@ export default class Confirmation {
 
     res.locals.isUpdate = isUpdate
     res.locals.prisoner = visitSessionData.prisoner
-    res.locals.visit = visitSessionData.visit
+    res.locals.visitSlot = visitSessionData.visitSlot
     res.locals.visitRestriction = visitSessionData.visitRestriction
     res.locals.visitors = visitSessionData.visitors
     res.locals.mainContact = visitSessionData.mainContact

--- a/server/routes/visitJourney/dateAndTime.test.ts
+++ b/server/routes/visitJourney/dateAndTime.test.ts
@@ -262,7 +262,7 @@ testJourneys.forEach(journey => {
     })
 
     it('should render the available sessions list with the slot in the session selected', () => {
-      visitSessionData.visit = {
+      visitSessionData.visitSlot = {
         id: '3',
         startTimestamp: '2022-02-14T12:00:00',
         endTimestamp: '2022-02-14T13:05:00',
@@ -353,7 +353,7 @@ testJourneys.forEach(journey => {
         .expect(302)
         .expect('location', `${journey.urlPrefix}/additional-support`)
         .expect(() => {
-          expect(visitSessionData.visit).toEqual(<VisitSlot>{
+          expect(visitSessionData.visitSlot).toEqual(<VisitSlot>{
             id: '2',
             startTimestamp: '2022-02-14T11:59:00',
             endTimestamp: '2022-02-14T12:59:00',
@@ -389,7 +389,7 @@ testJourneys.forEach(journey => {
     })
 
     it('should save new choice to session, update visit reservation and redirect to additional support page if existing session data present', () => {
-      visitSessionData.visit = {
+      visitSessionData.visitSlot = {
         id: '1',
         startTimestamp: '2022-02-14T10:00:00',
         endTimestamp: '2022-02-14T11:00:00',
@@ -409,7 +409,7 @@ testJourneys.forEach(journey => {
         .expect(302)
         .expect('location', `${journey.urlPrefix}/additional-support`)
         .expect(() => {
-          expect(visitSessionData.visit).toEqual(<VisitSlot>{
+          expect(visitSessionData.visitSlot).toEqual(<VisitSlot>{
             id: '3',
             startTimestamp: '2022-02-14T12:00:00',
             endTimestamp: '2022-02-14T13:05:00',

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -30,10 +30,10 @@ export default class DateAndTime {
     let matchingSlot = ''
     let selectedSlot
 
-    if (isUpdate && visitSessionData.visit?.id === '') {
+    if (isUpdate && visitSessionData.visitSlot?.id === '') {
       selectedSlot = getSelectedSlotByStartTimestamp(
         slotsList,
-        visitSessionData.visit.startTimestamp,
+        visitSessionData.visitSlot.startTimestamp,
         visitSessionData.visitRestriction,
       )
 
@@ -80,8 +80,8 @@ export default class DateAndTime {
     }
 
     const formValues = getFlashFormValues(req)
-    if (!Object.keys(formValues).length && visitSessionData.visit?.id) {
-      formValues['visit-date-and-time'] = visitSessionData.visit?.id
+    if (!Object.keys(formValues).length && visitSessionData.visitSlot?.id) {
+      formValues['visit-date-and-time'] = visitSessionData.visitSlot?.id
     }
     if (!Object.keys(formValues).length && matchingSlot) {
       formValues['visit-date-and-time'] = matchingSlot
@@ -126,7 +126,7 @@ export default class DateAndTime {
       return res.redirect(req.originalUrl)
     }
 
-    visitSessionData.visit = getSelectedSlot(req.session.slotsList, req.body['visit-date-and-time'])
+    visitSessionData.visitSlot = getSelectedSlot(req.session.slotsList, req.body['visit-date-and-time'])
 
     // See README ('Visit journeys – book and update') for explanation of this flow
     if (visitSessionData.applicationReference) {
@@ -158,8 +158,8 @@ export default class DateAndTime {
       visitReference: visitSessionData.visitReference,
       prisonerId: visitSessionData.prisoner.offenderNo,
       visitorIds: visitSessionData.visitors.map(visitor => visitor.personId.toString()),
-      startTimestamp: visitSessionData.visit.startTimestamp,
-      endTimestamp: visitSessionData.visit.endTimestamp,
+      startTimestamp: visitSessionData.visitSlot.startTimestamp,
+      endTimestamp: visitSessionData.visitSlot.endTimestamp,
       visitRestriction: visitSessionData.visitRestriction,
       username: res.locals.user?.username,
       operationId: res.locals.appInsightsOperationId,

--- a/server/routes/visitJourney/mainContact.test.ts
+++ b/server/routes/visitJourney/mainContact.test.ts
@@ -70,7 +70,7 @@ testJourneys.forEach(journey => {
           location: 'location place',
         },
         visitRestriction: 'OPEN',
-        visit: {
+        visitSlot: {
           id: 'visitId',
           startTimestamp: '123',
           endTimestamp: '456',

--- a/server/services/notificationsService.test.ts
+++ b/server/services/notificationsService.test.ts
@@ -23,7 +23,7 @@ describe('Notifications service', () => {
     const visitDetails = {
       phoneNumber: '07123456789',
       prisonName: 'Hewell',
-      visit: {
+      visitSlot: {
         id: '1',
         startTimestamp: '2022-02-14T10:00:00',
         endTimestamp: '2022-02-14T11:00:00',
@@ -54,7 +54,7 @@ describe('Notifications service', () => {
       phoneNumber: '07123456789',
       prisonName: 'Hewell',
       prisonPhoneNumber: '01234443225',
-      visit: '2022-02-14T10:00:00',
+      visitSlot: '2022-02-14T10:00:00',
     }
 
     it('should call the notifications client with the cancellation details', async () => {

--- a/server/services/notificationsService.ts
+++ b/server/services/notificationsService.ts
@@ -11,16 +11,16 @@ export default class NotificationsService {
   async sendBookingSms({
     phoneNumber,
     prisonName,
-    visit,
+    visitSlot,
     reference,
   }: {
     phoneNumber: string
     prisonName: string
-    visit: VisitSlot
+    visitSlot: VisitSlot
     reference: string
   }): Promise<SmsResponse> {
     const notificationsApiClient = this.notificationsApiClientBuilder()
-    const parsedDate = new Date(visit.startTimestamp)
+    const parsedDate = new Date(visitSlot.startTimestamp)
     const visitTime = format(parsedDate, 'h:mmaaa')
     const visitDay = format(parsedDate, 'EEEE')
     const visitDate = format(parsedDate, 'd MMMM yyyy')
@@ -38,16 +38,16 @@ export default class NotificationsService {
   async sendCancellationSms({
     phoneNumber,
     prisonName,
-    visit,
+    visitSlot,
     prisonPhoneNumber,
   }: {
     phoneNumber: string
     prisonName: string
-    visit: string
+    visitSlot: string
     prisonPhoneNumber: string
   }): Promise<SmsResponse> {
     const notificationsApiClient = this.notificationsApiClientBuilder()
-    const parsedDate = new Date(visit)
+    const parsedDate = new Date(visitSlot)
     const visitTime = format(parsedDate, 'h:mmaaa')
     const visitDate = format(parsedDate, 'd MMMM yyyy')
 
@@ -63,16 +63,16 @@ export default class NotificationsService {
   async sendUpdateSms({
     phoneNumber,
     prisonName,
-    visit,
+    visitSlot,
     reference,
   }: {
     phoneNumber: string
     prisonName: string
-    visit: VisitSlot
+    visitSlot: VisitSlot
     reference: string
   }): Promise<SmsResponse> {
     const notificationsApiClient = this.notificationsApiClientBuilder()
-    const parsedDate = new Date(visit.startTimestamp)
+    const parsedDate = new Date(visitSlot.startTimestamp)
     const visitTime = format(parsedDate, 'h:mmaaa')
     const visitDay = format(parsedDate, 'EEEE')
     const visitDate = format(parsedDate, 'd MMMM yyyy')

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -654,7 +654,7 @@ describe('Visit sessions service', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
-        visit: {
+        visitSlot: {
           id: '1',
           startTimestamp: '2022-02-14T10:00:00',
           endTimestamp: '2022-02-14T11:00:00',
@@ -688,7 +688,7 @@ describe('Visit sessions service', () => {
         reference: 'ab-cd-ef-gh',
         prisonerId: visitSessionData.prisoner.offenderNo,
         prisonId: 'HEI',
-        visitRoom: visitSessionData.visit.visitRoomName,
+        visitRoom: visitSessionData.visitSlot.visitRoomName,
         visitType: 'SOCIAL',
         visitStatus: 'RESERVED',
         visitRestriction: 'OPEN',
@@ -723,7 +723,7 @@ describe('Visit sessions service', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
-        visit: {
+        visitSlot: {
           id: 'visitId',
           startTimestamp: '2022-02-14T10:00:00',
           endTimestamp: '2022-02-14T11:00:00',
@@ -766,12 +766,12 @@ describe('Visit sessions service', () => {
         reference: visitSessionData.visitReference,
         prisonerId: visitSessionData.prisoner.offenderNo,
         prisonId: 'HEI',
-        visitRoom: visitSessionData.visit.visitRoomName,
+        visitRoom: visitSessionData.visitSlot.visitRoomName,
         visitType: 'SOCIAL',
         visitStatus: visitSessionData.visitStatus,
         visitRestriction: visitSessionData.visitRestriction,
-        startTimestamp: visitSessionData.visit.startTimestamp,
-        endTimestamp: visitSessionData.visit.endTimestamp,
+        startTimestamp: visitSessionData.visitSlot.startTimestamp,
+        endTimestamp: visitSessionData.visitSlot.endTimestamp,
         visitNotes: [],
         visitContact: {
           name: 'John Smith',
@@ -828,7 +828,7 @@ describe('Visit sessions service', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
-        visit: {
+        visitSlot: {
           id: 'visitId',
           startTimestamp: '2022-02-14T10:00:00',
           endTimestamp: '2022-02-14T11:00:00',
@@ -871,12 +871,12 @@ describe('Visit sessions service', () => {
         reference: visitSessionData.visitReference,
         prisonerId: visitSessionData.prisoner.offenderNo,
         prisonId: 'HEI',
-        visitRoom: visitSessionData.visit.visitRoomName,
+        visitRoom: visitSessionData.visitSlot.visitRoomName,
         visitType: 'SOCIAL',
         visitStatus: 'CHANGING',
         visitRestriction: visitSessionData.visitRestriction,
-        startTimestamp: visitSessionData.visit.startTimestamp,
-        endTimestamp: visitSessionData.visit.endTimestamp,
+        startTimestamp: visitSessionData.visitSlot.startTimestamp,
+        endTimestamp: visitSessionData.visitSlot.endTimestamp,
         visitNotes: [],
         visitContact: {
           name: 'John Smith',

--- a/server/views/pages/bookAVisit/checkYourBooking.njk
+++ b/server/views/pages/bookAVisit/checkYourBooking.njk
@@ -44,7 +44,7 @@
                     text: "Date"
                 },
                 value: {
-                    text: visit.startTimestamp | formatDate("EEEE d MMMM yyyy"),
+                    text: visitSlot.startTimestamp | formatDate("EEEE d MMMM yyyy"),
                     classes: "test-visit-date"
                 },
                 actions: {
@@ -63,7 +63,7 @@
                     text: "Time"
                 },
                 value: {
-                    text: visit.startTimestamp | formatTime + " to " + visit.endTimestamp | formatTime,
+                    text: visitSlot.startTimestamp | formatTime + " to " + visitSlot.endTimestamp | formatTime,
                     classes: "test-visit-time"
                 },
                 actions: {

--- a/server/views/pages/bookAVisit/confirmation.njk
+++ b/server/views/pages/bookAVisit/confirmation.njk
@@ -29,7 +29,7 @@
 
         {% if isUpdate %}
             <h2 class="govuk-heading-m govuk-!-margin-top-6">What happens next</h2>
-            <p>The visit booking for {{ visit.startTimestamp | formatTime + " to " + visit.endTimestamp | formatTime }} on {{ visit.startTimestamp | formatDate("EEEE d MMMM yyyy") }} has been updated.</p>
+            <p>The visit booking for {{ visitSlot.startTimestamp | formatTime + " to " + visitSlot.endTimestamp | formatTime }} on {{ visitSlot.startTimestamp | formatDate("EEEE d MMMM yyyy") }} has been updated.</p>
             <p>The main contact for this visit will get a text message to confirm the updated booking. This will include the booking reference.</p>
         {% else %}
             <h2 class="govuk-heading-m govuk-!-margin-top-6">What to do next</h2>
@@ -64,7 +64,7 @@
             text: "Date"
         },
         value: {
-            text: visit.startTimestamp | formatDate("EEEE d MMMM yyyy"),
+            text: visitSlot.startTimestamp | formatDate("EEEE d MMMM yyyy"),
             classes: "test-visit-date"
         }
     },
@@ -73,7 +73,7 @@
             text: "Time"
         },
         value: {
-            text: visit.startTimestamp | formatTime + " to " + visit.endTimestamp | formatTime,
+            text: visitSlot.startTimestamp | formatTime + " to " + visitSlot.endTimestamp | formatTime,
             classes: "test-visit-time"
         }
     },


### PR DESCRIPTION
This change renames `visit` in `visitSessionData` to be `visitSlot` to more accurately represent what it is.
* a 'visitSlot' is a combination of date, time and restriction (open/closed) - e.g. list of these are used when selecting date/time of visit
* a 'visit' represents the VisitDto from the visit scheduler; i.e. a visit with a reference, date/time, visitors, visit status, etc.

Hopefully this change will improve clarity in the code.