### PR TITLE
VB-1401: Remove prisonId from GET /visits call

### DIFF
--- a/integration_tests/mockApis/visitScheduler.ts
+++ b/integration_tests/mockApis/visitScheduler.ts
@@ -77,7 +77,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/visitScheduler/visits\\?prisonerId=${offenderNo}&prisonId=HEI&startTimestamp=.*`,
+        urlPattern: `/visitScheduler/visits\\?prisonerId=${offenderNo}&startTimestamp=.*`,
       },
       response: {
         status: 200,
@@ -90,7 +90,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/visitScheduler/visits\\?prisonerId=${offenderNo}&prisonId=HEI&endTimestamp=.*`,
+        urlPattern: `/visitScheduler/visits\\?prisonerId=${offenderNo}&endTimestamp=.*`,
       },
       response: {
         status: 200,

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -141,14 +141,13 @@ describe('visitSchedulerApiClient', () => {
         .get('/visits')
         .query({
           prisonerId: offenderNo,
-          prisonId: 'HEI',
           startTimestamp: timestamp,
           visitStatus: 'BOOKED',
         })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, results)
 
-      const output = await client.getUpcomingVisits(offenderNo, prisonId, timestamp)
+      const output = await client.getUpcomingVisits(offenderNo, timestamp)
 
       expect(output).toEqual(results)
     })
@@ -190,14 +189,13 @@ describe('visitSchedulerApiClient', () => {
         .get('/visits')
         .query({
           prisonerId: offenderNo,
-          prisonId: 'HEI',
           endTimestamp: timestamp,
           visitStatus: 'BOOKED',
         })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, results)
 
-      const output = await client.getPastVisits(offenderNo, prisonId, timestamp)
+      const output = await client.getPastVisits(offenderNo, timestamp)
 
       expect(output).toEqual(results)
     })

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -42,24 +42,22 @@ class VisitSchedulerApiClient {
     return this.restclient.get({ path: `/visits/${reference}` })
   }
 
