### PR TITLE
VB-1409: Add supported prisons service

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -22,6 +22,7 @@ import { prisonApiClientBuilder } from './data/prisonApiClient'
 import NotificationsService from './services/notificationsService'
 import PrisonerSearchService from './services/prisonerSearchService'
 import PrisonerProfileService from './services/prisonerProfileService'
+import SupportedPrisonsService from './services/supportedPrisonsService'
 import systemToken from './data/authClient'
 import setUpWebSession from './middleware/setUpWebSession'
 import setUpStaticResources from './middleware/setUpStaticResources'
@@ -53,7 +54,13 @@ export default function createApp(userService: UserService): express.Application
   app.use(appInsightsOperationId)
 
   app.use('/', indexRoutes(standardRouter(userService)))
-  app.use('/change-establishment/', establishmentRoutes(standardRouter(userService)))
+  app.use(
+    '/change-establishment/',
+    establishmentRoutes(
+      standardRouter(userService),
+      new SupportedPrisonsService(visitSchedulerApiClientBuilder, systemToken),
+    ),
+  )
   app.use(
     '/search/',
     searchRoutes(

--- a/server/constants/prisons.ts
+++ b/server/constants/prisons.ts
@@ -1,0 +1,14 @@
+import { Prison } from '../@types/bapv'
+
+const prisons: Prison[] = [
+  {
+    prisonId: 'HEI',
+    prisonName: 'Hewell (HMP)',
+  },
+  {
+    prisonId: 'BLI',
+    prisonName: 'Bristol (HMP & YOI)',
+  },
+]
+
+export default prisons

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -27,6 +27,22 @@ describe('visitSchedulerApiClient', () => {
     nock.cleanAll()
   })
 
+  describe('getSupportedPrisonIds', () => {
+    it('should return an array of supported prison IDs', async () => {
+      const results = ['HEI', 'BLI']
+
+      // awaiting endpoint on visit scheduler - VB-1222
+      // fakeVisitSchedulerApi
+      //   .get('/supported-prisons')
+      //   .matchHeader('authorization', `Bearer ${token}`)
+      //   .reply(200, results)
+
+      const output = await client.getSupportedPrisonIds()
+
+      expect(output).toEqual(results)
+    })
+  })
+
   describe('getAvailableSupportOptions', () => {
     it('should return an array of available support types', async () => {
       const results: SupportType[] = [

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -23,6 +23,15 @@ class VisitSchedulerApiClient {
 
   private visitStatus = 'BOOKED'
 
+  getSupportedPrisonIds(): Promise<string[]> {
+    // return this.restclient.get({
+    //   path: '/supported-prisons',
+    // })
+
+    // hard-coded here, awaiting endpoint on visit scheduler - VB-1222
+    return Promise.resolve(['HEI', 'BLI'])
+  }
+
   getAvailableSupportOptions(): Promise<SupportType[]> {
     return this.restclient.get({
       path: '/visit-support',

--- a/server/routes/changeEstablishment.ts
+++ b/server/routes/changeEstablishment.ts
@@ -1,19 +1,15 @@
 import type { RequestHandler, Router } from 'express'
-import { Prison } from '../@types/bapv'
-
 import asyncMiddleware from '../middleware/asyncMiddleware'
+import SupportedPrisonsService from '../services/supportedPrisonsService'
 
-export default function routes(router: Router): Router {
+export default function routes(router: Router, supportedPrisonsService: SupportedPrisonsService): Router {
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  const enabledPrisons: Prison[] = [
-    { prisonId: 'HEI', prisonName: 'Hewell (HMP)' },
-    { prisonId: 'BLI', prisonName: 'Bristol (HMP)' },
-  ]
+  get('/', async (req, res) => {
+    const supportedPrisons = await supportedPrisonsService.getSupportedPrisons(res.locals.user?.username)
 
-  get('/', (req, res, next) => {
     res.render('pages/changeEstablishment', {
-      enabledPrisons,
+      supportedPrisons,
     })
   })
   return router

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -23,6 +23,7 @@ import PrisonerProfileService from '../../services/prisonerProfileService'
 import PrisonerVisitorsService from '../../services/prisonerVisitorsService'
 import VisitSessionsService from '../../services/visitSessionsService'
 import NotificationsService from '../../services/notificationsService'
+import SupportedPrisonsService from '../../services/supportedPrisonsService'
 import * as auth from '../../authentication/auth'
 import systemToken from '../../data/authClient'
 import { SystemToken, VisitorListItem, VisitSlotList, VisitSessionData } from '../../@types/bapv'
@@ -58,6 +59,7 @@ function appSetup({
   visitSessionsServiceOverride,
   auditServiceOverride,
   notificationsServiceOverride,
+  supportedPrisonsServiceOverride,
   systemTokenOverride,
   production = false,
   sessionData = {
@@ -78,6 +80,7 @@ function appSetup({
   visitSessionsServiceOverride: VisitSessionsService
   auditServiceOverride: AuditService
   notificationsServiceOverride: NotificationsService
+  supportedPrisonsServiceOverride: SupportedPrisonsService
   systemTokenOverride: SystemToken
   production: boolean
   sessionData: SessionData
@@ -108,10 +111,15 @@ function appSetup({
   // app.use(cookieSession({ keys: [''] }))
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
-  app.use('/', indexRoutes(standardRouter(new MockUserService())))
-  app.use('/change-establishment/', establishmentRoutes(standardRouter(new MockUserService())))
 
   const systemTokenTest = systemTokenOverride || systemToken
+
+  app.use('/', indexRoutes(standardRouter(new MockUserService())))
+
+  const supportedPrisonsService =
+    supportedPrisonsServiceOverride || new SupportedPrisonsService(visitSchedulerApiClientBuilder, systemToken)
+  app.use('/change-establishment/', establishmentRoutes(standardRouter(new MockUserService()), supportedPrisonsService))
+
   const prisonerSearchService =
     prisonerSearchServiceOverride || new PrisonerSearchService(prisonerSearchClientBuilder, systemTokenTest)
   const visitSessionsService =
@@ -192,6 +200,7 @@ export function appWithAllRoutes({
   visitSessionsServiceOverride,
   auditServiceOverride,
   notificationsServiceOverride,
+  supportedPrisonsServiceOverride,
   systemTokenOverride,
   production = false,
   sessionData,
@@ -202,6 +211,7 @@ export function appWithAllRoutes({
   visitSessionsServiceOverride?: VisitSessionsService
   auditServiceOverride?: AuditService
   notificationsServiceOverride?: NotificationsService
+  supportedPrisonsServiceOverride?: SupportedPrisonsService
   systemTokenOverride?: SystemToken
   production?: boolean
   sessionData?: SessionData
@@ -214,6 +224,7 @@ export function appWithAllRoutes({
     visitSessionsServiceOverride,
     auditServiceOverride,
     notificationsServiceOverride,
+    supportedPrisonsServiceOverride,
     systemTokenOverride,
     production,
     sessionData,

--- a/server/services/supportedPrisonsService.test.ts
+++ b/server/services/supportedPrisonsService.test.ts
@@ -1,0 +1,43 @@
+import SupportedPrisonsService from './supportedPrisonsService'
+import prisons from '../constants/prisons'
+import VisitSchedulerApiClient from '../data/visitSchedulerApiClient'
+
+jest.mock('../data/visitSchedulerApiClient')
+
+const visitSchedulerApiClient = new VisitSchedulerApiClient(null) as jest.Mocked<VisitSchedulerApiClient>
+
+describe('Supported prisons service', () => {
+  let supportedPrisonsService: SupportedPrisonsService
+  let visitSchedulerApiClientBuilder
+  let systemToken
+
+  beforeEach(() => {
+    systemToken = async (user: string): Promise<string> => `${user}-token-1`
+    visitSchedulerApiClientBuilder = jest.fn().mockReturnValue(visitSchedulerApiClient)
+    supportedPrisonsService = new SupportedPrisonsService(visitSchedulerApiClientBuilder, systemToken)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('getSupportedPrisons', () => {
+    it('should return an array of supported prison IDs and names', async () => {
+      const supportedPrisonIds = ['HEI', 'BLI']
+      visitSchedulerApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
+
+      const results = await supportedPrisonsService.getSupportedPrisons('user')
+
+      expect(results).toEqual(prisons)
+    })
+
+    it('should ignore an unknown prison ID', async () => {
+      const supportedPrisonIds = ['HEI', 'BLI', 'unknown']
+      visitSchedulerApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
+
+      const results = await supportedPrisonsService.getSupportedPrisons('user')
+
+      expect(results).toStrictEqual(prisons)
+    })
+  })
+})

--- a/server/services/supportedPrisonsService.ts
+++ b/server/services/supportedPrisonsService.ts
@@ -1,0 +1,34 @@
+import { Prison, SystemToken } from '../@types/bapv'
+import prisons from '../constants/prisons'
+import VisitSchedulerApiClient from '../data/visitSchedulerApiClient'
+
+type VisitSchedulerApiClientBuilder = (token: string) => VisitSchedulerApiClient
+
+export default class SupportedPrisonsService {
+  constructor(
+    private readonly visitSchedulerApiClientBuilder: VisitSchedulerApiClientBuilder,
+    private readonly systemToken: SystemToken,
+  ) {}
+
+  async getSupportedPrisons(username: string): Promise<Prison[]> {
+    const prisonIds = await this.getSupportedPrisonIds(username)
+    const allPrisons = this.getAllPrisons()
+
+    const supportedPrisons = prisonIds
+      .map(prisonId => allPrisons.find(prison => prison.prisonId === prisonId))
+      .filter(prison => prison !== undefined)
+
+    return supportedPrisons
+  }
+
+  private async getSupportedPrisonIds(username: string): Promise<string[]> {
+    const token = await this.systemToken(username)
+    const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
+    return visitSchedulerApiClient.getSupportedPrisonIds()
+  }
+
+  // @TODO look up from static file to be replaced with call to Prison Register API
+  private getAllPrisons(): Prison[] {
+    return prisons
+  }
+}

--- a/server/views/pages/changeEstablishment.njk
+++ b/server/views/pages/changeEstablishment.njk
@@ -12,7 +12,7 @@
 
 {% set radios = [] %}
 
-{% for prison in enabledPrisons %}
+{% for prison in supportedPrisons %}
     {%- set radios = (radios.push({
         value: prison.prisonId,
         html: '<p class="bapv-radio-paragraph">' + prison.prisonName + '</p>',


### PR DESCRIPTION
Add initial `SupportedPrisonsService` and use this to populate the establishment switcher page.
* list of supported prison IDs is hard-coded in the visit scheduler API client until the relevant visit scheduler endpoint is completed
* A constants file is used for full prison details - longer term this can be replaced with a call to the Prison Register API