### PR TITLE
VB-1193: Fix '/sign-in' getting stuck following a form POST because of CSP

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -1,5 +1,6 @@
 import express, { Router } from 'express'
 import helmet from 'helmet'
+import config from '../config'
 
 export default function setUpWebSecurity(): Router {
   const router = express.Router()
@@ -16,6 +17,7 @@ export default function setUpWebSecurity(): Router {
           scriptSrc: ["'self'", 'code.jquery.com', "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"],
           styleSrc: ["'self'", 'code.jquery.com'],
           fontSrc: ["'self'"],
+          formAction: ["'self'", `${config.apis.hmppsAuth.url}`],
         },
       },
     }),


### PR DESCRIPTION
This change adds the the `HMPPS_AUTH_URL` to the CSP `form-action` directive so it is now, for example:
```
form-action 'self' https://sign-in-dev.hmpps.service.justice.gov.uk/auth;
```

If a user's session has expired, a subsequent `GET` page request would bounce via `/sign-in` and send the user to Auth to get a new session. If the session had expired and a `POST` request from a form was made, that request would end up 'stuck' as the re-authentication flow would be blocked by CSP. This change restores the previous behaviour by additionally allowing just the appropriate Auth domain.

This issue arose when Helmet was upgraded from [version 4 to 5](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#500---2022-01-02) because of this change:
* Breaking: `helmet.contentSecurityPolicy`: `form-action` directive is now set to `'self'` by default