### PR TITLE
VB-1390: Add selected establishment to session

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -13,6 +13,7 @@ declare module 'express-session' {
     adultVisitors: { adults: VisitorListItem[] }
     slotsList: VisitSlotList
     visitSessionData: VisitSessionData
+    selectedEstablishment: { prisonId: string; name: string }
   }
 }
 

--- a/server/middleware/populateSelectedEstablishment.test.ts
+++ b/server/middleware/populateSelectedEstablishment.test.ts
@@ -1,0 +1,45 @@
+import { Request, Response } from 'express'
+import { Cookie } from 'express-session'
+import populateSelectedEstablishment from './populateSelectedEstablishment'
+
+describe('populateSelectedEstablishment', () => {
+  let req: Partial<Request>
+  const res: Partial<Response> = { locals: undefined }
+  const next = jest.fn()
+
+  beforeEach(() => {
+    req = {
+      session: {
+        regenerate: jest.fn(),
+        destroy: jest.fn(),
+        reload: jest.fn(),
+        id: 'sessionId',
+        resetMaxAge: jest.fn(),
+        save: jest.fn(),
+        touch: jest.fn(),
+        cookie: new Cookie(),
+      },
+    }
+
+    res.locals = {}
+  })
+
+  it('should set default establishment if non is set in session and populate res.locals', () => {
+    const defaultEstablishment = { prisonId: 'HEI', name: 'Hewell (HMP)' }
+
+    populateSelectedEstablishment(req as Request, res as Response, next)
+
+    expect(req.session.selectedEstablishment).toEqual(defaultEstablishment)
+    expect(res.locals.selectedEstablishment).toEqual(defaultEstablishment)
+  })
+
+  it('should populate res.locals when establishment already set in session', () => {
+    const alreadySelectedEstablishment = { prisonId: 'BLI', name: 'Bristol (HMP)' }
+    req.session.selectedEstablishment = alreadySelectedEstablishment
+
+    populateSelectedEstablishment(req as Request, res as Response, next)
+
+    expect(req.session.selectedEstablishment).toEqual(alreadySelectedEstablishment)
+    expect(res.locals.selectedEstablishment).toEqual(alreadySelectedEstablishment)
+  })
+})

--- a/server/middleware/populateSelectedEstablishment.ts
+++ b/server/middleware/populateSelectedEstablishment.ts
@@ -1,0 +1,13 @@
+import type { NextFunction, Request, Response } from 'express'
+
+// temporarily hard-coding here pending work on establishment switcher and decision on default value
+const defaultEstablishment = { prisonId: 'HEI', name: 'Hewell (HMP)' }
+
+export default function populateSelectedEstablishment(req: Request, res: Response, next: NextFunction) {
+  if (req.session.selectedEstablishment === undefined) {
+    req.session.selectedEstablishment = defaultEstablishment
+  }
+  res.locals.selectedEstablishment = req.session.selectedEstablishment
+
+  next()
+}

--- a/server/routes/standardRouter.ts
+++ b/server/routes/standardRouter.ts
@@ -3,6 +3,7 @@ import csurf from 'csurf'
 import auth from '../authentication/auth'
 import tokenVerifier from '../data/tokenVerification'
 import populateCurrentUser from '../middleware/populateCurrentUser'
+import populateSelectedEstablishment from '../middleware/populateSelectedEstablishment'
 import type UserService from '../services/userService'
 
 const testMode = process.env.NODE_ENV === 'test'
@@ -12,6 +13,7 @@ export default function standardRouter(userService: UserService): Router {
 
   router.use(auth.authenticationMiddleware(tokenVerifier))
   router.use(populateCurrentUser(userService))
+  router.use(populateSelectedEstablishment)
 
   // CSRF protection
   if (!testMode) {

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -68,6 +68,7 @@ function appSetup({
     adultVisitors: { adults: [] as VisitorListItem[] },
     slotsList: {} as VisitSlotList,
     visitSessionData: {} as VisitSessionData,
+    selectedEstablishment: undefined,
   },
 }: {
   prisonerSearchServiceOverride: PrisonerSearchService

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -156,6 +156,7 @@ describe('clearSession', () => {
     adultVisitors: { adults: [] },
     slotsList: {},
     visitSessionData: { prisoner: undefined },
+    selectedEstablishment: undefined,
   }
 
   req.session = sessionData as Session & SessionData

--- a/server/routes/visitorUtils.ts
+++ b/server/routes/visitorUtils.ts
@@ -40,7 +40,14 @@ export const getSupportTypeDescriptions = (
 }
 
 export const clearSession = (req: Request): void => {
-  ;['availableSupportTypes', 'visitorList', 'adultVisitors', 'slotsList', 'visitSessionData'].forEach(sessionItem => {
+  ;[
+    'availableSupportTypes',
+    'visitorList',
+    'adultVisitors',
+    'slotsList',
+    'visitSessionData',
+    'selectedEstablishment',
+  ].forEach(sessionItem => {
     delete req.session[sessionItem]
   })
 }

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -36,7 +36,7 @@
 
 <div class="location-bar">
   <span class="location-bar__location" data-test="active-location">
-    Hewell (HMP)
+    {{ selectedEstablishment.name }}
   </span>
   {% if not hidePhaseBanner %}
     {{ govukPhaseBanner ({


### PR DESCRIPTION
This adds `selectedEstablishment` to the session. Currently it defaults to `HEI / Hewell (HMP)` - pending further work on the establishment switcher and a decision on what the default should be.

Middleware ensures that `res.locals` is populated with the currently selected establishment so it is available throughout the application and in templates.

Initially changed the hard-coded 'Hewell' in the page template to use the new value. (Next steps, replace all the other hard-coded instances...!)