### PR TITLE
VB 1255, cancelled visit message on summary page

### DIFF
--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -253,3 +253,12 @@
     margin-bottom: govuk-spacing(3);
   }
 }
+
+.moj-banner__message {
+  .app-warning-text--long {
+    margin-bottom: 0;
+    span.govuk-warning-text__icon {
+      margin-top: 5px;
+    }
+  }
+}

--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -253,12 +253,3 @@
     margin-bottom: govuk-spacing(3);
   }
 }
-
-.moj-banner__message {
-  .app-warning-text--long {
-    margin-bottom: 0;
-    // span.govuk-warning-text__icon {
-    //   margin-top: 5px;
-    // }
-  }
-}

--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -257,8 +257,8 @@
 .moj-banner__message {
   .app-warning-text--long {
     margin-bottom: 0;
-    span.govuk-warning-text__icon {
-      margin-top: 5px;
-    }
+    // span.govuk-warning-text__icon {
+    //   margin-top: 5px;
+    // }
   }
 }

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -616,7 +616,9 @@ describe('GET /visit/:reference', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = cheerio.load(res.text)
-        expect($('[data-test="cancelled-visit-reason"]').text()).toContain('because of an administrative error')
+        expect($('[data-test="cancelled-visit-reason"]').text()).toContain(
+          'due to an administrative error with the booking',
+        )
         expect($('[data-test="cancelled-visit-reason"]').text()).toContain('booking error')
       })
   })

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -605,6 +605,36 @@ describe('GET /visit/:reference', () => {
         expect($('[data-test="update-visit"]').length).toBe(0)
       })
   })
