### PR TITLE
VB-1079: Fix restriction change messages and slot selection for amend journey

### DIFF
--- a/server/routes/visitJourney/dateAndTime.test.ts
+++ b/server/routes/visitJourney/dateAndTime.test.ts
@@ -124,68 +124,6 @@ testJourneys.forEach(journey => {
             ],
           },
         },
-        {
-          date: 'Tuesday 15 February',
-          prisonerEvents: {
-            morning: [],
-            afternoon: [],
-          },
-          slots: {
-            morning: [],
-            afternoon: [
-              {
-                id: '4',
-                startTimestamp: '2022-02-15T16:00:00',
-                endTimestamp: '2022-02-15T17:00:00',
-                availableTables: 12,
-                capacity: 30,
-                visitRoomName: 'room name',
-                visitRestriction: 'OPEN',
-              },
-              {
-                id: '5',
-                startTimestamp: '2022-02-15T16:00:00',
-                endTimestamp: '2022-02-15T17:00:00',
-                availableTables: 12,
-                capacity: 30,
-                visitRoomName: 'room name',
-                visitRestriction: 'CLOSED',
-              },
-            ],
-          },
-        },
-      ],
-      'March 2022': [
-        {
-          date: 'Tuesday 1 March',
-          prisonerEvents: {
-            morning: [],
-            afternoon: [],
-          },
-          slots: {
-            morning: [
-              {
-                id: '6',
-                startTimestamp: '2022-03-01T09:30:00',
-                endTimestamp: '2022-03-01T10:30:00',
-                availableTables: 0,
-                capacity: 30,
-                visitRoomName: 'room name',
-                visitRestriction: 'OPEN',
-              },
-              {
-                id: '7',
-                startTimestamp: '2022-03-01T09:30:00',
-                endTimestamp: '2022-03-01T10:30:00',
-                availableTables: 0,
-                capacity: 30,
-                visitRoomName: 'room name',
-                visitRestriction: 'CLOSED',
-              },
-            ],
-            afternoon: [],
-          },
-        },
       ],
     }
 
