### PR TITLE
VB-1449, load session data when updating visit, not viewing

### DIFF
--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -594,7 +594,6 @@ describe('POST /visit/:reference', () => {
       .expect(302)
       .expect('location', '/visit/ab-cd-ef-gh/update/select-visitors')
       .expect(res => {
-        expect(auditService.overrodeZeroVO).not.toHaveBeenCalled()
         expect(clearSession).toHaveBeenCalledTimes(1)
         expect(visitSessionData).toEqual(<VisitSessionData>{
           prisoner: {

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -192,7 +192,7 @@ describe('GET /visit/:reference', () => {
     jest.useRealTimers()
   })
 
-  it('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
+  it.skip('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
     return request(app)
       .get('/visit/ab-cd-ef-gh')
       .expect(200)
@@ -305,7 +305,7 @@ describe('GET /visit/:reference', () => {
       })
   })
 
-  it('should render full booking summary page with prisoner, visit and visitor details, with default back link, formatting unknown contact telephone correctly', () => {
+  it.skip('should render full booking summary page with prisoner, visit and visitor details, with default back link, formatting unknown contact telephone correctly', () => {
     const unknownTelephoneVisit = JSON.parse(JSON.stringify(visit))
     unknownTelephoneVisit.visitContact.telephone = 'UNKNOWN'
     prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
@@ -368,7 +368,7 @@ describe('GET /visit/:reference', () => {
       })
   })
 
-  it('should render full booking summary page with prisoner, visit and visitor details with search back link when from visits', () => {
+  it.skip('should render full booking summary page with prisoner, visit and visitor details with search back link when from visits', () => {
     const url =
       '/visit/ab-cd-ef-gh?query=startDate%3D2022-05-24%26type%3DOPEN%26time%3D3pm%2Bto%2B3%253A59pm&from=visit-search'
 

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -192,7 +192,7 @@ describe('GET /visit/:reference', () => {
     jest.useRealTimers()
   })
 
-  it.skip('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
+  it('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
     return request(app)
       .get('/visit/ab-cd-ef-gh')
       .expect(200)
@@ -214,7 +214,7 @@ describe('GET /visit/:reference', () => {
         expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
         expect($('[data-test="visit-phone"]').text()).toBe('01234 567890')
         expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
-        expect($('[data-test="update-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/update/select-visitors')
+        expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
         // visitor details
         expect($('[data-test="visitor-name-1"]').text()).toBe('Smith, Jeanette')
         expect($('[data-test="visitor-dob-1"]').html()).toContain('28 July 1986')
@@ -241,71 +241,10 @@ describe('GET /visit/:reference', () => {
           username: 'user1',
           operationId: undefined,
         })
-
-        expect(clearSession).toHaveBeenCalledTimes(1)
-        expect(visitSessionData).toEqual(<VisitSessionData>{
-          prisoner: {
-            name: 'Smith, John',
-            offenderNo: 'A1234BC',
-            dateOfBirth: '1975-04-02',
-            location: '1-1-C-028, Hewell (HMP)',
-          },
-          visitSlot: {
-            id: '',
-            startTimestamp: '2022-02-09T10:00:00',
-            endTimestamp: '2022-02-09T11:15:00',
-            availableTables: 0,
-            visitRoomName: 'visit room',
-            visitRestriction: 'OPEN',
-          },
-          originalVisitSlot: {
-            id: '',
-            startTimestamp: '2022-02-09T10:00:00',
-            endTimestamp: '2022-02-09T11:15:00',
-            availableTables: 0,
-            visitRoomName: 'visit room',
-            visitRestriction: 'OPEN',
-          },
-          visitRestriction: 'OPEN',
-          visitors: [
-            {
-              address: '123 The Street,<br>Coventry',
-              adult: true,
-              banned: false,
-              dateOfBirth: '1986-07-28',
-              name: 'Jeanette Smith',
-              personId: 4321,
-              relationshipDescription: 'Sister',
-              restrictions: [
-                {
-                  globalRestriction: false,
-                  restrictionType: 'CLOSED',
-                  restrictionTypeDescription: 'Closed',
-                  startDate: '2022-01-03',
-                },
-              ],
-            },
-            {
-              address: 'Not entered',
-              adult: false,
-              banned: false,
-              dateOfBirth: '2017-01-02',
-              name: 'Anne Smith',
-              personId: 4324,
-              relationshipDescription: 'Niece',
-              restrictions: [],
-            },
-          ],
-          visitorSupport: [{ type: 'WHEELCHAIR' }, { text: 'custom request', type: 'OTHER' }],
-          mainContact: { phoneNumber: '01234 567890', contactName: 'Jeanette Smith' },
-          applicationReference: undefined,
-          visitReference: 'ab-cd-ef-gh',
-          visitStatus: 'BOOKED',
-        })
       })
   })
 
-  it.skip('should render full booking summary page with prisoner, visit and visitor details, with default back link, formatting unknown contact telephone correctly', () => {
+  it('should render full booking summary page with prisoner, visit and visitor details, with default back link, formatting unknown contact telephone correctly', () => {
     const unknownTelephoneVisit = JSON.parse(JSON.stringify(visit))
     unknownTelephoneVisit.visitContact.telephone = 'UNKNOWN'
     prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
@@ -336,7 +275,7 @@ describe('GET /visit/:reference', () => {
         expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
         expect($('[data-test="visit-phone"]').text()).toBe('Unknown')
         expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
-        expect($('[data-test="update-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/update/select-visitors')
+        expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
         // visitor details
         expect($('[data-test="visitor-name-1"]').text()).toBe('Smith, Jeanette')
         expect($('[data-test="visitor-dob-1"]').html()).toContain('28 July 1986')
@@ -363,12 +302,10 @@ describe('GET /visit/:reference', () => {
           username: 'user1',
           operationId: undefined,
         })
-
-        expect(clearSession).toHaveBeenCalledTimes(1)
       })
   })
 
-  it.skip('should render full booking summary page with prisoner, visit and visitor details with search back link when from visits', () => {
+  it('should render full booking summary page with prisoner, visit and visitor details with search back link when from visits', () => {
     const url =
       '/visit/ab-cd-ef-gh?query=startDate%3D2022-05-24%26type%3DOPEN%26time%3D3pm%2Bto%2B3%253A59pm&from=visit-search'
 
@@ -396,7 +333,7 @@ describe('GET /visit/:reference', () => {
         expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
         expect($('[data-test="visit-phone"]').text()).toBe('01234 567890')
         expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
-        expect($('[data-test="update-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/update/select-visitors')
+        expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
         // visitor details
         expect($('[data-test="visitor-name-1"]').text()).toBe('Smith, Jeanette')
         expect($('[data-test="visitor-dob-1"]').html()).toContain('28 July 1986')
@@ -423,8 +360,6 @@ describe('GET /visit/:reference', () => {
           username: 'user1',
           operationId: undefined,
         })
-
-        expect(clearSession).toHaveBeenCalledTimes(1)
       })
   })
 

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -70,403 +70,7 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('GET /visit/:reference', () => {
-  const childBirthYear = new Date().getFullYear() - 5
-
-  const prisoner: Prisoner = {
-    firstName: 'JOHN',
-    lastName: 'SMITH',
-    prisonerNumber: 'A1234BC',
-    dateOfBirth: '1975-04-02',
-    prisonId: 'HEI',
-    prisonName: 'Hewell (HMP)',
-    cellLocation: '1-1-C-028',
-    restrictedPatient: false,
-  }
-
-  let visit: Visit
-
-  const visitors: VisitorListItem[] = [
-    {
-      personId: 4321,
-      name: 'Jeanette Smith',
-      dateOfBirth: '1986-07-28',
-      adult: true,
-      relationshipDescription: 'Sister',
-      address: '123 The Street,<br>Coventry',
-      restrictions: [
-        {
-          restrictionType: 'CLOSED',
-          restrictionTypeDescription: 'Closed',
-          startDate: '2022-01-03',
-          globalRestriction: false,
-        },
-      ],
-      banned: false,
-    },
-    {
-      personId: 4324,
-      name: 'Anne Smith',
-      dateOfBirth: `${childBirthYear}-01-02`,
-      adult: false,
-      relationshipDescription: 'Niece',
-      address: 'Not entered',
-      restrictions: [],
-      banned: false,
-    },
-  ]
-
-  const additionalSupport = ['Wheelchair ramp', 'custom request']
-
-  beforeEach(() => {
-    visit = {
-      applicationReference: 'aaa-bbb-ccc',
-      reference: 'ab-cd-ef-gh',
-      prisonerId: 'A1234BC',
-      prisonId: 'HEI',
-      visitRoom: 'visit room',
-      visitType: 'SOCIAL',
-      visitStatus: 'BOOKED',
-      visitRestriction: 'OPEN',
-      startTimestamp: '2022-02-09T10:00:00',
-      endTimestamp: '2022-02-09T11:15:00',
-      visitNotes: [
-        {
-          type: 'VISIT_COMMENT',
-          text: 'Example of a visit comment',
-        },
-        {
-          type: 'VISITOR_CONCERN',
-          text: 'Example of a visitor concern',
-        },
-      ],
-      visitContact: {
-        name: 'Jeanette Smith',
-        telephone: '01234 567890',
-      },
-      visitors: [
-        {
-          nomisPersonId: 4321,
-        },
-        {
-          nomisPersonId: 4324,
-        },
-      ],
-      visitorSupport: [
-        {
-          type: 'WHEELCHAIR',
-        },
-        {
-          type: 'OTHER',
-          text: 'custom request',
-        },
-      ],
-      createdTimestamp: '2022-02-14T10:00:00',
-      modifiedTimestamp: '2022-02-14T10:05:00',
-    }
-
-    const fakeDate = new Date('2022-01-01')
-    jest.useFakeTimers({ doNotFake: ['nextTick'], now: fakeDate })
-
-    prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
-    visitSessionsService.getFullVisitDetails.mockResolvedValue({ visit, visitors, additionalSupport })
-    prisonerVisitorsService.getVisitors.mockResolvedValue(visitors)
-    supportedPrisonsService.getSupportedPrisonIds.mockResolvedValue(['HEI'])
-
-    visitSessionData = { prisoner: undefined }
-
-    app = appWithAllRoutes({
-      prisonerSearchServiceOverride: prisonerSearchService,
-      visitSessionsServiceOverride: visitSessionsService,
-      auditServiceOverride: auditService,
-      prisonerVisitorsServiceOverride: prisonerVisitorsService,
-      supportedPrisonsServiceOverride: supportedPrisonsService,
-      systemTokenOverride: systemToken,
-      // sessionData: {
-      // visitSessionData,
-      // } as SessionData,
-    })
-  })
-
-  afterAll(() => {
-    jest.useRealTimers()
-  })
-
-  it('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
-    return request(app)
-      .get('/visit/ab-cd-ef-gh')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('h1').text()).toBe('Booking details')
-        expect($('.govuk-back-link').attr('href')).toBe('/prisoner/A1234BC/visits')
-        expect($('[data-test="reference"]').text()).toBe('ab-cd-ef-gh')
-        // prisoner details
-        expect($('[data-test="prisoner-name"]').text()).toBe('Smith, John')
-        expect($('[data-test="prisoner-number"]').text()).toBe('A1234BC')
-        expect($('[data-test="prisoner-dob"]').text()).toBe('2 April 1975')
-        expect($('[data-test="prisoner-location"]').text()).toBe('1-1-C-028, Hewell (HMP)')
-        // visit details
-        expect($('[data-test="visit-date"]').text()).toBe('9 February 2022')
-        expect($('[data-test="visit-time"]').text()).toBe('10am to 11:15am')
-        expect($('[data-test="visit-type"]').text()).toBe('Open')
-        expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
-        expect($('[data-test="visit-phone"]').text()).toBe('01234 567890')
-        expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
-        expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
-        // visitor details
-        expect($('[data-test="visitor-name-1"]').text()).toBe('Smith, Jeanette')
-        expect($('[data-test="visitor-dob-1"]').html()).toContain('28 July 1986')
-        expect($('[data-test="visitor-relationship-1"]').text()).toBe('Sister')
-        expect($('[data-test="visitor-address-1"]').html()).toBe('123 The Street,<br>Coventry')
-        expect($('[data-test="visitor-restrictions-1"] .visitor-restriction-badge--CLOSED').text()).toBe('Closed')
-        expect($('[data-test="visitor-restrictions-1"]').text()).toContain('End date not entered')
-        expect($('[data-test="visitor-name-2"]').text()).toBe('Smith, Anne')
-        expect($('[data-test="visitor-dob-2"]').html()).toContain(`2 January ${childBirthYear}`)
-        expect($('[data-test="visitor-relationship-2"]').text()).toBe('Niece')
-        expect($('[data-test="visitor-address-2"]').html()).toBe('Not entered')
-        expect($('[data-test="visitor-restrictions-2"]').text()).toBe('None')
-        // additional info
-        expect($('[data-test="visit-comment"]').eq(0).text()).toBe('Example of a visit comment')
-        expect($('[data-test="visitor-concern"]').eq(0).text()).toBe('Example of a visitor concern')
-        expect($('[data-test="additional-support"]').text()).toBe('Wheelchair ramp, custom request')
-        expect($('[data-test="visit-booked"]').text()).toBe('Monday 14 February 2022 at 10am')
-
-        expect(auditService.viewedVisitDetails).toHaveBeenCalledTimes(1)
-        expect(auditService.viewedVisitDetails).toHaveBeenCalledWith({
-          visitReference: 'ab-cd-ef-gh',
-          prisonerId: 'A1234BC',
-          prisonId: 'HEI',
-          username: 'user1',
-          operationId: undefined,
-        })
-      })
-  })
-
-  it('should render full booking summary page with prisoner, visit and visitor details, with default back link, formatting unknown contact telephone correctly', () => {
-    const unknownTelephoneVisit = JSON.parse(JSON.stringify(visit))
-    unknownTelephoneVisit.visitContact.telephone = 'UNKNOWN'
-    prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
-    visitSessionsService.getFullVisitDetails.mockResolvedValue({
-      visit: unknownTelephoneVisit,
-      visitors,
-      additionalSupport,
-    })
-
-    return request(app)
-      .get('/visit/ab-cd-ef-gh')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('h1').text()).toBe('Booking details')
-        expect($('.govuk-back-link').attr('href')).toBe('/prisoner/A1234BC/visits')
-        expect($('[data-test="reference"]').text()).toBe('ab-cd-ef-gh')
-        // prisoner details
-        expect($('[data-test="prisoner-name"]').text()).toBe('Smith, John')
-        expect($('[data-test="prisoner-number"]').text()).toBe('A1234BC')
-        expect($('[data-test="prisoner-dob"]').text()).toBe('2 April 1975')
-        expect($('[data-test="prisoner-location"]').text()).toBe('1-1-C-028, Hewell (HMP)')
-        // visit details
-        expect($('[data-test="visit-date"]').text()).toBe('9 February 2022')
-        expect($('[data-test="visit-time"]').text()).toBe('10am to 11:15am')
-        expect($('[data-test="visit-type"]').text()).toBe('Open')
-        expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
-        expect($('[data-test="visit-phone"]').text()).toBe('Unknown')
-        expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
-        expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
-        // visitor details
-        expect($('[data-test="visitor-name-1"]').text()).toBe('Smith, Jeanette')
-        expect($('[data-test="visitor-dob-1"]').html()).toContain('28 July 1986')
-        expect($('[data-test="visitor-relationship-1"]').text()).toBe('Sister')
-        expect($('[data-test="visitor-address-1"]').html()).toBe('123 The Street,<br>Coventry')
-        expect($('[data-test="visitor-restrictions-1"] .visitor-restriction-badge--CLOSED').text()).toBe('Closed')
-        expect($('[data-test="visitor-restrictions-1"]').text()).toContain('End date not entered')
-        expect($('[data-test="visitor-name-2"]').text()).toBe('Smith, Anne')
-        expect($('[data-test="visitor-dob-2"]').html()).toContain(`2 January ${childBirthYear}`)
-        expect($('[data-test="visitor-relationship-2"]').text()).toBe('Niece')
-        expect($('[data-test="visitor-address-2"]').html()).toBe('Not entered')
-        expect($('[data-test="visitor-restrictions-2"]').text()).toBe('None')
-        // additional info
-        expect($('[data-test="visit-comment"]').eq(0).text()).toBe('Example of a visit comment')
-        expect($('[data-test="visitor-concern"]').eq(0).text()).toBe('Example of a visitor concern')
-        expect($('[data-test="additional-support"]').text()).toBe('Wheelchair ramp, custom request')
-        expect($('[data-test="visit-booked"]').text()).toBe('Monday 14 February 2022 at 10am')
-
-        expect(auditService.viewedVisitDetails).toHaveBeenCalledTimes(1)
-        expect(auditService.viewedVisitDetails).toHaveBeenCalledWith({
-          visitReference: 'ab-cd-ef-gh',
-          prisonerId: 'A1234BC',
-          prisonId: 'HEI',
-          username: 'user1',
-          operationId: undefined,
-        })
-      })
-  })
-
-  it('should render full booking summary page with prisoner, visit and visitor details with search back link when from visits', () => {
-    const url =
-      '/visit/ab-cd-ef-gh?query=startDate%3D2022-05-24%26type%3DOPEN%26time%3D3pm%2Bto%2B3%253A59pm&from=visit-search'
-
-    prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
-    visitSessionsService.getFullVisitDetails.mockResolvedValue({ visit, visitors, additionalSupport })
-
-    return request(app)
-      .get(url)
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('h1').text()).toBe('Booking details')
-        expect($('.govuk-back-link').attr('href')).toBe('/visits?startDate=2022-05-24&type=OPEN&time=3pm+to+3%3A59pm')
-        expect($('[data-test="reference"]').text()).toBe('ab-cd-ef-gh')
-        // prisoner details
-        expect($('[data-test="prisoner-name"]').text()).toBe('Smith, John')
-        expect($('[data-test="prisoner-number"]').text()).toBe('A1234BC')
-        expect($('[data-test="prisoner-dob"]').text()).toBe('2 April 1975')
-        expect($('[data-test="prisoner-location"]').text()).toBe('1-1-C-028, Hewell (HMP)')
-        // visit details
-        expect($('[data-test="visit-date"]').text()).toBe('9 February 2022')
-        expect($('[data-test="visit-time"]').text()).toBe('10am to 11:15am')
-        expect($('[data-test="visit-type"]').text()).toBe('Open')
-        expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
-        expect($('[data-test="visit-phone"]').text()).toBe('01234 567890')
-        expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
-        expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
-        // visitor details
-        expect($('[data-test="visitor-name-1"]').text()).toBe('Smith, Jeanette')
-        expect($('[data-test="visitor-dob-1"]').html()).toContain('28 July 1986')
-        expect($('[data-test="visitor-relationship-1"]').text()).toBe('Sister')
-        expect($('[data-test="visitor-address-1"]').html()).toBe('123 The Street,<br>Coventry')
-        expect($('[data-test="visitor-restrictions-1"] .visitor-restriction-badge--CLOSED').text()).toBe('Closed')
-        expect($('[data-test="visitor-restrictions-1"]').text()).toContain('End date not entered')
-        expect($('[data-test="visitor-name-2"]').text()).toBe('Smith, Anne')
-        expect($('[data-test="visitor-dob-2"]').html()).toContain(`2 January ${childBirthYear}`)
-        expect($('[data-test="visitor-relationship-2"]').text()).toBe('Niece')
-        expect($('[data-test="visitor-address-2"]').html()).toBe('Not entered')
-        expect($('[data-test="visitor-restrictions-2"]').text()).toBe('None')
-        // additional info
-        expect($('[data-test="visit-comment"]').eq(0).text()).toBe('Example of a visit comment')
-        expect($('[data-test="visitor-concern"]').eq(0).text()).toBe('Example of a visitor concern')
-        expect($('[data-test="additional-support"]').text()).toBe('Wheelchair ramp, custom request')
-        expect($('[data-test="visit-booked"]').text()).toBe('Monday 14 February 2022 at 10am')
-
-        expect(auditService.viewedVisitDetails).toHaveBeenCalledTimes(1)
-        expect(auditService.viewedVisitDetails).toHaveBeenCalledWith({
-          visitReference: 'ab-cd-ef-gh',
-          prisonerId: 'A1234BC',
-          prisonId: 'HEI',
-          username: 'user1',
-          operationId: undefined,
-        })
-      })
-  })
-
-  it('should render full booking summary page with prisoner location showing as "Unknown" if not a supported prison', () => {
-    const transferPrisoner: Prisoner = {
-      firstName: 'JOHN',
-      lastName: 'SMITH',
-      prisonerNumber: 'A1234BC',
-      dateOfBirth: '1975-04-02',
-      prisonId: 'TRN',
-      prisonName: 'Transfer',
-      restrictedPatient: false,
-    }
-
-    prisonerSearchService.getPrisonerById.mockResolvedValue(transferPrisoner)
-
-    return request(app)
-      .get('/visit/ab-cd-ef-gh')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('h1').text()).toBe('Booking details')
-        expect($('.govuk-back-link').attr('href')).toBe('/prisoner/A1234BC/visits')
-        expect($('[data-test="reference"]').text()).toBe('ab-cd-ef-gh')
-        // prisoner details
-        expect($('[data-test="prisoner-name"]').text()).toBe('Smith, John')
-        expect($('[data-test="prisoner-number"]').text()).toBe('A1234BC')
-        expect($('[data-test="prisoner-dob"]').text()).toBe('2 April 1975')
-        expect($('[data-test="prisoner-location"]').text()).toBe('Unknown')
-      })
-  })
-
-  it('should render 400 Bad Request error for invalid visit reference', () => {
-    return request(app)
-      .get('/visit/12-34-56-78')
-      .expect(400)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('BadRequestError: Bad Request')
-      })
-  })
-
-  it('should not display update and cancel buttons if visit is cancelled', () => {
-    visit.visitStatus = 'CANCELLED'
-    visit.outcomeStatus = 'ADMINISTRATIVE_CANCELLATION'
-    visit.visitNotes = [{ type: 'VISIT_OUTCOMES', text: 'booking error' }]
-    return request(app)
-      .get('/visit/ab-cd-ef-gh')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('[data-test="cancel-visit"]').length).toBe(0)
-        expect($('[data-test="update-visit"]').length).toBe(0)
-      })
-  })
-
-  it('should not display update and cancel buttons if start date has passed', () => {
-    const visitDate = new Date(visit.startTimestamp)
-    const testDate = visitDate.setFullYear(visitDate.getFullYear() + 1)
-    jest.useFakeTimers({ advanceTimers: true, now: testDate })
-    return request(app)
-      .get('/visit/ab-cd-ef-gh')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('[data-test="cancel-visit"]').length).toBe(0)
-        expect($('[data-test="update-visit"]').length).toBe(0)
-      })
-  })
-
-  it('should display cancelled message - administrative', () => {
-    visit.visitStatus = 'CANCELLED'
-    visit.outcomeStatus = 'ADMINISTRATIVE_CANCELLATION'
-    visit.visitNotes = [{ type: 'VISIT_OUTCOMES', text: 'booking error' }]
-    return request(app)
-      .get('/visit/ab-cd-ef-gh')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('[data-test="cancelled-visit-reason"]').text()).toContain(
-          'due to an administrative error with the booking',
-        )
-        expect($('[data-test="cancelled-visit-reason"]').text()).toContain('booking error')
-      })
-  })
-
-  it('should display cancelled message - visitor cancelled', () => {
-    visit.visitStatus = 'CANCELLED'
-    visit.outcomeStatus = 'VISITOR_CANCELLED'
-    visit.visitNotes = [{ type: 'VISIT_OUTCOMES', text: 'no longer required' }]
-    return request(app)
-      .get('/visit/ab-cd-ef-gh')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('[data-test="cancelled-visit-reason"]').text()).toContain('by the visitor')
-        expect($('[data-test="cancelled-visit-reason"]').text()).toContain('no longer required')
-      })
-  })
-})
-
-describe('POST /visit/:reference', () => {
+describe('/visit/:reference', () => {
   const childBirthYear = new Date().getFullYear() - 5
 
   const prisoner: Prisoner = {
@@ -588,73 +192,361 @@ describe('POST /visit/:reference', () => {
     jest.useRealTimers()
   })
 
-  it('should set up sessionData and redirect to select visitors page', () => {
-    return request(app)
-      .post('/visit/ab-cd-ef-gh')
-      .expect(302)
-      .expect('location', '/visit/ab-cd-ef-gh/update/select-visitors')
-      .expect(res => {
-        expect(clearSession).toHaveBeenCalledTimes(1)
-        expect(visitSessionData).toEqual(<VisitSessionData>{
-          prisoner: {
-            name: 'Smith, John',
-            offenderNo: 'A1234BC',
-            dateOfBirth: '1975-04-02',
-            location: '1-1-C-028, Hewell (HMP)',
-          },
-          visitSlot: {
-            id: '',
-            startTimestamp: '2022-02-09T10:00:00',
-            endTimestamp: '2022-02-09T11:15:00',
-            availableTables: 0,
-            visitRoomName: 'visit room',
-            visitRestriction: 'OPEN',
-          },
-          originalVisitSlot: {
-            id: '',
-            startTimestamp: '2022-02-09T10:00:00',
-            endTimestamp: '2022-02-09T11:15:00',
-            availableTables: 0,
-            visitRoomName: 'visit room',
-            visitRestriction: 'OPEN',
-          },
-          visitRestriction: 'OPEN',
-          visitors: [
-            {
-              address: '123 The Street,<br>Coventry',
-              adult: true,
-              banned: false,
-              dateOfBirth: '1986-07-28',
-              name: 'Jeanette Smith',
-              personId: 4321,
-              relationshipDescription: 'Sister',
-              restrictions: [
-                {
-                  globalRestriction: false,
-                  restrictionType: 'CLOSED',
-                  restrictionTypeDescription: 'Closed',
-                  startDate: '2022-01-03',
-                },
-              ],
-            },
-            {
-              address: 'Not entered',
-              adult: false,
-              banned: false,
-              dateOfBirth: '2017-01-02',
-              name: 'Anne Smith',
-              personId: 4324,
-              relationshipDescription: 'Niece',
-              restrictions: [],
-            },
-          ],
-          visitorSupport: [{ type: 'WHEELCHAIR' }, { text: 'custom request', type: 'OTHER' }],
-          mainContact: { phoneNumber: '01234 567890', contactName: 'Jeanette Smith' },
-          applicationReference: undefined,
-          visitReference: 'ab-cd-ef-gh',
-          visitStatus: 'BOOKED',
+  describe('GET /visit/:reference', () => {
+    it('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
+      return request(app)
+        .get('/visit/ab-cd-ef-gh')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('Booking details')
+          expect($('.govuk-back-link').attr('href')).toBe('/prisoner/A1234BC/visits')
+          expect($('[data-test="reference"]').text()).toBe('ab-cd-ef-gh')
+          // prisoner details
+          expect($('[data-test="prisoner-name"]').text()).toBe('Smith, John')
+          expect($('[data-test="prisoner-number"]').text()).toBe('A1234BC')
+          expect($('[data-test="prisoner-dob"]').text()).toBe('2 April 1975')
+          expect($('[data-test="prisoner-location"]').text()).toBe('1-1-C-028, Hewell (HMP)')
+          // visit details
+          expect($('[data-test="visit-date"]').text()).toBe('9 February 2022')
+          expect($('[data-test="visit-time"]').text()).toBe('10am to 11:15am')
+          expect($('[data-test="visit-type"]').text()).toBe('Open')
+          expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
+          expect($('[data-test="visit-phone"]').text()).toBe('01234 567890')
+          expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
+          expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
+          // visitor details
+          expect($('[data-test="visitor-name-1"]').text()).toBe('Smith, Jeanette')
+          expect($('[data-test="visitor-dob-1"]').html()).toContain('28 July 1986')
+          expect($('[data-test="visitor-relationship-1"]').text()).toBe('Sister')
+          expect($('[data-test="visitor-address-1"]').html()).toBe('123 The Street,<br>Coventry')
+          expect($('[data-test="visitor-restrictions-1"] .visitor-restriction-badge--CLOSED').text()).toBe('Closed')
+          expect($('[data-test="visitor-restrictions-1"]').text()).toContain('End date not entered')
+          expect($('[data-test="visitor-name-2"]').text()).toBe('Smith, Anne')
+          expect($('[data-test="visitor-dob-2"]').html()).toContain(`2 January ${childBirthYear}`)
+          expect($('[data-test="visitor-relationship-2"]').text()).toBe('Niece')
+          expect($('[data-test="visitor-address-2"]').html()).toBe('Not entered')
+          expect($('[data-test="visitor-restrictions-2"]').text()).toBe('None')
+          // additional info
+          expect($('[data-test="visit-comment"]').eq(0).text()).toBe('Example of a visit comment')
+          expect($('[data-test="visitor-concern"]').eq(0).text()).toBe('Example of a visitor concern')
+          expect($('[data-test="additional-support"]').text()).toBe('Wheelchair ramp, custom request')
+          expect($('[data-test="visit-booked"]').text()).toBe('Monday 14 February 2022 at 10am')
+          expect(visitSessionData).toEqual({ prisoner: undefined })
+
+          expect(auditService.viewedVisitDetails).toHaveBeenCalledTimes(1)
+          expect(auditService.viewedVisitDetails).toHaveBeenCalledWith({
+            visitReference: 'ab-cd-ef-gh',
+            prisonerId: 'A1234BC',
+            prisonId: 'HEI',
+            username: 'user1',
+            operationId: undefined,
+          })
         })
+    })
+
+    it('should render full booking summary page with prisoner, visit and visitor details, with default back link, formatting unknown contact telephone correctly', () => {
+      const unknownTelephoneVisit = JSON.parse(JSON.stringify(visit))
+      unknownTelephoneVisit.visitContact.telephone = 'UNKNOWN'
+      prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
+      visitSessionsService.getFullVisitDetails.mockResolvedValue({
+        visit: unknownTelephoneVisit,
+        visitors,
+        additionalSupport,
       })
+
+      return request(app)
+        .get('/visit/ab-cd-ef-gh')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('Booking details')
+          expect($('.govuk-back-link').attr('href')).toBe('/prisoner/A1234BC/visits')
+          expect($('[data-test="reference"]').text()).toBe('ab-cd-ef-gh')
+          // prisoner details
+          expect($('[data-test="prisoner-name"]').text()).toBe('Smith, John')
+          expect($('[data-test="prisoner-number"]').text()).toBe('A1234BC')
+          expect($('[data-test="prisoner-dob"]').text()).toBe('2 April 1975')
+          expect($('[data-test="prisoner-location"]').text()).toBe('1-1-C-028, Hewell (HMP)')
+          // visit details
+          expect($('[data-test="visit-date"]').text()).toBe('9 February 2022')
+          expect($('[data-test="visit-time"]').text()).toBe('10am to 11:15am')
+          expect($('[data-test="visit-type"]').text()).toBe('Open')
+          expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
+          expect($('[data-test="visit-phone"]').text()).toBe('Unknown')
+          expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
+          expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
+          // visitor details
+          expect($('[data-test="visitor-name-1"]').text()).toBe('Smith, Jeanette')
+          expect($('[data-test="visitor-dob-1"]').html()).toContain('28 July 1986')
+          expect($('[data-test="visitor-relationship-1"]').text()).toBe('Sister')
+          expect($('[data-test="visitor-address-1"]').html()).toBe('123 The Street,<br>Coventry')
+          expect($('[data-test="visitor-restrictions-1"] .visitor-restriction-badge--CLOSED').text()).toBe('Closed')
+          expect($('[data-test="visitor-restrictions-1"]').text()).toContain('End date not entered')
+          expect($('[data-test="visitor-name-2"]').text()).toBe('Smith, Anne')
+          expect($('[data-test="visitor-dob-2"]').html()).toContain(`2 January ${childBirthYear}`)
+          expect($('[data-test="visitor-relationship-2"]').text()).toBe('Niece')
+          expect($('[data-test="visitor-address-2"]').html()).toBe('Not entered')
+          expect($('[data-test="visitor-restrictions-2"]').text()).toBe('None')
+          // additional info
+          expect($('[data-test="visit-comment"]').eq(0).text()).toBe('Example of a visit comment')
+          expect($('[data-test="visitor-concern"]').eq(0).text()).toBe('Example of a visitor concern')
+          expect($('[data-test="additional-support"]').text()).toBe('Wheelchair ramp, custom request')
+          expect($('[data-test="visit-booked"]').text()).toBe('Monday 14 February 2022 at 10am')
+
+          expect(auditService.viewedVisitDetails).toHaveBeenCalledTimes(1)
+          expect(auditService.viewedVisitDetails).toHaveBeenCalledWith({
+            visitReference: 'ab-cd-ef-gh',
+            prisonerId: 'A1234BC',
+            prisonId: 'HEI',
+            username: 'user1',
+            operationId: undefined,
+          })
+        })
+    })
+
+    it('should render full booking summary page with prisoner, visit and visitor details with search back link when from visits', () => {
+      const url =
+        '/visit/ab-cd-ef-gh?query=startDate%3D2022-05-24%26type%3DOPEN%26time%3D3pm%2Bto%2B3%253A59pm&from=visit-search'
+
+      prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
+      visitSessionsService.getFullVisitDetails.mockResolvedValue({ visit, visitors, additionalSupport })
+
+      return request(app)
+        .get(url)
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('Booking details')
+          expect($('.govuk-back-link').attr('href')).toBe('/visits?startDate=2022-05-24&type=OPEN&time=3pm+to+3%3A59pm')
+          expect($('[data-test="reference"]').text()).toBe('ab-cd-ef-gh')
+          // prisoner details
+          expect($('[data-test="prisoner-name"]').text()).toBe('Smith, John')
+          expect($('[data-test="prisoner-number"]').text()).toBe('A1234BC')
+          expect($('[data-test="prisoner-dob"]').text()).toBe('2 April 1975')
+          expect($('[data-test="prisoner-location"]').text()).toBe('1-1-C-028, Hewell (HMP)')
+          // visit details
+          expect($('[data-test="visit-date"]').text()).toBe('9 February 2022')
+          expect($('[data-test="visit-time"]').text()).toBe('10am to 11:15am')
+          expect($('[data-test="visit-type"]').text()).toBe('Open')
+          expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
+          expect($('[data-test="visit-phone"]').text()).toBe('01234 567890')
+          expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
+          expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
+          // visitor details
+          expect($('[data-test="visitor-name-1"]').text()).toBe('Smith, Jeanette')
+          expect($('[data-test="visitor-dob-1"]').html()).toContain('28 July 1986')
+          expect($('[data-test="visitor-relationship-1"]').text()).toBe('Sister')
+          expect($('[data-test="visitor-address-1"]').html()).toBe('123 The Street,<br>Coventry')
+          expect($('[data-test="visitor-restrictions-1"] .visitor-restriction-badge--CLOSED').text()).toBe('Closed')
+          expect($('[data-test="visitor-restrictions-1"]').text()).toContain('End date not entered')
+          expect($('[data-test="visitor-name-2"]').text()).toBe('Smith, Anne')
+          expect($('[data-test="visitor-dob-2"]').html()).toContain(`2 January ${childBirthYear}`)
+          expect($('[data-test="visitor-relationship-2"]').text()).toBe('Niece')
+          expect($('[data-test="visitor-address-2"]').html()).toBe('Not entered')
+          expect($('[data-test="visitor-restrictions-2"]').text()).toBe('None')
+          // additional info
+          expect($('[data-test="visit-comment"]').eq(0).text()).toBe('Example of a visit comment')
+          expect($('[data-test="visitor-concern"]').eq(0).text()).toBe('Example of a visitor concern')
+          expect($('[data-test="additional-support"]').text()).toBe('Wheelchair ramp, custom request')
+          expect($('[data-test="visit-booked"]').text()).toBe('Monday 14 February 2022 at 10am')
+
+          expect(auditService.viewedVisitDetails).toHaveBeenCalledTimes(1)
+          expect(auditService.viewedVisitDetails).toHaveBeenCalledWith({
+            visitReference: 'ab-cd-ef-gh',
+            prisonerId: 'A1234BC',
+            prisonId: 'HEI',
+            username: 'user1',
+            operationId: undefined,
+          })
+        })
+    })
+
+    it('should render full booking summary page with prisoner location showing as "Unknown" if not a supported prison', () => {
+      const transferPrisoner: Prisoner = {
+        firstName: 'JOHN',
+        lastName: 'SMITH',
+        prisonerNumber: 'A1234BC',
+        dateOfBirth: '1975-04-02',
+        prisonId: 'TRN',
+        prisonName: 'Transfer',
+        restrictedPatient: false,
+      }
+
+      prisonerSearchService.getPrisonerById.mockResolvedValue(transferPrisoner)
+
+      return request(app)
+        .get('/visit/ab-cd-ef-gh')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('Booking details')
+          expect($('.govuk-back-link').attr('href')).toBe('/prisoner/A1234BC/visits')
+          expect($('[data-test="reference"]').text()).toBe('ab-cd-ef-gh')
+          // prisoner details
+          expect($('[data-test="prisoner-name"]').text()).toBe('Smith, John')
+          expect($('[data-test="prisoner-number"]').text()).toBe('A1234BC')
+          expect($('[data-test="prisoner-dob"]').text()).toBe('2 April 1975')
+          expect($('[data-test="prisoner-location"]').text()).toBe('Unknown')
+        })
+    })
+
+    it('should render 400 Bad Request error for invalid visit reference', () => {
+      return request(app)
+        .get('/visit/12-34-56-78')
+        .expect(400)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('BadRequestError: Bad Request')
+        })
+    })
+
+    it('should not display update and cancel buttons if visit is cancelled', () => {
+      visit.visitStatus = 'CANCELLED'
+      visit.outcomeStatus = 'ADMINISTRATIVE_CANCELLATION'
+      visit.visitNotes = [{ type: 'VISIT_OUTCOMES', text: 'booking error' }]
+      return request(app)
+        .get('/visit/ab-cd-ef-gh')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test="cancel-visit"]').length).toBe(0)
+          expect($('[data-test="update-visit"]').length).toBe(0)
+        })
+    })
+
+    it('should not display update and cancel buttons if start date has passed', () => {
+      const visitDate = new Date(visit.startTimestamp)
+      const testDate = visitDate.setFullYear(visitDate.getFullYear() + 1)
+      jest.useFakeTimers({ advanceTimers: true, now: testDate })
+      return request(app)
+        .get('/visit/ab-cd-ef-gh')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test="cancel-visit"]').length).toBe(0)
+          expect($('[data-test="update-visit"]').length).toBe(0)
+        })
+    })
+
+    it('should display cancelled message - administrative', () => {
+      visit.visitStatus = 'CANCELLED'
+      visit.outcomeStatus = 'ADMINISTRATIVE_CANCELLATION'
+      visit.visitNotes = [{ type: 'VISIT_OUTCOMES', text: 'booking error' }]
+      return request(app)
+        .get('/visit/ab-cd-ef-gh')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test="cancelled-visit-reason"]').text()).toContain(
+            'due to an administrative error with the booking',
+          )
+          expect($('[data-test="cancelled-visit-reason"]').text()).toContain('booking error')
+        })
+    })
+
+    it('should display cancelled message - visitor cancelled', () => {
+      visit.visitStatus = 'CANCELLED'
+      visit.outcomeStatus = 'VISITOR_CANCELLED'
+      visit.visitNotes = [{ type: 'VISIT_OUTCOMES', text: 'no longer required' }]
+      return request(app)
+        .get('/visit/ab-cd-ef-gh')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test="cancelled-visit-reason"]').text()).toContain('by the visitor')
+          expect($('[data-test="cancelled-visit-reason"]').text()).toContain('no longer required')
+        })
+    })
+  })
+
+  describe('POST /visit/:reference', () => {
+    it('should set up sessionData and redirect to select visitors page', () => {
+      return request(app)
+        .post('/visit/ab-cd-ef-gh')
+        .expect(302)
+        .expect('location', '/visit/ab-cd-ef-gh/update/select-visitors')
+        .expect(res => {
+          expect(clearSession).toHaveBeenCalledTimes(1)
+          expect(visitSessionData).toEqual(<VisitSessionData>{
+            prisoner: {
+              name: 'Smith, John',
+              offenderNo: 'A1234BC',
+              dateOfBirth: '1975-04-02',
+              location: '1-1-C-028, Hewell (HMP)',
+            },
+            visitSlot: {
+              id: '',
+              startTimestamp: '2022-02-09T10:00:00',
+              endTimestamp: '2022-02-09T11:15:00',
+              availableTables: 0,
+              visitRoomName: 'visit room',
+              visitRestriction: 'OPEN',
+            },
+            originalVisitSlot: {
+              id: '',
+              startTimestamp: '2022-02-09T10:00:00',
+              endTimestamp: '2022-02-09T11:15:00',
+              availableTables: 0,
+              visitRoomName: 'visit room',
+              visitRestriction: 'OPEN',
+            },
+            visitRestriction: 'OPEN',
+            visitors: [
+              {
+                address: '123 The Street,<br>Coventry',
+                adult: true,
+                banned: false,
+                dateOfBirth: '1986-07-28',
+                name: 'Jeanette Smith',
+                personId: 4321,
+                relationshipDescription: 'Sister',
+                restrictions: [
+                  {
+                    globalRestriction: false,
+                    restrictionType: 'CLOSED',
+                    restrictionTypeDescription: 'Closed',
+                    startDate: '2022-01-03',
+                  },
+                ],
+              },
+              {
+                address: 'Not entered',
+                adult: false,
+                banned: false,
+                dateOfBirth: '2017-01-02',
+                name: 'Anne Smith',
+                personId: 4324,
+                relationshipDescription: 'Niece',
+                restrictions: [],
+              },
+            ],
+            visitorSupport: [{ type: 'WHEELCHAIR' }, { text: 'custom request', type: 'OTHER' }],
+            mainContact: { phoneNumber: '01234 567890', contactName: 'Jeanette Smith' },
+            applicationReference: undefined,
+            visitReference: 'ab-cd-ef-gh',
+            visitStatus: 'BOOKED',
+          })
+        })
+    })
+
+    it('should render 400 Bad Request error for invalid visit reference', () => {
+      return request(app)
+        .post('/visit/12-34-56-78')
+        .expect(400)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('BadRequestError: Bad Request')
+        })
+    })
   })
 })
 

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -88,47 +88,6 @@ export default function routes(
       operationId: res.locals.appInsightsOperationId,
     })
 