-  getUpcomingVisits(offenderNo: string, prisonId: string, startTimestamp?: string): Promise<Visit[]> {
+  getUpcomingVisits(offenderNo: string, startTimestamp?: string): Promise<Visit[]> {
     return this.restclient.get({
       path: '/visits',
       query: new URLSearchParams({
         prisonerId: offenderNo,
-        prisonId, // @TODO won't need this once VB-1403 resolved
         startTimestamp: startTimestamp || new Date().toISOString(),
         visitStatus: this.visitStatus,
       }).toString(),
     })
   }
 
-  getPastVisits(offenderNo: string, prisonId: string, endTimestamp?: string): Promise<Visit[]> {
+  getPastVisits(offenderNo: string, endTimestamp?: string): Promise<Visit[]> {
     return this.restclient.get({
       path: '/visits',
       query: new URLSearchParams({
         prisonerId: offenderNo,
-        prisonId, // @TODO won't need this once VB-1403 resolved
         endTimestamp: endTimestamp || new Date().toISOString(),
         visitStatus: this.visitStatus,
       }).toString(),

--- a/server/routes/prisoner.ts
+++ b/server/routes/prisoner.ts
@@ -101,7 +101,6 @@ export default function routes(
     const visits = await visitSessionsService.getUpcomingVisits({
       username: res.locals.user?.username,
       offenderNo,
-      prisonId,
     })
 
     return res.render('pages/prisoner/visits', { offenderNo, prisonerName, visits, queryParamsForBackLink })

--- a/server/services/prisonerProfileService.ts
+++ b/server/services/prisonerProfileService.ts
@@ -60,16 +60,10 @@ export default class PrisonerProfileService {
     const socialContacts = await prisonerContactRegistryApiClient.getPrisonerSocialContacts(offenderNo)
     const upcomingVisits: UpcomingVisitItem[] = await this.getUpcomingVisits(
       offenderNo,
-      inmateDetail.agencyId, // @TODO won't need this once VB-1403 resolved
       socialContacts,
       visitSchedulerApiClient,
     )
-    const pastVisits: PastVisitItem[] = await this.getPastVisits(
-      offenderNo,
-      inmateDetail.agencyId, // @TODO won't need this once VB-1403 resolved
-      socialContacts,
-      visitSchedulerApiClient,
-    )
+    const pastVisits: PastVisitItem[] = await this.getPastVisits(offenderNo, socialContacts, visitSchedulerApiClient)
 
     const activeAlertsForDisplay: PrisonerAlertItem[] = activeAlerts.map(alert => {
       return [
@@ -158,11 +152,10 @@ export default class PrisonerProfileService {
 
   private async getUpcomingVisits(
     offenderNo: string,
-    prisonId: string,
     socialContacts: Contact[],
     visitSchedulerApiClient: VisitSchedulerApiClient,
   ): Promise<UpcomingVisitItem[]> {
-    const visits: Visit[] = await visitSchedulerApiClient.getUpcomingVisits(offenderNo, prisonId)
+    const visits: Visit[] = await visitSchedulerApiClient.getUpcomingVisits(offenderNo)
     const socialVisits: Visit[] = visits.filter(visit => visit.visitType === 'SOCIAL')
 
     const visitsForDisplay: UpcomingVisitItem[] = await Promise.all(
@@ -206,11 +199,10 @@ export default class PrisonerProfileService {
 
   private async getPastVisits(
     offenderNo: string,
-    prisonId: string,
     socialContacts: Contact[],
     visitSchedulerApiClient: VisitSchedulerApiClient,
   ): Promise<PastVisitItem[]> {
-    const visits: Visit[] = await visitSchedulerApiClient.getPastVisits(offenderNo, prisonId)
+    const visits: Visit[] = await visitSchedulerApiClient.getPastVisits(offenderNo)
     const socialVisits: Visit[] = visits.filter(visit => visit.visitType === 'SOCIAL')
 
     const visitsForDisplay: PastVisitItem[] = await Promise.all(

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -860,11 +860,10 @@ describe('Visit sessions service', () => {
         const result = await visitSessionsService.getUpcomingVisits({
           username: 'user',
           offenderNo: 'A1234BC',
-          prisonId,
         })
 
         expect(visitSchedulerApiClient.getUpcomingVisits).toHaveBeenCalledTimes(1)
-        expect(visitSchedulerApiClient.getUpcomingVisits).toHaveBeenCalledWith('A1234BC', prisonId)
+        expect(visitSchedulerApiClient.getUpcomingVisits).toHaveBeenCalledWith('A1234BC')
         expect(result).toEqual(<VisitInformation[]>[
           {
             reference: 'ab-cd-ef-gh',
@@ -884,11 +883,10 @@ describe('Visit sessions service', () => {
         const result = await visitSessionsService.getUpcomingVisits({
           username: 'user',
           offenderNo: 'A1234BC',
-          prisonId,
         })
 
         expect(visitSchedulerApiClient.getUpcomingVisits).toHaveBeenCalledTimes(1)
-        expect(visitSchedulerApiClient.getUpcomingVisits).toHaveBeenCalledWith('A1234BC', prisonId)
+        expect(visitSchedulerApiClient.getUpcomingVisits).toHaveBeenCalledWith('A1234BC')
         expect(result).toEqual([])
       })
     })

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -243,17 +243,15 @@ export default class VisitSessionsService {
   async getUpcomingVisits({
     username,
     offenderNo,
-    prisonId,
   }: {
     username: string
     offenderNo: string
-    prisonId: string
   }): Promise<VisitInformation[]> {
     const token = await this.systemToken(username)
     const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
 
     logger.info(`Get upcoming visits for ${offenderNo}`)
-    const visits = await visitSchedulerApiClient.getUpcomingVisits(offenderNo, prisonId)
+    const visits = await visitSchedulerApiClient.getUpcomingVisits(offenderNo)
 
     return visits.map(visit => {
       return this.buildVisitInformation(visit)


### PR DESCRIPTION
This removes the `prisonId` parameter when calling `GET /visits` now that this is no longer required by the Visit Scheduler. 

This means that , for example, on a prisoner profile visit history tab visits from any prison will show instead of just those from the selected establishment.