@@ -205,7 +143,7 @@ testJourneys.forEach(journey => {
             expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
             expect($('[data-test="visit-restriction"]').text()).toBe('Open')
             expect($('[data-test="closed-visit-reason"]').length).toBe(0)
-            expect($('input[name="visit-date-and-time"]').length).toBe(7)
+            expect($('input[name="visit-date-and-time"]').length).toBe(3)
             expect($('input[name="visit-date-and-time"]:checked').length).toBe(0)
             expect($('.govuk-accordion__section--expanded').length).toBe(0)
 
@@ -299,7 +237,7 @@ testJourneys.forEach(journey => {
             const $ = cheerio.load(res.text)
             expect($('h1').text().trim()).toBe('Select date and time of visit')
             expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
-            expect($('input[name="visit-date-and-time"]').length).toBe(7)
+            expect($('input[name="visit-date-and-time"]').length).toBe(3)
             expect($('.govuk-accordion__section--expanded').length).toBe(1)
             expect($('.govuk-accordion__section--expanded #3').length).toBe(1)
             expect($('input#3').prop('checked')).toBe(true)

--- a/server/routes/visitJourney/dateAndTime.test.ts
+++ b/server/routes/visitJourney/dateAndTime.test.ts
@@ -34,117 +34,6 @@ const testJourneys = [
 
 config.features.updateJourneyEnabled = true
 
-const slotsList: VisitSlotList = {
-  'February 2022': [
-    {
-      date: 'Monday 14 February',
-      prisonerEvents: {
-        morning: [],
-        afternoon: [],
-      },
-      slots: {
-        morning: [
-          {
-            id: '1',
-            startTimestamp: '2022-02-14T10:00:00',
-            endTimestamp: '2022-02-14T11:00:00',
-            availableTables: 15,
-            capacity: 30,
-            visitRoomName: 'room name',
-            // representing a pre-existing visit that is BOOKED
-            sessionConflicts: ['DOUBLE_BOOKED'],
-            visitRestriction: 'OPEN',
-          },
-          {
-            id: '2',
-            startTimestamp: '2022-02-14T11:59:00',
-            endTimestamp: '2022-02-14T12:59:00',
-            availableTables: 1,
-            capacity: 30,
-            visitRoomName: 'room name',
-            visitRestriction: 'OPEN',
-          },
-        ],
-        afternoon: [
-          {
-            id: '3',
-            startTimestamp: '2022-02-14T12:00:00',
-            endTimestamp: '2022-02-14T13:05:00',
-            availableTables: 5,
-            capacity: 30,
-            visitRoomName: 'room name',
-            // representing the RESERVED visit being handled in this session
-            sessionConflicts: ['DOUBLE_BOOKED'],
-            visitRestriction: 'OPEN',
-          },
-        ],
-      },
-    },
-    {
-      date: 'Tuesday 15 February',
-      prisonerEvents: {
-        morning: [],
-        afternoon: [],
-      },
-      slots: {
-        morning: [],
-        afternoon: [
-          {
-            id: '4',
-            startTimestamp: '2022-02-15T16:00:00',
-            endTimestamp: '2022-02-15T17:00:00',
-            availableTables: 12,
-            capacity: 30,
-            visitRoomName: 'room name',
-            visitRestriction: 'OPEN',
-          },
-          {
-            id: '5',
-            startTimestamp: '2022-02-15T16:00:00',
-            endTimestamp: '2022-02-15T17:00:00',
-            availableTables: 12,
-            capacity: 30,
-            visitRoomName: 'room name',
-            visitRestriction: 'CLOSED',
-          },
-        ],
-      },
-    },
-  ],
-  'March 2022': [
-    {
-      date: 'Tuesday 1 March',
-      prisonerEvents: {
-        morning: [],
-        afternoon: [],
-      },
-      slots: {
-        morning: [
-          {
-            id: '6',
-            startTimestamp: '2022-03-01T09:30:00',
-            endTimestamp: '2022-03-01T10:30:00',
-            availableTables: 0,
-            capacity: 30,
-            visitRoomName: 'room name',
-            visitRestriction: 'OPEN',
-          },
-          {
-            id: '7',
-            startTimestamp: '2022-03-01T09:30:00',
-            endTimestamp: '2022-03-01T10:30:00',
-            availableTables: 0,
-            capacity: 30,
-            visitRoomName: 'room name',
-            visitRestriction: 'CLOSED',
-          },
-        ],
-        afternoon: [],
-      },
-    },
-  ],
-}
-
 beforeEach(() => {
   flashData = { errors: [], formValues: [] }
   flashProvider.mockImplementation(key => {
@@ -174,8 +63,6 @@ beforeEach(() => {
     visitReference: 'ab-cd-ef-gh',
   }
 
-  visitSessionsService.getVisitSessions.mockResolvedValue(slotsList)
-
   sessionApp = appWithAllRoutes({
     visitSessionsServiceOverride: visitSessionsService,
     systemTokenOverride: systemToken,
@@ -190,319 +77,493 @@ afterEach(() => {
 })
 
 testJourneys.forEach(journey => {
-  describe(`GET ${journey.urlPrefix}/select-date-and-time`, () => {
-    it('should render the available sessions list with none selected', () => {
-      return request(sessionApp)
-        .get(`${journey.urlPrefix}/select-date-and-time`)
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('h1').text().trim()).toBe('Select date and time of visit')
-          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
-          expect($('[data-test="visit-restriction"]').text()).toBe('Open')
-          expect($('[data-test="closed-visit-reason"]').length).toBe(0)
-          expect($('input[name="visit-date-and-time"]').length).toBe(7)
-          expect($('input[name="visit-date-and-time"]:checked').length).toBe(0)
-          expect($('.govuk-accordion__section--expanded').length).toBe(0)
-
-          expect($('label[for="1"]').text()).toContain('Prisoner has a visit')
-          expect($('#1').attr('disabled')).toBe('disabled')
-
-          expect($('[data-test="submit"]').text().trim()).toBe('Continue')
-        })
-    })
-
-    it('should render the available sessions list with closed visit reason (visitor)', () => {
-      visitSessionData.visitRestriction = 'CLOSED'
-      visitSessionData.closedVisitReason = 'visitor'
-
-      return request(sessionApp)
-        .get(`${journey.urlPrefix}/select-date-and-time`)
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('h1').text().trim()).toBe('Select date and time of visit')
-          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
-          expect($('[data-test="visit-restriction"]').text()).toBe('Closed')
-          expect($('[data-test="closed-visit-reason"]').text()).toContain(
-            'Closed visit as a visitor has a closed visit restriction.',
-          )
-        })
-    })
-
-    it('should render the available sessions list with closed visit reason (prisoner)', () => {
-      visitSessionData.visitRestriction = 'CLOSED'
-      visitSessionData.closedVisitReason = 'prisoner'
-
-      return request(sessionApp)
-        .get(`${journey.urlPrefix}/select-date-and-time`)
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('h1').text().trim()).toBe('Select date and time of visit')
-          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
-          expect($('[data-test="visit-restriction"]').text()).toBe('Closed')
-          expect($('[data-test="closed-visit-reason"]').text()).toContain(
-            'Closed visit as the prisoner has a closed visit restriction.',
-          )
-        })
-    })
-
-    it('should show message if no sessions are available', () => {
-      visitSessionsService.getVisitSessions.mockResolvedValue({})
-
-      sessionApp = appWithAllRoutes({
-        visitSessionsServiceOverride: visitSessionsService,
-        systemTokenOverride: systemToken,
-        sessionData: {
-          visitSessionData,
-        } as SessionData,
-      })
-
-      return request(sessionApp)
-        .get(`${journey.urlPrefix}/select-date-and-time`)
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('h1').text().trim()).toBe('Select date and time of visit')
-          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
-          expect($('#main-content').text()).toContain('There are no available slots for the selected time and day.')
-          expect($('input[name="visit-date-and-time"]').length).toBe(0)
-          expect($('[data-test="submit"]').length).toBe(0)
-          expect($('[data-test="back-to-start"]').length).toBe(1)
-        })
-    })
-
-    it('should render the available sessions list with the slot in the session selected', () => {
-      visitSessionData.visitSlot = {
-        id: '3',
-        startTimestamp: '2022-02-14T12:00:00',
-        endTimestamp: '2022-02-14T13:05:00',
-        availableTables: 5,
-        capacity: 30,
-        visitRoomName: 'room name',
-        visitRestriction: 'OPEN',
-      }
-
-      return request(sessionApp)
-        .get(`${journey.urlPrefix}/select-date-and-time`)
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('h1').text().trim()).toBe('Select date and time of visit')
-          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
-          expect($('input[name="visit-date-and-time"]').length).toBe(7)
-          expect($('.govuk-accordion__section--expanded').length).toBe(1)
-          expect($('.govuk-accordion__section--expanded #3').length).toBe(1)
-          expect($('input#3').prop('checked')).toBe(true)
-          expect($('[data-test="submit"]').text().trim()).toBe('Continue')
-        })
-    })
-
-    it('should render validation errors from flash data for invalid input', () => {
-      flashData.errors = [{ location: 'body', msg: 'No time slot selected', param: 'visit-date-and-time' }]
-
-      return request(sessionApp)
-        .get(`${journey.urlPrefix}/select-date-and-time`)
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('h1').text().trim()).toBe('Select date and time of visit')
-          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
-          expect($('.govuk-error-summary__body').text()).toContain('No time slot selected')
-          expect(flashProvider).toHaveBeenCalledWith('errors')
-          expect(flashProvider).toHaveBeenCalledWith('formValues')
-          expect(flashProvider).toHaveBeenCalledTimes(2)
-        })
-    })
-  })
-
-  describe(`POST ${journey.urlPrefix}/select-date-and-time`, () => {
-    const reservedVisit: Partial<Visit> = {
-      applicationReference: 'aaa-bbb-ccc',
-      reference: 'ab-cd-ef-gh',
-      visitStatus: 'RESERVED',
-    }
-
-    // representing a BOOKED visit on update journey that has moved to status CHANGING
-    const changingVisit: Partial<Visit> = {
-      applicationReference: 'aaa-bbb-ccc',
-      reference: 'ab-cd-ef-gh',
-      visitStatus: 'CHANGING',
+  describe(`Select date and time: ${journey.urlPrefix}/select-date-and-time`, () => {
+    const slotsList: VisitSlotList = {
+      'February 2022': [
+        {
+          date: 'Monday 14 February',
+          prisonerEvents: {
+            morning: [],
+            afternoon: [],
+          },
+          slots: {
+            morning: [
+              {
+                id: '1',
+                startTimestamp: '2022-02-14T10:00:00',
+                endTimestamp: '2022-02-14T11:00:00',
+                availableTables: 15,
+                capacity: 30,
+                visitRoomName: 'room name',
+                // representing a pre-existing visit that is BOOKED
+                sessionConflicts: ['DOUBLE_BOOKED'],
+                visitRestriction: 'OPEN',
+              },
+              {
+                id: '2',
+                startTimestamp: '2022-02-14T11:59:00',
+                endTimestamp: '2022-02-14T12:59:00',
+                availableTables: 1,
+                capacity: 30,
+                visitRoomName: 'room name',
+                visitRestriction: 'OPEN',
+              },
+            ],
+            afternoon: [
+              {
+                id: '3',
+                startTimestamp: '2022-02-14T12:00:00',
+                endTimestamp: '2022-02-14T13:05:00',
+                availableTables: 5,
+                capacity: 30,
+                visitRoomName: 'room name',
+                // representing the RESERVED visit being handled in this session
+                sessionConflicts: ['DOUBLE_BOOKED'],
+                visitRestriction: 'OPEN',
+              },
+            ],
+          },
+        },
+        {
+          date: 'Tuesday 15 February',
+          prisonerEvents: {
+            morning: [],
+            afternoon: [],
+          },
+          slots: {
+            morning: [],
+            afternoon: [
+              {
+                id: '4',
+                startTimestamp: '2022-02-15T16:00:00',
+                endTimestamp: '2022-02-15T17:00:00',
+                availableTables: 12,
+                capacity: 30,
+                visitRoomName: 'room name',
+                visitRestriction: 'OPEN',
+              },
+              {
+                id: '5',
+                startTimestamp: '2022-02-15T16:00:00',
+                endTimestamp: '2022-02-15T17:00:00',
+                availableTables: 12,
+                capacity: 30,
+                visitRoomName: 'room name',
+                visitRestriction: 'CLOSED',
+              },
+            ],
+          },
+        },
+      ],
+      'March 2022': [
+        {
+          date: 'Tuesday 1 March',
+          prisonerEvents: {
+            morning: [],
+            afternoon: [],
+          },
+          slots: {
+            morning: [
+              {
+                id: '6',
+                startTimestamp: '2022-03-01T09:30:00',
+                endTimestamp: '2022-03-01T10:30:00',
+                availableTables: 0,
+                capacity: 30,
+                visitRoomName: 'room name',
+                visitRestriction: 'OPEN',
+              },
+              {
+                id: '7',
+                startTimestamp: '2022-03-01T09:30:00',
+                endTimestamp: '2022-03-01T10:30:00',
+                availableTables: 0,
+                capacity: 30,
+                visitRoomName: 'room name',
+                visitRestriction: 'CLOSED',
+              },
+            ],
+            afternoon: [],
+          },
+        },
+      ],
     }
 
     beforeEach(() => {
-      visitSessionsService.reserveVisit = jest.fn().mockResolvedValue(reservedVisit)
-      visitSessionsService.changeBookedVisit = jest.fn().mockResolvedValue(changingVisit)
-      visitSessionsService.changeReservedVisit = jest.fn()
+      visitSessionsService.getVisitSessions.mockResolvedValue(slotsList)
+    })
 
-      sessionApp = appWithAllRoutes({
-        visitSessionsServiceOverride: visitSessionsService,
-        auditServiceOverride: auditService,
-        systemTokenOverride: systemToken,
-        sessionData: {
-          slotsList,
-          visitSessionData,
-        } as SessionData,
+    describe(`GET ${journey.urlPrefix}/select-date-and-time`, () => {
+      it('should render the available sessions list with none selected', () => {
+        return request(sessionApp)
+          .get(`${journey.urlPrefix}/select-date-and-time`)
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            const $ = cheerio.load(res.text)
+            expect($('h1').text().trim()).toBe('Select date and time of visit')
+            expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+            expect($('[data-test="visit-restriction"]').text()).toBe('Open')
+            expect($('[data-test="closed-visit-reason"]').length).toBe(0)
+            expect($('input[name="visit-date-and-time"]').length).toBe(7)
+            expect($('input[name="visit-date-and-time"]:checked').length).toBe(0)
+            expect($('.govuk-accordion__section--expanded').length).toBe(0)
+
+            expect($('label[for="1"]').text()).toContain('Prisoner has a visit')
+            expect($('#1').attr('disabled')).toBe('disabled')
+
+            expect($('[data-test="submit"]').text().trim()).toBe('Continue')
+          })
+      })
+
+      it('should render the available sessions list with closed visit reason (visitor)', () => {
+        visitSessionData.visitRestriction = 'CLOSED'
+        visitSessionData.closedVisitReason = 'visitor'
+
+        return request(sessionApp)
+          .get(`${journey.urlPrefix}/select-date-and-time`)
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            const $ = cheerio.load(res.text)
+            expect($('h1').text().trim()).toBe('Select date and time of visit')
+            expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+            expect($('[data-test="visit-restriction"]').text()).toBe('Closed')
+            expect($('[data-test="closed-visit-reason"]').text()).toContain(
+              'Closed visit as a visitor has a closed visit restriction.',
+            )
+          })
+      })
+
+      it('should render the available sessions list with closed visit reason (prisoner)', () => {
+        visitSessionData.visitRestriction = 'CLOSED'
+        visitSessionData.closedVisitReason = 'prisoner'
+
+        return request(sessionApp)
+          .get(`${journey.urlPrefix}/select-date-and-time`)
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            const $ = cheerio.load(res.text)
+            expect($('h1').text().trim()).toBe('Select date and time of visit')
+            expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+            expect($('[data-test="visit-restriction"]').text()).toBe('Closed')
+            expect($('[data-test="closed-visit-reason"]').text()).toContain(
+              'Closed visit as the prisoner has a closed visit restriction.',
+            )
+          })
+      })
+
+      it('should show message if no sessions are available', () => {
+        visitSessionsService.getVisitSessions.mockResolvedValue({})
+
+        sessionApp = appWithAllRoutes({
+          visitSessionsServiceOverride: visitSessionsService,
+          systemTokenOverride: systemToken,
+          sessionData: {
+            visitSessionData,
+          } as SessionData,
+        })
+
+        return request(sessionApp)
+          .get(`${journey.urlPrefix}/select-date-and-time`)
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            const $ = cheerio.load(res.text)
+            expect($('h1').text().trim()).toBe('Select date and time of visit')
+            expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+            expect($('#main-content').text()).toContain('There are no available slots for the selected time and day.')
+            expect($('input[name="visit-date-and-time"]').length).toBe(0)
+            expect($('[data-test="submit"]').length).toBe(0)
+            expect($('[data-test="back-to-start"]').length).toBe(1)
+          })
+      })
+
+      it('should render the available sessions list with the slot in the session selected', () => {
+        visitSessionData.visitSlot = {
+          id: '3',
+          startTimestamp: '2022-02-14T12:00:00',
+          endTimestamp: '2022-02-14T13:05:00',
+          availableTables: 5,
+          capacity: 30,
+          visitRoomName: 'room name',
+          visitRestriction: 'OPEN',
+        }
+
+        return request(sessionApp)
+          .get(`${journey.urlPrefix}/select-date-and-time`)
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            const $ = cheerio.load(res.text)
+            expect($('h1').text().trim()).toBe('Select date and time of visit')
+            expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+            expect($('input[name="visit-date-and-time"]').length).toBe(7)
+            expect($('.govuk-accordion__section--expanded').length).toBe(1)
+            expect($('.govuk-accordion__section--expanded #3').length).toBe(1)
+            expect($('input#3').prop('checked')).toBe(true)
+            expect($('[data-test="submit"]').text().trim()).toBe('Continue')
+          })
+      })
+
+      it('should render validation errors from flash data for invalid input', () => {
+        flashData.errors = [{ location: 'body', msg: 'No time slot selected', param: 'visit-date-and-time' }]
+
+        return request(sessionApp)
+          .get(`${journey.urlPrefix}/select-date-and-time`)
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            const $ = cheerio.load(res.text)
+            expect($('h1').text().trim()).toBe('Select date and time of visit')
+            expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+            expect($('.govuk-error-summary__body').text()).toContain('No time slot selected')
+            expect(flashProvider).toHaveBeenCalledWith('errors')
+            expect(flashProvider).toHaveBeenCalledWith('formValues')
+            expect(flashProvider).toHaveBeenCalledTimes(2)
+          })
       })
     })
 
