### PR TITLE
VB-1402: Booking details page - show location if a supported prison

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -139,6 +139,7 @@ export default function createApp(userService: UserService): express.Application
         new SupportedPrisonsService(visitSchedulerApiClientBuilder, systemToken),
         systemToken,
       ),
+      new SupportedPrisonsService(visitSchedulerApiClientBuilder, systemToken),
     ),
   )
   app.use(

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -181,6 +181,7 @@ function appSetup({
       auditService,
       prisonerVisitorsService,
       prisonerProfileService,
+      supportedPrisonsService,
     ),
   )
   app.use(

--- a/server/services/supportedPrisonsService.test.ts
+++ b/server/services/supportedPrisonsService.test.ts
@@ -52,4 +52,16 @@ describe('Supported prisons service', () => {
       expect(results).toStrictEqual(prisons)
     })
   })
+
+  describe('getSupportedPrisonIds', () => {
+    it('should return an array of supported prison IDs', async () => {
+      const supportedPrisonIds = ['HEI', 'BLI']
+      visitSchedulerApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
+
+      const results = await supportedPrisonsService.getSupportedPrisonIds('user')
+
+      expect(visitSchedulerApiClient.getSupportedPrisonIds).toHaveBeenCalledTimes(1)
+      expect(results).toStrictEqual(supportedPrisonIds)
+    })
+  })
 })

--- a/server/services/supportedPrisonsService.ts
+++ b/server/services/supportedPrisonsService.ts
@@ -25,7 +25,7 @@ export default class SupportedPrisonsService {
     return supportedPrisons
   }
 
-  private async getSupportedPrisonIds(username: string): Promise<string[]> {
+  async getSupportedPrisonIds(username: string): Promise<string[]> {
     const token = await this.systemToken(username)
     const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
     return visitSchedulerApiClient.getSupportedPrisonIds()


### PR DESCRIPTION
Prisoner's current location currently showing as either Hewell or Unknown on booking details page. 

This change displays the prisoners current location as long as it is in the list of supported prisons. Otherwise 'Unknown' is still shown (as a precaution against, for example, revealing a transfer or similar).