### PR TITLE
Change to CSP to fix for Safari on localhost

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -16,6 +16,7 @@ export default function setUpWebSecurity(): Router {
           scriptSrc: ["'self'", 'code.jquery.com', "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"],
           styleSrc: ["'self'", 'code.jquery.com'],
           fontSrc: ["'self'"],
+          upgradeInsecureRequests: process.env.NODE_ENV === 'development' ? null : [],
         },
       },
     }),


### PR DESCRIPTION
This change removes the `'upgrade-insecure-requests'` directive from the CSP when the application is in `development` mode.

This fixes the application for Safari when running on `localhost`. Other browsers don't try to upgrade insecure requests on `localhost` but Safari does - which means that assets like CSS, etc are blocked.

(This issue arose when Helmet was upgraded from [version 4 to 5](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#500---2022-01-02) and a new default CSP was used that included `upgrade-insecure-requests`.)