### PR TITLE
VB-1450 audit event - change establishment

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -61,7 +61,10 @@ export default function createApp(userService: UserService): express.Application
   )
 
   app.use('/', indexRoutes(standardRouter(userService)))
-  app.use('/change-establishment/', establishmentRoutes(standardRouter(userService), supportedPrisonsService))
+  app.use(
+    '/change-establishment/',
+    establishmentRoutes(standardRouter(userService), supportedPrisonsService, new AuditService()),
+  )
   app.use(
     '/search/',
     searchRoutes(

--- a/server/routes/changeEstablishment.test.ts
+++ b/server/routes/changeEstablishment.test.ts
@@ -7,8 +7,10 @@ import { appWithAllRoutes, flashProvider } from './testutils/appSetup'
 import * as visitorUtils from './visitorUtils'
 import SupportedPrisonsService from '../services/supportedPrisonsService'
 import { createPrisons } from '../data/__testutils/testObjects'
+import AuditService from '../services/auditService'
 
 jest.mock('../services/supportedPrisonsService')
+jest.mock('../services/auditService')
 
 let app: Express
 const systemToken = async (user: string): Promise<string> => `${user}-token-1`
@@ -20,6 +22,8 @@ const supportedPrisonsService = new SupportedPrisonsService(
 ) as jest.Mocked<SupportedPrisonsService>
 
 const supportedPrisons = createPrisons()
+
+const auditService = new AuditService() as jest.Mocked<AuditService>
 
 beforeEach(() => {
   supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
@@ -108,6 +112,7 @@ describe('POST /change-establishment', () => {
 
     app = appWithAllRoutes({
       supportedPrisonsServiceOverride: supportedPrisonsService,
+      auditServiceOverride: auditService,
       systemTokenOverride: systemToken,
       sessionData,
     })
@@ -125,6 +130,7 @@ describe('POST /change-establishment', () => {
           { location: 'body', msg: 'No prison selected', param: 'establishment', value: '' },
         ])
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(0)
+        expect(auditService.changeEstablishment).toHaveBeenCalledTimes(0)
       })
   })
 
@@ -140,6 +146,7 @@ describe('POST /change-establishment', () => {
           { location: 'body', msg: 'No prison selected', param: 'establishment', value: 'HEX' },
         ])
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(0)
+        expect(auditService.changeEstablishment).toHaveBeenCalledTimes(0)
       })
   })
 
@@ -152,6 +159,12 @@ describe('POST /change-establishment', () => {
       .expect(() => {
         expect(sessionData.selectedEstablishment).toStrictEqual(supportedPrisons[0])
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
+        expect(auditService.changeEstablishment).toHaveBeenCalledWith({
+          originEstablishment: 'BLI',
+          newEstablishment: 'HEI',
+          username: undefined,
+          operationId: undefined,
+        })
       })
   })
 
@@ -164,6 +177,7 @@ describe('POST /change-establishment', () => {
       .expect(() => {
         expect(sessionData.selectedEstablishment).toStrictEqual(supportedPrisons[0])
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
+        expect(auditService.changeEstablishment).toHaveBeenCalledTimes(1)
       })
   })
 
@@ -176,6 +190,7 @@ describe('POST /change-establishment', () => {
       .expect(() => {
         expect(sessionData.selectedEstablishment).toStrictEqual(supportedPrisons[0])
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
+        expect(auditService.changeEstablishment).toHaveBeenCalledTimes(1)
       })
   })
 

