### PR TITLE
VB-1495: Add default background colour to date picker

### DIFF
--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -200,6 +200,7 @@
   right: 0;
   top: 49px;
   width: 350px;
+  background-color: $govuk-body-background-colour;
   z-index: 10;
   border-left: 1px solid govuk-colour("mid-grey");
   border-right: 1px solid govuk-colour("mid-grey");


### PR DESCRIPTION
Add a background colour to the pop-up date picker on 'View visits by date' page so that at narrow window size the main content isn't visible underneath.