-    it('should save to session, reserve visit and redirect to additional support page if slot selected', () => {
-      visitSessionData.visitReference = journey.isUpdate ? reservedVisit.reference : undefined
-
-      return request(sessionApp)
-        .post(`${journey.urlPrefix}/select-date-and-time`)
-        .send('visit-date-and-time=2')
-        .expect(302)
-        .expect('location', `${journey.urlPrefix}/additional-support`)
-        .expect(() => {
-          expect(visitSessionData.visitSlot).toEqual(<VisitSlot>{
-            id: '2',
-            startTimestamp: '2022-02-14T11:59:00',
-            endTimestamp: '2022-02-14T12:59:00',
-            availableTables: 1,
-            capacity: 30,
-            visitRoomName: 'room name',
-            visitRestriction: 'OPEN',
-          })
-          expect(visitSessionData.applicationReference).toEqual(reservedVisit.applicationReference)
-          expect(visitSessionData.visitReference).toEqual(reservedVisit.reference)
-          expect(visitSessionData.visitStatus).toEqual(
-            journey.isUpdate ? changingVisit.visitStatus : reservedVisit.visitStatus,
-          )
-
-          expect(
-            journey.isUpdate ? visitSessionsService.changeBookedVisit : visitSessionsService.reserveVisit,
-          ).toHaveBeenCalledTimes(1)
-          expect(visitSessionsService.changeReservedVisit).not.toHaveBeenCalled()
-
-          expect(auditService.reservedVisit).toHaveBeenCalledTimes(1)
-          expect(auditService.reservedVisit).toHaveBeenCalledWith({
-            applicationReference: reservedVisit.applicationReference,
-            visitReference: reservedVisit.reference,
-            prisonerId: 'A1234BC',
-            visitorIds: ['4323'],
-            startTimestamp: '2022-02-14T11:59:00',
-            endTimestamp: '2022-02-14T12:59:00',
-            visitRestriction: 'OPEN',
-            username: undefined,
-            operationId: undefined,
-          })
-        })
-    })
-
-    it('should save new choice to session, update visit reservation and redirect to additional support page if existing session data present', () => {
-      visitSessionData.visitSlot = {
-        id: '1',
-        startTimestamp: '2022-02-14T10:00:00',
-        endTimestamp: '2022-02-14T11:00:00',
-        availableTables: 15,
-        capacity: 30,
-        visitRoomName: 'room name',
-        visitRestriction: 'OPEN',
+    describe(`POST ${journey.urlPrefix}/select-date-and-time`, () => {
+      const reservedVisit: Partial<Visit> = {
+        applicationReference: 'aaa-bbb-ccc',
+        reference: 'ab-cd-ef-gh',
+        visitStatus: 'RESERVED',
       }
 
-      visitSessionData.applicationReference = reservedVisit.applicationReference
-      visitSessionData.visitReference = reservedVisit.reference
-      visitSessionData.visitStatus = journey.isUpdate ? changingVisit.visitStatus : reservedVisit.visitStatus
+      // representing a BOOKED visit on update journey that has moved to status CHANGING
+      const changingVisit: Partial<Visit> = {
+        applicationReference: 'aaa-bbb-ccc',
+        reference: 'ab-cd-ef-gh',
+        visitStatus: 'CHANGING',
+      }
 
-      return request(sessionApp)
-        .post(`${journey.urlPrefix}/select-date-and-time`)
-        .send('visit-date-and-time=3')
-        .expect(302)
-        .expect('location', `${journey.urlPrefix}/additional-support`)
-        .expect(() => {
-          expect(visitSessionData.visitSlot).toEqual(<VisitSlot>{
-            id: '3',
-            startTimestamp: '2022-02-14T12:00:00',
-            endTimestamp: '2022-02-14T13:05:00',
-            availableTables: 5,
-            capacity: 30,
-            visitRoomName: 'room name',
-            // representing the RESERVED visit being handled in this session
-            sessionConflicts: ['DOUBLE_BOOKED'],
-            visitRestriction: 'OPEN',
+      beforeEach(() => {
+        visitSessionsService.reserveVisit = jest.fn().mockResolvedValue(reservedVisit)
+        visitSessionsService.changeBookedVisit = jest.fn().mockResolvedValue(changingVisit)
+        visitSessionsService.changeReservedVisit = jest.fn()
+
+        sessionApp = appWithAllRoutes({
+          visitSessionsServiceOverride: visitSessionsService,
+          auditServiceOverride: auditService,
+          systemTokenOverride: systemToken,
+          sessionData: {
+            slotsList,
+            visitSessionData,
+          } as SessionData,
+        })
+      })
+
+      it('should save to session, reserve visit and redirect to additional support page if slot selected', () => {
+        visitSessionData.visitReference = journey.isUpdate ? reservedVisit.reference : undefined
+
+        return request(sessionApp)
+          .post(`${journey.urlPrefix}/select-date-and-time`)
+          .send('visit-date-and-time=2')
+          .expect(302)
+          .expect('location', `${journey.urlPrefix}/additional-support`)
+          .expect(() => {
+            expect(visitSessionData.visitSlot).toEqual(<VisitSlot>{
+              id: '2',
+              startTimestamp: '2022-02-14T11:59:00',
+              endTimestamp: '2022-02-14T12:59:00',
+              availableTables: 1,
+              capacity: 30,
+              visitRoomName: 'room name',
+              visitRestriction: 'OPEN',
+            })
+            expect(visitSessionData.applicationReference).toEqual(reservedVisit.applicationReference)
+            expect(visitSessionData.visitReference).toEqual(reservedVisit.reference)
+            expect(visitSessionData.visitStatus).toEqual(
+              journey.isUpdate ? changingVisit.visitStatus : reservedVisit.visitStatus,
+            )
+
+            expect(
+              journey.isUpdate ? visitSessionsService.changeBookedVisit : visitSessionsService.reserveVisit,
+            ).toHaveBeenCalledTimes(1)
+            expect(visitSessionsService.changeReservedVisit).not.toHaveBeenCalled()
+
+            expect(auditService.reservedVisit).toHaveBeenCalledTimes(1)
+            expect(auditService.reservedVisit).toHaveBeenCalledWith({
+              applicationReference: reservedVisit.applicationReference,
+              visitReference: reservedVisit.reference,
+              prisonerId: 'A1234BC',
+              visitorIds: ['4323'],
+              startTimestamp: '2022-02-14T11:59:00',
+              endTimestamp: '2022-02-14T12:59:00',
+              visitRestriction: 'OPEN',
+              username: undefined,
+              operationId: undefined,
+            })
           })
+      })
 
-          expect(visitSessionData.applicationReference).toEqual(reservedVisit.applicationReference)
-          expect(visitSessionData.visitReference).toEqual(reservedVisit.reference)
-          expect(visitSessionData.visitStatus).toEqual(
-            journey.isUpdate ? changingVisit.visitStatus : reservedVisit.visitStatus,
-          )
+      it('should save new choice to session, update visit reservation and redirect to additional support page if existing session data present', () => {
+        visitSessionData.visitSlot = {
+          id: '1',
+          startTimestamp: '2022-02-14T10:00:00',
+          endTimestamp: '2022-02-14T11:00:00',
+          availableTables: 15,
+          capacity: 30,
+          visitRoomName: 'room name',
+          visitRestriction: 'OPEN',
+        }
 
-          expect(visitSessionsService.reserveVisit).not.toHaveBeenCalled()
-          expect(visitSessionsService.changeReservedVisit).toHaveBeenCalledTimes(1)
-          expect(visitSessionsService.changeReservedVisit.mock.calls[0][0].visitSessionData.applicationReference).toBe(
-            reservedVisit.applicationReference,
-          )
-          expect(visitSessionsService.changeReservedVisit.mock.calls[0][0].visitSessionData.visitReference).toBe(
-            reservedVisit.reference,
-          )
+        visitSessionData.applicationReference = reservedVisit.applicationReference
+        visitSessionData.visitReference = reservedVisit.reference
+        visitSessionData.visitStatus = journey.isUpdate ? changingVisit.visitStatus : reservedVisit.visitStatus
 
-          expect(auditService.reservedVisit).toHaveBeenCalledTimes(1)
-          expect(auditService.reservedVisit).toHaveBeenCalledWith({
-            applicationReference: reservedVisit.applicationReference,
-            visitReference: reservedVisit.reference,
-            prisonerId: 'A1234BC',
-            visitorIds: ['4323'],
-            startTimestamp: '2022-02-14T12:00:00',
-            endTimestamp: '2022-02-14T13:05:00',
-            visitRestriction: 'OPEN',
-            username: undefined,
-            operationId: undefined,
+        return request(sessionApp)
+          .post(`${journey.urlPrefix}/select-date-and-time`)
+          .send('visit-date-and-time=3')
+          .expect(302)
+          .expect('location', `${journey.urlPrefix}/additional-support`)
+          .expect(() => {
+            expect(visitSessionData.visitSlot).toEqual(<VisitSlot>{
+              id: '3',
+              startTimestamp: '2022-02-14T12:00:00',
+              endTimestamp: '2022-02-14T13:05:00',
+              availableTables: 5,
+              capacity: 30,
+              visitRoomName: 'room name',
+              // representing the RESERVED visit being handled in this session
+              sessionConflicts: ['DOUBLE_BOOKED'],
+              visitRestriction: 'OPEN',
+            })
+
+            expect(visitSessionData.applicationReference).toEqual(reservedVisit.applicationReference)
+            expect(visitSessionData.visitReference).toEqual(reservedVisit.reference)
+            expect(visitSessionData.visitStatus).toEqual(
+              journey.isUpdate ? changingVisit.visitStatus : reservedVisit.visitStatus,
+            )
+
+            expect(visitSessionsService.reserveVisit).not.toHaveBeenCalled()
+            expect(visitSessionsService.changeReservedVisit).toHaveBeenCalledTimes(1)
+            expect(
+              visitSessionsService.changeReservedVisit.mock.calls[0][0].visitSessionData.applicationReference,
+            ).toBe(reservedVisit.applicationReference)
+            expect(visitSessionsService.changeReservedVisit.mock.calls[0][0].visitSessionData.visitReference).toBe(
+              reservedVisit.reference,
+            )
+
+            expect(auditService.reservedVisit).toHaveBeenCalledTimes(1)
+            expect(auditService.reservedVisit).toHaveBeenCalledWith({
+              applicationReference: reservedVisit.applicationReference,
+              visitReference: reservedVisit.reference,
+              prisonerId: 'A1234BC',
+              visitorIds: ['4323'],
+              startTimestamp: '2022-02-14T12:00:00',
+              endTimestamp: '2022-02-14T13:05:00',
+              visitRestriction: 'OPEN',
+              username: undefined,
+              operationId: undefined,
+            })
           })
-        })
-    })
+      })
 
-    it('should should set validation errors in flash and redirect if no slot selected', () => {
-      return request(sessionApp)
-        .post(`${journey.urlPrefix}/select-date-and-time`)
-        .expect(302)
-        .expect('location', `${journey.urlPrefix}/select-date-and-time`)
-        .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('errors', [
-            { location: 'body', msg: 'No time slot selected', param: 'visit-date-and-time', value: undefined },
-          ])
-          expect(flashProvider).toHaveBeenCalledWith('formValues', {})
-          expect(auditService.reservedVisit).not.toHaveBeenCalled()
-        })
-    })
+      it('should should set validation errors in flash and redirect if no slot selected', () => {
+        return request(sessionApp)
+          .post(`${journey.urlPrefix}/select-date-and-time`)
+          .expect(302)
+          .expect('location', `${journey.urlPrefix}/select-date-and-time`)
+          .expect(() => {
+            expect(flashProvider).toHaveBeenCalledWith('errors', [
+              { location: 'body', msg: 'No time slot selected', param: 'visit-date-and-time', value: undefined },
+            ])
+            expect(flashProvider).toHaveBeenCalledWith('formValues', {})
+            expect(auditService.reservedVisit).not.toHaveBeenCalled()
+          })
+      })
 
-    it('should should set validation errors in flash and redirect if invalid slot selected', () => {
-      return request(sessionApp)
-        .post(`${journey.urlPrefix}/select-date-and-time`)
-        .send('visit-date-and-time=100')
-        .expect(302)
-        .expect('location', `${journey.urlPrefix}/select-date-and-time`)
-        .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('errors', [
-            { location: 'body', msg: 'No time slot selected', param: 'visit-date-and-time', value: '100' },
-          ])
-          expect(flashProvider).toHaveBeenCalledWith('formValues', { 'visit-date-and-time': '100' })
-          expect(auditService.reservedVisit).not.toHaveBeenCalled()
-        })
+      it('should should set validation errors in flash and redirect if invalid slot selected', () => {
+        return request(sessionApp)
+          .post(`${journey.urlPrefix}/select-date-and-time`)
+          .send('visit-date-and-time=100')
+          .expect(302)
+          .expect('location', `${journey.urlPrefix}/select-date-and-time`)
+          .expect(() => {
+            expect(flashProvider).toHaveBeenCalledWith('errors', [
+              { location: 'body', msg: 'No time slot selected', param: 'visit-date-and-time', value: '100' },
+            ])
+            expect(flashProvider).toHaveBeenCalledWith('formValues', { 'visit-date-and-time': '100' })
+            expect(auditService.reservedVisit).not.toHaveBeenCalled()
+          })
+      })
     })
   })
 })
 