--- a/server/routes/changeEstablishment.test.ts
+++ b/server/routes/changeEstablishment.test.ts
@@ -160,7 +160,7 @@ describe('POST /change-establishment', () => {
         expect(sessionData.selectedEstablishment).toStrictEqual(supportedPrisons[0])
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
         expect(auditService.changeEstablishment).toHaveBeenCalledWith({
-          originEstablishment: 'BLI',
+          previousEstablishment: 'BLI',
           newEstablishment: 'HEI',
           username: undefined,
           operationId: undefined,

--- a/server/routes/changeEstablishment.ts
+++ b/server/routes/changeEstablishment.ts
@@ -54,7 +54,7 @@ export default function routes(
     clearSession(req)
 
     await auditService.changeEstablishment({
-      originEstablishment: req.session.selectedEstablishment.prisonId,
+      previousEstablishment: req.session.selectedEstablishment.prisonId,
       newEstablishment: req.body.establishment,
       username: res.locals.user?.username,
       operationId: res.locals.appInsightsOperationId,

--- a/server/routes/changeEstablishment.ts
+++ b/server/routes/changeEstablishment.ts
@@ -7,8 +7,13 @@ import asyncMiddleware from '../middleware/asyncMiddleware'
 import SupportedPrisonsService from '../services/supportedPrisonsService'
 import { clearSession } from './visitorUtils'
 import { safeReturnUrl } from '../utils/utils'
+import AuditService from '../services/auditService'
 
-export default function routes(router: Router, supportedPrisonsService: SupportedPrisonsService): Router {
+export default function routes(
+  router: Router,
+  supportedPrisonsService: SupportedPrisonsService,
+  auditService: AuditService,
+): Router {
   const get = (path: string, ...handlers: RequestHandler[]) =>
     router.get(
       path,
@@ -47,6 +52,13 @@ export default function routes(router: Router, supportedPrisonsService: Supporte
     }
 
     clearSession(req)
+
+    await auditService.changeEstablishment({
+      originEstablishment: req.session.selectedEstablishment.prisonId,
+      newEstablishment: req.body.establishment,
+      username: res.locals.user?.username,
+      operationId: res.locals.appInsightsOperationId,
+    })
 
     const newEstablishment = supportedPrisons.find(prison => prison.prisonId === req.body.establishment)
     req.session.selectedEstablishment = Object.assign(req.session.selectedEstablishment ?? {}, newEstablishment)

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -117,10 +117,15 @@ function appSetup({
 
   app.use('/', indexRoutes(standardRouter(new MockUserService())))
 
+  const auditService = auditServiceOverride || new AuditService()
+
   const supportedPrisonsService =
     supportedPrisonsServiceOverride ||
     new SupportedPrisonsService(visitSchedulerApiClientBuilder, prisonRegisterApiClientBuilder, systemToken)
-  app.use('/change-establishment/', establishmentRoutes(standardRouter(new MockUserService()), supportedPrisonsService))
+  app.use(
+    '/change-establishment/',
+    establishmentRoutes(standardRouter(new MockUserService()), supportedPrisonsService, auditService),
+  )
 
   const prisonerSearchService =
     prisonerSearchServiceOverride || new PrisonerSearchService(prisonerSearchClientBuilder, systemTokenTest)
@@ -132,7 +137,6 @@ function appSetup({
       whereaboutsApiClientBuilder,
       systemTokenTest,
     )
-  const auditService = auditServiceOverride || new AuditService()
   app.use(
     '/search/',
     searchRoutes(standardRouter(new MockUserService()), prisonerSearchService, visitSessionsService, auditService),

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -62,6 +62,7 @@ export default function routes(
     const reference = getVisitReference(req)
     const fromVisitSearch = (req.query?.from as string) === 'visit-search'
     const fromVisitSearchQuery = req.query?.query as string
+    const { prisonId } = req.session.selectedEstablishment
 
     const {
       visit,
@@ -83,7 +84,7 @@ export default function routes(
     await auditService.viewedVisitDetails({
       visitReference: reference,
       prisonerId: visit.prisonerId,
-      prisonId: visit.prisonId,
+      prisonId,
       username: res.locals.user?.username,
       operationId: res.locals.appInsightsOperationId,
     })
@@ -263,6 +264,7 @@ export default function routes(
         await body(reasonFieldName).notEmpty().withMessage('Enter a reason for the cancellation').run(req)
       }
 
+      const { prisonId } = req.session.selectedEstablishment
       const errors = validationResult(req)
 
       if (!errors.isEmpty()) {
@@ -282,7 +284,7 @@ export default function routes(
       await auditService.cancelledVisit({
         visitReference: reference,
         prisonerId: visit.prisonerId.toString(),
-        prisonId: visit.prisonId,
+        prisonId,
         reason: `${req.body.cancel}: ${req.body[reasonFieldName]}`,
         username: res.locals.user?.username,
         operationId: res.locals.appInsightsOperationId,

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -62,7 +62,6 @@ export default function routes(
     const reference = getVisitReference(req)
     const fromVisitSearch = (req.query?.from as string) === 'visit-search'
     const fromVisitSearchQuery = req.query?.query as string
-    const { prisonId } = req.session.selectedEstablishment
 
     const {
       visit,
@@ -84,7 +83,7 @@ export default function routes(
     await auditService.viewedVisitDetails({
       visitReference: reference,
       prisonerId: visit.prisonerId,
-      prisonId,
+      prisonId: visit.prisonId,
       username: res.locals.user?.username,
       operationId: res.locals.appInsightsOperationId,
     })
@@ -264,7 +263,6 @@ export default function routes(
         await body(reasonFieldName).notEmpty().withMessage('Enter a reason for the cancellation').run(req)
       }
 
-      const { prisonId } = req.session.selectedEstablishment
       const errors = validationResult(req)
 
       if (!errors.isEmpty()) {
@@ -284,7 +282,7 @@ export default function routes(
       await auditService.cancelledVisit({
         visitReference: reference,
         prisonerId: visit.prisonerId.toString(),
-        prisonId,
+        prisonId: visit.prisonId,
         reason: `${req.body.cancel}: ${req.body[reasonFieldName]}`,
         username: res.locals.user?.username,
         operationId: res.locals.appInsightsOperationId,

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -32,7 +32,7 @@ describe('Audit service', () => {
 
   it('sends a change establishment message', async () => {
     await auditService.changeEstablishment({
-      originEstablishment: 'HEI',
+      previousEstablishment: 'HEI',
       newEstablishment: 'BLI',
       username: 'username',
       operationId: 'operation-id',
@@ -47,7 +47,7 @@ describe('Audit service', () => {
           operationId: 'operation-id',
           who: 'username',
           service: 'book-a-prison-visit-staff-ui',
-          details: '{"originEstablishment":"HEI","newEstablishment":"BLI"}',
+          details: '{"previousEstablishment":"HEI","newEstablishment":"BLI"}',
         }),
         QueueUrl,
       },

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -30,6 +30,30 @@ describe('Audit service', () => {
     jest.clearAllMocks()
   })
 
+  it('sends a change establishment message', async () => {
+    await auditService.changeEstablishment({
+      originEstablishment: 'HEI',
+      newEstablishment: 'BLI',
+      username: 'username',
+      operationId: 'operation-id',
+    })
+
+    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
+    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
+      input: {
+        MessageBody: JSON.stringify({
+          what: 'CHANGE_ESTABLISHMENT',
+          when: fakeDate,
+          operationId: 'operation-id',
+          who: 'username',
+          service: 'book-a-prison-visit-staff-ui',
+          details: '{"originEstablishment":"HEI","newEstablishment":"BLI"}',
+        }),
+        QueueUrl,
+      },
+    })
+  })
+
   it('sends a prisoner search audit message', async () => {
     await auditService.prisonerSearch({
       searchTerms: 'Smith',

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -22,6 +22,28 @@ export default class AuditService {
     })
   }
 
+  async changeEstablishment({
+    originEstablishment,
+    newEstablishment,
+    username,
+    operationId,
+  }: {
+    originEstablishment: string
+    newEstablishment: string
+    username: string
+    operationId: string
+  }) {
+    return this.sendAuditMessage({
+      action: 'CHANGE_ESTABLISHMENT',
+      who: username,
+      operationId,
+      details: {
+        originEstablishment,
+        newEstablishment,
+      },
+    })
+  }
+
   async prisonerSearch({
     searchTerms,
     prisonId,

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -23,12 +23,12 @@ export default class AuditService {
   }
 
   async changeEstablishment({
-    originEstablishment,
+    previousEstablishment,
     newEstablishment,
     username,
     operationId,
   }: {
-    originEstablishment: string
+    previousEstablishment: string
     newEstablishment: string
     username: string
     operationId: string
@@ -38,7 +38,7 @@ export default class AuditService {
       who: username,
       operationId,
       details: {
-        originEstablishment,
+        previousEstablishment,
         newEstablishment,
       },
     })


### PR DESCRIPTION
## Description
Added audit event messages to successful establishment changes.
Logs the old and new establishment.

The second part of the ticket has already been covered, the only audit message that doesn't use currentEstablishment is visit search, which should show the visits prison, not the users.