+
+  it('should display cancelled message - administrative', () => {
+    visit.visitStatus = 'CANCELLED'
+    visit.outcomeStatus = 'ADMINISTRATIVE_CANCELLATION'
+    visit.visitNotes = [{ type: 'VISIT_OUTCOMES', text: 'booking error' }]
+    return request(app)
+      .get('/visit/ab-cd-ef-gh')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-test="cancelled-visit-reason"]').text()).toContain('because of an administrative error')
+        expect($('[data-test="cancelled-visit-reason"]').text()).toContain('booking error')
+      })
+  })
+
+  it('should display cancelled message - visitor cancelled', () => {
+    visit.visitStatus = 'CANCELLED'
+    visit.outcomeStatus = 'VISITOR_CANCELLED'
+    visit.visitNotes = [{ type: 'VISIT_OUTCOMES', text: 'no longer required' }]
+    return request(app)
+      .get('/visit/ab-cd-ef-gh')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-test="cancelled-visit-reason"]').text()).toContain('by the visitor')
+        expect($('[data-test="cancelled-visit-reason"]').text()).toContain('no longer required')
+      })
+  })
 })
 
 describe('GET /visit/:reference/cancel', () => {

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -29,16 +29,16 @@
 
                 {% set cancelledBy %}
                   {% if status[0] === 'ADMINISTRATIVE' %}
-                    {{ 'because of an administrative error.' }}
+                    {{ 'because of an administrative error' }}
                   {% else %}
-                    {{ 'by the ' + status[0] | lower  + '.' }}
+                    {{ 'by the ' + status[0] | lower }}
                   {% endif %}
                 {% endset %}
 
                 {% set cancelledVisitHtml %}
                   {{ govukWarningText({
-                    classes: "app-warning-text--long govuk-!-padding-left-4",
-                    html: "<span>This visit was cancelled " + cancelledBy +"</span><br><span>Reason: " + visitNote.text + ".</span>",
+                    classes: "govuk-!-margin-bottom-0 govuk-!-padding-left-4",
+                    html: "<span>This visit was cancelled " + cancelledBy +"</span><br><span>Reason: " + visitNote.text + "</span>",
                     iconFallbackText: "Warning",
                     attributes: {
                       "data-test": "cancelled-visit-reason"

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -26,8 +26,7 @@
         {% set status = visit.outcomeStatus.split("_") %}
             {%- for visitNote in visit.visitNotes %}
               {% if visitNote.type == "VISIT_OUTCOMES" %}
-                {# <h1>This visit was cancelled by the {{ status[0] | lower }}.</h1>
-                <h1>Reason: {{ visitNote.text }}.</h1> #}
+
                 {% set cancelledBy %}
                   {% if status[0] === 'ADMINISTRATIVE' %}
                     {{ 'because of an administrative error.' }}
@@ -35,25 +34,26 @@
                     {{ 'by the ' + status[0] | lower  + '.' }}
                   {% endif %}
                 {% endset %}
-              {% set cancelledVisitHtml %}
-                {{ govukWarningText({
-                  classes: "app-warning-text--long govuk-!-padding-left-4",
-                  html: "<span>This visit was cancelled " + cancelledBy +"</span><br><span>Reason: " + visitNote.text + ".</span>",
-                  iconFallbackText: "Warning",
-                  attributes: {
-                    "data-test": "cancelled-visit-reason"
-                  }
-                }) }}
-              {% endset %}
+
+                {% set cancelledVisitHtml %}
+                  {{ govukWarningText({
+                    classes: "app-warning-text--long govuk-!-padding-left-4",
+                    html: "<span>This visit was cancelled " + cancelledBy +"</span><br><span>Reason: " + visitNote.text + ".</span>",
+                    iconFallbackText: "Warning",
+                    attributes: {
+                      "data-test": "cancelled-visit-reason"
+                    }
+                  }) }}
+                {% endset %}
+
                 {{ mojBanner({
                   classes: "govuk-!-padding-left-4",
                   html: cancelledVisitHtml
                 }) }}
+
               {% endif %}
           {% endfor %}
         {% endif %}
-
-      
 
       <h2 class="govuk-heading-m">Prisoner details</h2>
       <ul class="bapv-item-list--horizontal">

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -29,16 +29,16 @@
 
                 {% set cancelledBy %}
                   {% if status[0] === 'ADMINISTRATIVE' %}
-                    {{ 'because of an administrative error' }}
+                    {{ 'This visit was cancelled due to an administrative error with the booking.' }}
                   {% else %}
-                    {{ 'by the ' + status[0] | lower }}
+                    {{ 'This visit was cancelled by the ' + status[0] | lower + '.' }}
                   {% endif %}
                 {% endset %}
 
                 {% set cancelledVisitHtml %}
                   {{ govukWarningText({
                     classes: "govuk-!-margin-bottom-0 govuk-!-padding-left-4",
-                    html: "<span>This visit was cancelled " + cancelledBy +"</span><br><span>Reason: " + visitNote.text + "</span>",
+                    html: "<span>" + cancelledBy + "</span><br><span>Reason: " + visitNote.text + "</span>",
                     iconFallbackText: "Warning",
                     attributes: {
                       "data-test": "cancelled-visit-reason"

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -2,6 +2,8 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "components/visitors.njk" import visitorDateOfBirth, visitorRestrictions %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{%-from "moj/components/banner/macro.njk" import mojBanner %}
 
 
 {% set pageHeaderTitle = "Booking details" %}
@@ -19,6 +21,39 @@
       <p class="bapv-secondary-text govuk-!-margin-bottom-0">Booking reference: <span data-test="reference">{{ visit.reference }}</span></p>
 
       <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
+
+       {% if visit.visitStatus === "CANCELLED" %}
+        {% set status = visit.outcomeStatus.split("_") %}
+            {%- for visitNote in visit.visitNotes %}
+              {% if visitNote.type == "VISIT_OUTCOMES" %}
+                {# <h1>This visit was cancelled by the {{ status[0] | lower }}.</h1>
+                <h1>Reason: {{ visitNote.text }}.</h1> #}
+                {% set cancelledBy %}
+                  {% if status[0] === 'ADMINISTRATIVE' %}
+                    {{ 'because of an administrative error.' }}
+                  {% else %}
+                    {{ 'by the ' + status[0] | lower  + '.' }}
+                  {% endif %}
+                {% endset %}
+              {% set cancelledVisitHtml %}
+                {{ govukWarningText({
+                  classes: "app-warning-text--long govuk-!-padding-left-4",
+                  html: "<span>This visit was cancelled " + cancelledBy +"</span><br><span>Reason: " + visitNote.text + ".</span>",
+                  iconFallbackText: "Warning",
+                  attributes: {
+                    "data-test": "cancelled-visit-reason"
+                  }
+                }) }}
+              {% endset %}
+                {{ mojBanner({
+                  classes: "govuk-!-padding-left-4",
+                  html: cancelledVisitHtml
+                }) }}
+              {% endif %}
+          {% endfor %}
+        {% endif %}
+
+      
 
       <h2 class="govuk-heading-m">Prisoner details</h2>
       <ul class="bapv-item-list--horizontal">
@@ -93,24 +128,6 @@
         {% endif %}
 
       </div>
-        
-      {% if visit.visitStatus !== "BOOKED" %}
-        {% if visit.outcomeStatus === 'SUPERSEDED_CANCELLATION' %}
-          {%- for visitNote in visit.visitNotes %}
-            {% if visitNote.type == 'VISIT_OUTCOMES' %}
-              <p>This booking has been rebooked as <a href="../{{visitNote.text}}">{{ visitNote.text }}</a> </p>
-            {% endif %}
-          {% endfor %}     
-        {% else %}
-          {% set status = visit.outcomeStatus.split("_") %}
-            <p>This booking has been cancelled.
-          {%- for visitNote in visit.visitNotes %}
-            {% if visitNote.type == "VISIT_OUTCOMES" %}
-              <br>{{ status[0] | capitalize }} {{status[1] | lower }}: {{ visitNote.text }}.</p>
-            {% endif %}
-          {% endfor %}
-        {% endif %}
-      {% endif %}
 
       {% set visitorRows = [] %}
       {% for visitor in visitors %}


### PR DESCRIPTION
## Description
Visit cancelled message on visit summary page now uses GDS warning component.

Tests run for visitor cancelled and administrative cancellation as they use different wordings.

Had to include some CSS as the GDS component doesn't natively support multiple lines of text
