### PR TITLE
VB-1388: Add feature flag for establishment switcher

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -22,6 +22,7 @@ generic-service:
     WHEREABOUTS_API_URL: "https://whereabouts-api-dev.service.justice.gov.uk"
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk/"
     SMS_NOTIFICATIONS_ENABLED: "true"
+    FEATURE_ESTABLISHMENT_SWITCHER_ENABLED: "true"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,6 +22,7 @@ generic-service:
     WHEREABOUTS_API_URL: "https://whereabouts-api-preprod.service.justice.gov.uk"
     DPS_URL: "https://digital-preprod.prison.service.justice.gov.uk/"
     SMS_NOTIFICATIONS_ENABLED: "true"
+    FEATURE_ESTABLISHMENT_SWITCHER_ENABLED: "false"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -22,6 +22,7 @@ generic-service:
     WHEREABOUTS_API_URL: "https://whereabouts-api.service.justice.gov.uk"
     DPS_URL: "https://digital.prison.service.justice.gov.uk/"
     SMS_NOTIFICATIONS_ENABLED: "true"
+    FEATURE_ESTABLISHMENT_SWITCHER_ENABLED: "false"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -22,6 +22,7 @@ generic-service:
     WHEREABOUTS_API_URL: "https://whereabouts-api-dev.service.justice.gov.uk"
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk/"
     SMS_NOTIFICATIONS_ENABLED: "true"
+    FEATURE_ESTABLISHMENT_SWITCHER_ENABLED: "false"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/server/config.ts
+++ b/server/config.ts
@@ -150,5 +150,9 @@ export default {
       },
     },
   },
+  features: {
+    establishmentSwitcherEnabled:
+      get('FEATURE_ESTABLISHMENT_SWITCHER_ENABLED', 'false', requiredInProduction) === 'true',
+  },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
 }


### PR DESCRIPTION
Adds feature flag for establishment switcher, specifically so far the `/change-establishment` route. Initially only enabled on the `dev` environment. Getting this in prior to merging #404, which will actually allow the establishment to be changed.

(Tests will be added to #404 once this is PR is in.)