-    // const visitorIds = visit.visitors.flatMap(visitor => visitor.nomisPersonId)
-    // const mainContactVisitor = visit.visitors.find(visitor => visitor.visitContact)
-    // const mainContactId = mainContactVisitor ? mainContactVisitor.nomisPersonId : null
-    // const visitorList = await prisonerVisitorsService.getVisitors(visit.prisonerId, res.locals.user?.username)
-    // const currentVisitors = visitorList.filter(visitor => visitorIds.includes(visitor.personId))
-    // const mainContact = currentVisitors.find(visitor => visitor.personId === mainContactId)
-
-    // clean then load session
-    // clearSession(req)
-    // const visitSlot: VisitSlot = {
-    //   id: '',
-    //   startTimestamp: visit.startTimestamp,
-    //   endTimestamp: visit.endTimestamp,
-    //   availableTables: 0,
-    //   capacity: undefined,
-    //   visitRoomName: visit.visitRoom,
-    //   visitRestriction: visit.visitRestriction,
-    // }
-    // const visitSessionData: VisitSessionData = {
-    //   prisoner: {
-    //     name: properCaseFullName(`${prisoner.lastName}, ${prisoner.firstName}`),
-    //     offenderNo: prisoner.prisonerNumber,
-    //     dateOfBirth: prisoner.dateOfBirth,
-    //     location: prisonerLocation,
-    //   },
-    //   visitSlot,
-    //   originalVisitSlot: visitSlot,
-    //   visitRestriction: visit.visitRestriction,
-    //   visitors: currentVisitors,
-    //   visitorSupport: visit.visitorSupport,
-    //   mainContact: {
-    //     contact: mainContact,
-    //     phoneNumber: visit.visitContact.telephone,
-    //     contactName: visit.visitContact.name,
-    //   },
-    //   visitReference: visit.reference,
-    //   visitStatus: visit.visitStatus,
-    // }
-
-    // req.session.visitSessionData = Object.assign(req.session.visitSessionData ?? {}, visitSessionData)
-
     const nowTimestamp = new Date()
     const visitStartTimestamp = new Date(visit.startTimestamp)
     const showButtons = nowTimestamp < visitStartTimestamp

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -88,6 +88,78 @@ export default function routes(
       operationId: res.locals.appInsightsOperationId,
     })
 
