### PR TITLE
VB-1268: Trim text input on prisoner search

### DIFF
--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -186,6 +186,20 @@ describe('Prisoner search page', () => {
           })
       })
     })
+
+    describe('POST /search/prisoner', () => {
+      it('should redirect to search results page with search query when no search term entered', () => {
+        return request(app).post('/search/prisoner').expect(302).expect('location', '/search/prisoner/results')
+      })
+
+      it('should redirect to search results page with trimmed query param when search term entered', () => {
+        return request(app)
+          .post('/search/prisoner')
+          .send('search= john smith ')
+          .expect(302)
+          .expect('location', '/search/prisoner/results?search=john%20smith')
+      })
+    })
   })
 
   describe('for visit', () => {
@@ -300,6 +314,23 @@ describe('Prisoner search page', () => {
               expect(prisonerSearchService.getPrisoners).not.toHaveBeenCalled()
             })
         })
+      })
+    })
+
+    describe('POST /search/prisoner-visit', () => {
+      it('should redirect to search results page with search query when no search term entered', () => {
+        return request(app)
+          .post('/search/prisoner-visit')
+          .expect(302)
+          .expect('location', '/search/prisoner-visit/results')
+      })
+
+      it('should redirect to search results page with trimmed query param when search term entered', () => {
+        return request(app)
+          .post('/search/prisoner-visit')
+          .send('search= john smith ')
+          .expect(302)
+          .expect('location', '/search/prisoner-visit/results?search=john%20smith')
       })
     })
   })

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler, Router } from 'express'
 import url from 'url'
+import { body } from 'express-validator'
 import { validatePrisonerSearch, validateVisitSearch } from './searchValidation'
 import PrisonerSearchService from '../services/prisonerSearchService'
 import VisitSessionsService from '../services/visitSessionsService'
@@ -16,7 +17,11 @@ export default function routes(
   auditService: AuditService,
 ): Router {
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
-  const post = (path: string | string[], handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
+  const post = (path: string | string[], ...handlers: RequestHandler[]) =>
+    router.post(
+      path,
+      handlers.map(handler => asyncMiddleware(handler)),
+    )
 
   get(['/prisoner', '/prisoner-visit'], (req, res) => {
     const search = req?.body?.search
@@ -24,7 +29,7 @@ export default function routes(
     res.render('pages/search/prisoner', { search, visit: req.originalUrl.includes('-visit') })
   })
 
-  post(['/prisoner', '/prisoner-visit'], (req, res) => {
+  post(['/prisoner', '/prisoner-visit'], body('search').trim(), (req, res) => {
     const isVisit = req.originalUrl.includes('-visit')
     const { search } = req.body
 


### PR DESCRIPTION
Trim text input when searching for a prisoner.

(While looking in Application Insights, I noticed that users were commonly submitting search queries with trailing spaces so there was lots of unnecessary `%20` type encodings in the logs.)