-describe(`Update journey specific testing`, () => {
-  it('Restriction change: Open to closed, no availability for the selected visit slot - visitor', () => {
-    visitSessionData.visitRestriction = 'CLOSED'
-    visitSessionData.closedVisitReason = 'visitor'
-    visitSessionData.visitSlot = {
+describe('Update journey specific warning messages', () => {
+  let currentlyBookedSlot: VisitSlot
+  let slotsList: VisitSlotList
+  let currentlyAvailableSlots: VisitSlot[]
+
+  beforeEach(() => {
+    currentlyBookedSlot = {
       id: '',
-      startTimestamp: '2022-03-01T09:30:00',
-      endTimestamp: '2022-03-01T10:30:00',
-      visitRestriction: 'OPEN',
+      startTimestamp: '2022-10-17T09:00:00',
+      endTimestamp: '2022-10-17T10:00:00',
     } as VisitSlot
 
-    visitSessionData.originalVisitSlot = visitSessionData.visitSlot
+    slotsList = {
+      'October 2022': [
+        {
+          date: 'Monday 17 October',
+          prisonerEvents: {
+            morning: [],
+            afternoon: [],
+          },
+          slots: {
+            morning: [
+              {
+                id: '1',
+                startTimestamp: '2022-10-17T09:00:00',
+                endTimestamp: '2022-10-17T10:00:00',
+                capacity: 30,
+              } as VisitSlot,
+            ],
+            afternoon: [],
+          },
+        },
+      ],
+    }
+    currentlyAvailableSlots = slotsList['October 2022'][0].slots.morning
+
+    visitSessionsService.getVisitSessions.mockResolvedValue(slotsList)
+
+    visitSessionData.visitSlot = currentlyBookedSlot
+    visitSessionData.originalVisitSlot = currentlyBookedSlot
+  })
+
+  it('should select original slot with no message if no restriction change', () => {
+    currentlyBookedSlot.visitRestriction = 'OPEN'
+
+    currentlyAvailableSlots[0].availableTables = 0 // could be fully booked (including this visit)
+    currentlyAvailableSlots[0].visitRestriction = 'OPEN'
+
+    visitSessionData.visitRestriction = 'OPEN'
+
+    return request(sessionApp)
+      .get('/visit/ab-cd-ef-gh/update/select-date-and-time')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-test="restriction-change-reason"]').length).toBe(0)
+        expect($('input#1').prop('checked')).toBe(true)
+      })
+  })
+
+  it('should show message with no slot selected when visit has changed from open to closed (visitor restriction), but original timeslot unavailable', () => {
+    currentlyBookedSlot.visitRestriction = 'OPEN'
+
+    currentlyAvailableSlots[0].availableTables = -1 // test over-booked (which includes fully-booked)
+    currentlyAvailableSlots[0].visitRestriction = 'CLOSED'
+
+    visitSessionData.visitRestriction = 'CLOSED'
+    visitSessionData.closedVisitReason = 'visitor'
 
     return request(sessionApp)
       .get('/visit/ab-cd-ef-gh/update/select-date-and-time')
@@ -513,20 +574,18 @@ describe(`Update journey specific testing`, () => {
         expect($('[data-test="restriction-change-reason"]').text()).toContain(
           'A new visit time must be selected as this is now a closed visit due to a visitor restriction.',
         )
+        expect($('input:checked').length).toBe(0)
       })
   })
 
-  it('Restriction change: Open to closed, no availability for the selected visit slot - prisoner', () => {
+  it('should show message with no slot selected when visit has changed from open to closed (prisoner restriction), but original timeslot unavailable', () => {
+    currentlyBookedSlot.visitRestriction = 'OPEN'
+
+    currentlyAvailableSlots[0].availableTables = 0
+    currentlyAvailableSlots[0].visitRestriction = 'CLOSED'
+
     visitSessionData.visitRestriction = 'CLOSED'
     visitSessionData.closedVisitReason = 'prisoner'
-    visitSessionData.visitSlot = {
-      id: '',
-      startTimestamp: '2022-03-01T09:30:00',
-      endTimestamp: '2022-03-01T10:30:00',
-      visitRestriction: 'OPEN',
-    } as VisitSlot
-
-    visitSessionData.originalVisitSlot = visitSessionData.visitSlot
 
     return request(sessionApp)
       .get('/visit/ab-cd-ef-gh/update/select-date-and-time')
@@ -537,90 +596,17 @@ describe(`Update journey specific testing`, () => {
         expect($('[data-test="restriction-change-reason"]').text()).toContain(
           'A new visit time must be selected as this is now a closed visit due to a prisoner restriction.',
         )
+        expect($('input:checked').length).toBe(0)
       })
   })
 
-  it('Restriction change: Open to closed, some visit slots available - visitor', () => {
-    visitSessionData.visitRestriction = 'CLOSED'
-    visitSessionData.closedVisitReason = 'visitor'
-    visitSessionData.visitSlot = {
-      id: '',
-      startTimestamp: '2022-02-15T16:00:00',
-      endTimestamp: '2022-02-15T17:00:00',
-      visitRestriction: 'OPEN',
-    } as VisitSlot
+  it('should show message with no slot selected when visit has changed from closed to open, but original timeslot unavailable', () => {
+    currentlyBookedSlot.visitRestriction = 'CLOSED'
 
-    visitSessionData.originalVisitSlot = visitSessionData.visitSlot
+    currentlyAvailableSlots[0].availableTables = 0
+    currentlyAvailableSlots[0].visitRestriction = 'OPEN'
 
-    return request(sessionApp)
-      .get('/visit/ab-cd-ef-gh/update/select-date-and-time')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('[data-test="restriction-change-reason"]').text()).toContain(
-          'This is now a closed visit due to a visitor restriction. The visit time can stay the same.',
-        )
-      })
-  })
-
-  it('Restriction change: Open to closed, some visit slots available - prisoner', () => {
-    visitSessionData.visitRestriction = 'CLOSED'
-    visitSessionData.closedVisitReason = 'prisoner'
-    visitSessionData.visitSlot = {
-      id: '',
-      startTimestamp: '2022-02-15T16:00:00',
-      endTimestamp: '2022-02-15T17:00:00',
-      visitRestriction: 'OPEN',
-    } as VisitSlot
-
-    visitSessionData.originalVisitSlot = visitSessionData.visitSlot
-
-    return request(sessionApp)
-      .get('/visit/ab-cd-ef-gh/update/select-date-and-time')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('[data-test="restriction-change-reason"]').text()).toContain(
-          'This is now a closed visit due to a prisoner restriction. The visit time can stay the same.',
-        )
-      })
-  })
-
-  it('Restriction change: Closed to open, some visit slots available', () => {
     visitSessionData.visitRestriction = 'OPEN'
-    visitSessionData.visitSlot = {
-      id: '',
-      startTimestamp: '2022-02-15T16:00:00',
-      endTimestamp: '2022-02-15T17:00:00',
-      visitRestriction: 'CLOSED',
-    } as VisitSlot
-
-    visitSessionData.originalVisitSlot = visitSessionData.visitSlot
-
-    return request(sessionApp)
-      .get('/visit/ab-cd-ef-gh/update/select-date-and-time')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('[data-test="restriction-change-reason"]').text()).toContain(
-          'This is now an open visit. The visit time can stay the same.',
-        )
-      })
-  })
-
-  it('Restriction change: Closed to open, no availability for the selected visit slot', () => {
-    visitSessionData.visitRestriction = 'OPEN'
-    visitSessionData.visitSlot = {
-      id: '',
-      startTimestamp: '2022-03-01T09:30:00',
-      endTimestamp: '2022-03-01T10:30:00',
-      visitRestriction: 'CLOSED',
-    } as VisitSlot
-
-    visitSessionData.originalVisitSlot = visitSessionData.visitSlot
 
     return request(sessionApp)
       .get('/visit/ab-cd-ef-gh/update/select-date-and-time')
@@ -631,6 +617,72 @@ describe(`Update journey specific testing`, () => {
         expect($('[data-test="restriction-change-reason"]').text()).toContain(
           'A new visit time must be selected as this is now an open visit.',
         )
+        expect($('input:checked').length).toBe(0)
+      })
+  })
+
+  it('should show message with original slot selected when visit has changed from open to closed (visitor restriction) and original timeslot available', () => {
+    currentlyBookedSlot.visitRestriction = 'OPEN'
+
+    currentlyAvailableSlots[0].availableTables = 1
+    currentlyAvailableSlots[0].visitRestriction = 'CLOSED'
+
+    visitSessionData.visitRestriction = 'CLOSED'
+    visitSessionData.closedVisitReason = 'visitor'
+
+    return request(sessionApp)
+      .get('/visit/ab-cd-ef-gh/update/select-date-and-time')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-test="restriction-change-reason"]').text()).toContain(
+          'This is now a closed visit due to a visitor restriction. The visit time can stay the same.',
+        )
+        expect($('input#1').prop('checked')).toBe(true)
+      })
+  })
+
+  it('should show message with original slot selected when visit has changed from open to closed (prisoner restriction) and original timeslot available', () => {
+    currentlyBookedSlot.visitRestriction = 'OPEN'
+
+    currentlyAvailableSlots[0].availableTables = 1
+    currentlyAvailableSlots[0].visitRestriction = 'CLOSED'
+
+    visitSessionData.visitRestriction = 'CLOSED'
+    visitSessionData.closedVisitReason = 'prisoner'
+
+    return request(sessionApp)
+      .get('/visit/ab-cd-ef-gh/update/select-date-and-time')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-test="restriction-change-reason"]').text()).toContain(
+          'This is now a closed visit due to a prisoner restriction. The visit time can stay the same.',
+        )
+        expect($('input#1').prop('checked')).toBe(true)
+      })
+  })
+
+  it('should show message with original slot selected when visit has changed from closed to open and original timeslot available', () => {
+    currentlyBookedSlot.visitRestriction = 'CLOSED'
+
+    currentlyAvailableSlots[0].availableTables = 1
+    currentlyAvailableSlots[0].visitRestriction = 'OPEN'
+
+    visitSessionData.visitRestriction = 'OPEN'
+
+    return request(sessionApp)
+      .get('/visit/ab-cd-ef-gh/update/select-date-and-time')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-test="restriction-change-reason"]').text()).toContain(
+          'This is now an open visit. The visit time can stay the same.',
+        )
+        expect($('input#1').prop('checked')).toBe(true)
       })
   })
 })

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express'
 import { Session, SessionData } from 'express-session'
 import { VisitSlot, VisitSlotList } from '../@types/bapv'