+    // const visitorIds = visit.visitors.flatMap(visitor => visitor.nomisPersonId)
+    // const mainContactVisitor = visit.visitors.find(visitor => visitor.visitContact)
+    // const mainContactId = mainContactVisitor ? mainContactVisitor.nomisPersonId : null
+    // const visitorList = await prisonerVisitorsService.getVisitors(visit.prisonerId, res.locals.user?.username)
+    // const currentVisitors = visitorList.filter(visitor => visitorIds.includes(visitor.personId))
+    // const mainContact = currentVisitors.find(visitor => visitor.personId === mainContactId)
+
+    // clean then load session
+    // clearSession(req)
+    // const visitSlot: VisitSlot = {
+    //   id: '',
+    //   startTimestamp: visit.startTimestamp,
+    //   endTimestamp: visit.endTimestamp,
+    //   availableTables: 0,
+    //   capacity: undefined,
+    //   visitRoomName: visit.visitRoom,
+    //   visitRestriction: visit.visitRestriction,
+    // }
+    // const visitSessionData: VisitSessionData = {
+    //   prisoner: {
+    //     name: properCaseFullName(`${prisoner.lastName}, ${prisoner.firstName}`),
+    //     offenderNo: prisoner.prisonerNumber,
+    //     dateOfBirth: prisoner.dateOfBirth,
+    //     location: prisonerLocation,
+    //   },
+    //   visitSlot,
+    //   originalVisitSlot: visitSlot,
+    //   visitRestriction: visit.visitRestriction,
+    //   visitors: currentVisitors,
+    //   visitorSupport: visit.visitorSupport,
+    //   mainContact: {
+    //     contact: mainContact,
+    //     phoneNumber: visit.visitContact.telephone,
+    //     contactName: visit.visitContact.name,
+    //   },
+    //   visitReference: visit.reference,
+    //   visitStatus: visit.visitStatus,
+    // }
+
+    // req.session.visitSessionData = Object.assign(req.session.visitSessionData ?? {}, visitSessionData)
+
+    const nowTimestamp = new Date()
+    const visitStartTimestamp = new Date(visit.startTimestamp)
+    const showButtons = nowTimestamp < visitStartTimestamp
+
+    return res.render('pages/visit/summary', {
+      prisoner,
+      prisonerLocation,
+      visit,
+      visitors,
+      additionalSupport,
+      fromVisitSearch,
+      fromVisitSearchQuery,
+      showButtons,
+    })
+  })
+
+  post('/:reference', async (req, res) => {
+    const reference = getVisitReference(req)
+
+    const { visit }: { visit: Visit } = await visitSessionsService.getFullVisitDetails({
+      reference,
+      username: res.locals.user?.username,
+    })
+
+    const prisoner: Prisoner = await prisonerSearchService.getPrisonerById(visit.prisonerId, res.locals.user?.username)
+    const supportedPrisonIds = await supportedPrisonsService.getSupportedPrisonIds(res.locals.user?.username)
+
+    const prisonerLocation = supportedPrisonIds.includes(prisoner.prisonId)
+      ? `${prisoner.cellLocation}, ${prisoner.prisonName}`
+      : 'Unknown'
+
     const visitorIds = visit.visitors.flatMap(visitor => visitor.nomisPersonId)
     const mainContactVisitor = visit.visitors.find(visitor => visitor.visitContact)
     const mainContactId = mainContactVisitor ? mainContactVisitor.nomisPersonId : null
@@ -129,20 +201,7 @@ export default function routes(
 
     req.session.visitSessionData = Object.assign(req.session.visitSessionData ?? {}, visitSessionData)
 
-    const nowTimestamp = new Date()
-    const visitStartTimestamp = new Date(visitSessionData.visitSlot.startTimestamp)
-    const showButtons = nowTimestamp < visitStartTimestamp
-
-    return res.render('pages/visit/summary', {
-      prisoner,
-      prisonerLocation,
-      visit,
-      visitors,
-      additionalSupport,
-      fromVisitSearch,
-      fromVisitSearchQuery,
-      showButtons,
-    })
+    return res.redirect(`/visit/${reference}/update/select-visitors`)
   })
 
   const selectVisitors = new SelectVisitors('update', prisonerVisitorsService, prisonerProfileService)

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -76,9 +76,7 @@ export default function routes(
     const prisoner: Prisoner = await prisonerSearchService.getPrisonerById(visit.prisonerId, res.locals.user?.username)
     const supportedPrisonIds = await supportedPrisonsService.getSupportedPrisonIds(res.locals.user?.username)
 
-    const prisonerLocation = supportedPrisonIds.includes(prisoner.prisonId)
-      ? `${prisoner.cellLocation}, ${prisoner.prisonName}`
-      : 'Unknown'
+    const prisonerLocation = getPrisonerLocation(supportedPrisonIds, prisoner)
 
     await auditService.viewedVisitDetails({
       visitReference: reference,
@@ -115,9 +113,7 @@ export default function routes(
     const prisoner: Prisoner = await prisonerSearchService.getPrisonerById(visit.prisonerId, res.locals.user?.username)
     const supportedPrisonIds = await supportedPrisonsService.getSupportedPrisonIds(res.locals.user?.username)
 
-    const prisonerLocation = supportedPrisonIds.includes(prisoner.prisonId)
-      ? `${prisoner.cellLocation}, ${prisoner.prisonName}`
-      : 'Unknown'
+    const prisonerLocation = getPrisonerLocation(supportedPrisonIds, prisoner)
 
     const visitorIds = visit.visitors.flatMap(visitor => visitor.nomisPersonId)
     const mainContactVisitor = visit.visitors.find(visitor => visitor.visitContact)
@@ -339,6 +335,10 @@ function getVisitReference(req: Request): string {
     throw new BadRequest()
   }
   return reference
+}
+
+function getPrisonerLocation(supportedPrisonIds: string[], prisoner: Prisoner) {
+  return supportedPrisonIds.includes(prisoner.prisonId) ? `${prisoner.cellLocation}, ${prisoner.prisonName}` : 'Unknown'
 }
 
 const checkVisitReferenceMiddleware = (req: Request, res: Response, next: NextFunction): void => {

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -104,14 +104,21 @@
         {% if showButtons %}
           {% set cancelButtonClasses = 'govuk-!-margin-top-5 govuk-button--secondary' %}
           {% if visit.visitStatus === 'BOOKED' %}
-            {# If update journey abled and visit is booked, do this #}
-            {{ govukButton({
-              text: "Update booking",
-              classes: "govuk-!-margin-top-5",
-              href: "/visit/" + visit.reference + "/update/select-visitors",
-              attributes: { "data-test": "update-visit" },
-              preventDoubleClick: true
-            }) }}
+
+
+            <form action="/visit/{{ visit.reference }}" method="POST" novalidate>
+              <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+              {{ govukButton({
+                text: "Update booking",
+                classes: "govuk-!-margin-top-5",
+                attributes: { "data-test": "update-visit" },
+                preventDoubleClick: true
+              }) }}
+            </form>
+
+
+           
             {{ govukButton({
               text: "Cancel booking",
               classes: cancelButtonClasses,

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -104,18 +104,14 @@
         {% if showButtons %}
           {% set cancelButtonClasses = 'govuk-!-margin-top-5 govuk-button--secondary' %}
           {% if visit.visitStatus === 'BOOKED' %}
-
-
             <form action="/visit/{{ visit.reference }}" method="POST" novalidate>
               <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
               {{ govukButton({
                 text: "Update booking",
                 classes: "govuk-!-margin-top-5",
                 attributes: { "data-test": "update-visit" },
                 preventDoubleClick: true
               }) }}
-            
               {{ govukButton({
                 text: "Cancel booking",
                 classes: cancelButtonClasses,
@@ -123,7 +119,6 @@
                 attributes: { "data-test": "cancel-visit" },
                 preventDoubleClick: true
               }) }}
-
             </form>
           {% endif %}
         {% endif %}

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -115,17 +115,16 @@
                 attributes: { "data-test": "update-visit" },
                 preventDoubleClick: true
               }) }}
+            
+              {{ govukButton({
+                text: "Cancel booking",
+                classes: cancelButtonClasses,
+                href: "/visit/" + visit.reference + "/cancel",
+                attributes: { "data-test": "cancel-visit" },
+                preventDoubleClick: true
+              }) }}
+
             </form>
-
-
-           
-            {{ govukButton({
-              text: "Cancel booking",
-              classes: cancelButtonClasses,
-              href: "/visit/" + visit.reference + "/cancel",
-              attributes: { "data-test": "cancel-visit" },
-              preventDoubleClick: true
-            }) }}
           {% endif %}
         {% endif %}
 


### PR DESCRIPTION
Session data is now populated when entering the update journey, instead of when viewing a visit.

test data is used for both GET and POST methods, instead of having copies in each describe block