### PR TITLE
VB-1276, stop service title disappearing on smaller screensize

### DIFF
--- a/assets/sass/components/_header-bar.scss
+++ b/assets/sass/components/_header-bar.scss
@@ -30,7 +30,6 @@
     }
 
     &__service-name {
-      display: none;
       @include govuk-font(24);
 
       @include govuk-media-query($from: desktop) {


### PR DESCRIPTION
## Description
Removed the display none from the service name CSS file for small screen sizes, meant the home page couldn't be navigated to if the user has a small screen size