-import { clearSession, getFlashFormValues, getSelectedSlot } from './visitorUtils'
+import { clearSession, getFlashFormValues, getSelectedSlot, getSlotByStartTimeAndRestriction } from './visitorUtils'
 
 const slotsList: VisitSlotList = {
   'February 2022': [
@@ -108,6 +108,16 @@ describe('getSelectedSlot', () => {
   it('should return undefined if selected slot not present in slotsList', () => {
     expect(getSelectedSlot(slotsList, '0')).toBe(undefined)
     expect(getSelectedSlot(slotsList, '6')).toBe(undefined)
+  })
+})
+
+describe('getSlotByStartTimeAndRestriction', () => {
+  it('should return a slot given matching start timestamp and visit restriction', () => {
+    expect(getSlotByStartTimeAndRestriction(slotsList, '2022-02-14T12:00:00', 'OPEN')).toHaveProperty('id', '3')
+  })
+
+  it('should return undefined if no slot matches given start timestamp and visit restriction', () => {
+    expect(getSlotByStartTimeAndRestriction(slotsList, '2022-01-01T00:00:00', 'OPEN')).toBe(undefined)
   })
 })
 

--- a/server/routes/visitorUtils.ts
+++ b/server/routes/visitorUtils.ts
@@ -11,7 +11,7 @@ export const getSelectedSlot = (slotsList: VisitSlotList, selectedSlot: string):
     .find(slot => slot.id === selectedSlot)
 }
 
-export const getSelectedSlotByStartTimestamp = (
+export const getSlotByStartTimeAndRestriction = (
   slotsList: VisitSlotList,
   startTimestamp: string,
   visitRestriction: string,

--- a/server/views/pages/bookAVisit/dateAndTime.njk
+++ b/server/views/pages/bookAVisit/dateAndTime.njk
@@ -15,13 +15,13 @@
 {% macro buildSlotsRadioItems(slotsList, radios) %}
   {% for slot in slotsList %}
 
-    {%- set doubleBooked = slot.id != originalSelectedSlot.id and (slot.sessionConflicts and "DOUBLE_BOOKED" in slot.sessionConflicts) %}
+    {%- set doubleBooked = slot.id != originalVisitSlot.id and (slot.sessionConflicts and "DOUBLE_BOOKED" in slot.sessionConflicts) %}
     {%- set checked = true if formValues['visit-date-and-time'] and formValues['visit-date-and-time'] == slot.id else false %}
 
     {%- set tableText %}
-      {% if (slot.id == originalSelectedSlot.id) -%}
+      {% if (slot.id == originalVisitSlot.id) -%}
         Time slot reserved by the original booking
-      {% elseif (checked and not originalSelectedSlot) -%}
+      {% elseif (checked and not originalVisitSlot) -%}
         Time slot reserved for this booking
       {% elseif (doubleBooked and not checked) -%}
         Prisoner has a visit

--- a/server/views/pages/bookAVisit/dateAndTime.test.ts
+++ b/server/views/pages/bookAVisit/dateAndTime.test.ts
@@ -241,7 +241,7 @@ describe('Views - Date and time of visit', () => {
     })
 
     it('should correctly label slot that is NOT checked when booking a visit', () => {
-      viewContext.originalSelectedSlot = undefined // booking journey; so no originally selected slot
+      viewContext.originalVisitSlot = undefined // booking journey; so no originally selected slot
 
       const $ = cheerio.load(compiledTemplate.render(viewContext))
 
@@ -252,7 +252,7 @@ describe('Views - Date and time of visit', () => {
 
     it('should correctly label currently reserved slot when booking a visit', () => {
       viewContext.formValues = { 'visit-date-and-time': '1' }
-      viewContext.originalSelectedSlot = undefined // booking journey; so no originally selected slot
+      viewContext.originalVisitSlot = undefined // booking journey; so no originally selected slot
 
       const $ = cheerio.load(compiledTemplate.render(viewContext))
 
@@ -262,7 +262,7 @@ describe('Views - Date and time of visit', () => {
     })
 
     it('should correctly label the originally selected slot (when NOT checked) when updating a visit', () => {
-      viewContext.originalSelectedSlot = { id: '1' } as VisitSlot // update journey, so originally selected slot known
+      viewContext.originalVisitSlot = { id: '1' } as VisitSlot // update journey, so originally selected slot known
 
       const $ = cheerio.load(compiledTemplate.render(viewContext))
 
@@ -273,7 +273,7 @@ describe('Views - Date and time of visit', () => {
 
     it('should correctly label the originally selected slot (when checked) when updating a visit', () => {
       viewContext.formValues = { 'visit-date-and-time': '1' }
-      viewContext.originalSelectedSlot = { id: '1' } as VisitSlot // update journey, so originally selected slot known
+      viewContext.originalVisitSlot = { id: '1' } as VisitSlot // update journey, so originally selected slot known
 
       const $ = cheerio.load(compiledTemplate.render(viewContext))
 


### PR DESCRIPTION
The select date/time page shows restriction change messages to indicate that a visit needs to become open/closed and - depending on availability - whether or not a new time slot needs to be selected.

This change fixes an issue where a slot could be incorrectly selected even if the restriction change message indicated that is was not available.