### PR TITLE
VB-1412: Keep selected establishment when clearing session

### DIFF
--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -156,7 +156,7 @@ describe('clearSession', () => {
     adultVisitors: { adults: [] },
     slotsList: {},
     visitSessionData: { prisoner: undefined },
-    selectedEstablishment: undefined,
+    selectedEstablishment: { prisonId: 'HEI', prisonName: 'Hewell (HMP)' },
   }
 
   req.session = sessionData as Session & SessionData
@@ -168,6 +168,7 @@ describe('clearSession', () => {
       returnTo: '/url',
       nowInMinutes: 123456,
       cookie: undefined,
+      selectedEstablishment: { prisonId: 'HEI', prisonName: 'Hewell (HMP)' },
     })
   })
 })

--- a/server/routes/visitorUtils.ts
+++ b/server/routes/visitorUtils.ts
@@ -40,14 +40,7 @@ export const getSupportTypeDescriptions = (
 }
 
 export const clearSession = (req: Request): void => {
-  ;[
-    'availableSupportTypes',
-    'visitorList',
-    'adultVisitors',
-    'slotsList',
-    'visitSessionData',
-    'selectedEstablishment',
-  ].forEach(sessionItem => {
+  ;['availableSupportTypes', 'visitorList', 'adultVisitors', 'slotsList', 'visitSessionData'].forEach(sessionItem => {
     delete req.session[sessionItem]
   })
 }


### PR DESCRIPTION
When `clearSession` is called, keep the `selectedEstablishment` set. This will prevent it inadvertently being defaulted to a different value to the one a user may have chosen.