### PR TITLE
VB-1223: Add padding to right of beta banner

### DIFF
--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -237,7 +237,7 @@
 
 .bapv-phase-banner {
   border: 0;
-  padding: 0;
+  padding: 0 govuk-spacing(5) 0 0;
 
   @media print {
     display: none;


### PR DESCRIPTION
Stop the beta banner text getting too close to the right-hand edge of the screen on smaller sizes.