### PR TITLE
VB-1412: Default selected establishment to user's active caseload

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -17,3 +17,5 @@ VISIT_SCHEDULER_API_URL=http://localhost:9091/visitScheduler
 PRISONER_CONTACT_REGISTRY_API_URL=http://localhost:9091/contactRegistry
 WHEREABOUTS_API_URL=http://localhost:9091/whereabouts
 PRISON_REGISTER_API_URL=http://localhost:9091/prisonRegister
+
+FEATURE_ESTABLISHMENT_SWITCHER_ENABLED=true

--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -8,6 +8,8 @@ context('SignIn', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubGetSupportedPrisonIds')
+    cy.task('stubGetPrisons')
   })
 
   it('Unauthenticated user directed to auth', () => {

--- a/integration_tests/e2e/searchForAPrisoner.cy.ts
+++ b/integration_tests/e2e/searchForAPrisoner.cy.ts
@@ -27,6 +27,8 @@ context('Search for a prisoner', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubGetSupportedPrisonIds')
+    cy.task('stubGetPrisons')
   })
 
   it('should show Search For A Prisoner page', () => {
@@ -190,8 +192,6 @@ context('Search for a prisoner', () => {
           cy.task('stubGetUpcomingVisits', { offenderNo: prisonerNumber, upcomingVisits })
           cy.task('stubGetPastVisits', { offenderNo: prisonerNumber, pastVisits })
           cy.task('stubGetPrisonerSocialContacts', prisonerNumber)
-          cy.task('stubGetSupportedPrisonIds')
-          cy.task('stubGetPrisons')
           searchForAPrisonerResultsPage.firstResultLink().click()
 
           const prisonerProfilePage = new PrisonerProfilePage(pageTitle)

--- a/server/app.ts
+++ b/server/app.ts
@@ -60,15 +60,19 @@ export default function createApp(userService: UserService): express.Application
     systemToken,
   )
 
-  app.use('/', indexRoutes(standardRouter(userService)))
+  app.use('/', indexRoutes(standardRouter(userService, supportedPrisonsService)))
   app.use(
     '/change-establishment/',
-    establishmentRoutes(standardRouter(userService), supportedPrisonsService, new AuditService()),
+    establishmentRoutes(
+      standardRouter(userService, supportedPrisonsService),
+      supportedPrisonsService,
+      new AuditService(),
+    ),
   )
   app.use(
     '/search/',
     searchRoutes(
-      standardRouter(userService),
+      standardRouter(userService, supportedPrisonsService),
       new PrisonerSearchService(prisonerSearchClientBuilder, systemToken),
       new VisitSessionsService(
         prisonerContactRegistryApiClientBuilder,
@@ -82,7 +86,7 @@ export default function createApp(userService: UserService): express.Application
   app.use(
     '/prisoner/',
     prisonerRoutes(
-      standardRouter(userService),
+      standardRouter(userService, supportedPrisonsService),
       new PrisonerProfileService(
         prisonApiClientBuilder,
         visitSchedulerApiClientBuilder,
@@ -103,7 +107,7 @@ export default function createApp(userService: UserService): express.Application
   app.use(
     '/book-a-visit/',
     bookAVisitRoutes(
-      standardRouter(userService),
+      standardRouter(userService, supportedPrisonsService),
       new PrisonerVisitorsService(prisonerContactRegistryApiClientBuilder, systemToken),
       new VisitSessionsService(
         prisonerContactRegistryApiClientBuilder,
@@ -125,7 +129,7 @@ export default function createApp(userService: UserService): express.Application
   app.use(
     '/visit/',
     visitRoutes(
-      standardRouter(userService),
+      standardRouter(userService, supportedPrisonsService),
       new PrisonerSearchService(prisonerSearchClientBuilder, systemToken),
       new VisitSessionsService(
         prisonerContactRegistryApiClientBuilder,
@@ -149,7 +153,7 @@ export default function createApp(userService: UserService): express.Application
   app.use(
     '/visits/',
     visitsRoutes(
-      standardRouter(userService),
+      standardRouter(userService, supportedPrisonsService),
       new PrisonerSearchService(prisonerSearchClientBuilder, systemToken),
       new VisitSessionsService(
         prisonerContactRegistryApiClientBuilder,

--- a/server/middleware/populateSelectedEstablishment.test.ts
+++ b/server/middleware/populateSelectedEstablishment.test.ts
@@ -1,15 +1,36 @@
 import { Request, Response } from 'express'
 import { Cookie } from 'express-session'
 import { Prison } from '../@types/bapv'
+import config from '../config'
+import { User } from '../data/hmppsAuthClient'
+import { createSupportedPrisons } from '../data/__testutils/testObjects'
+import SupportedPrisonsService from '../services/supportedPrisonsService'
 import populateSelectedEstablishment from './populateSelectedEstablishment'
 
-describe('populateSelectedEstablishment', () => {
-  let req: Partial<Request>
-  const res: Partial<Response> = { locals: undefined }
-  const next = jest.fn()
+jest.mock('../services/supportedPrisonsService')
 
+const systemToken = async (user: string): Promise<string> => `${user}-token-1`
+
+const supportedPrisonsService = new SupportedPrisonsService(
+  null,
+  null,
+  systemToken,
+) as jest.Mocked<SupportedPrisonsService>
+
+const supportedPrisons = createSupportedPrisons()
+supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
+
+let req: Request
+const res = {
+  locals: {},
+  redirect: jest.fn(),
+} as unknown as Response
+const next = jest.fn()
+
+describe('populateSelectedEstablishment', () => {
   beforeEach(() => {
     req = {
+      originalUrl: '/',
       session: {
         regenerate: jest.fn(),
         destroy: jest.fn(),
@@ -20,27 +41,111 @@ describe('populateSelectedEstablishment', () => {
         touch: jest.fn(),
         cookie: new Cookie(),
       },
+    } as unknown as Request
+
+    res.locals = {
+      selectedEstablishment: <Prison>undefined,
+      user: <User>{ activeCaseLoadId: 'HEI' },
     }
 
-    res.locals = {}
+    config.features.establishmentSwitcherEnabled = true
   })
 
-  it('should set default establishment if non is set in session and populate res.locals', () => {
-    const defaultEstablishment: Prison = { prisonId: 'HEI', prisonName: 'Hewell (HMP)' }
-
-    populateSelectedEstablishment(req as Request, res as Response, next)
-
-    expect(req.session.selectedEstablishment).toEqual(defaultEstablishment)
-    expect(res.locals.selectedEstablishment).toEqual(defaultEstablishment)
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
-  it('should populate res.locals when establishment already set in session', () => {
-    const alreadySelectedEstablishment: Prison = { prisonId: 'BLI', prisonName: 'Bristol (HMP)' }
-    req.session.selectedEstablishment = alreadySelectedEstablishment
+  describe('establishment switcher feature flag', () => {
+    it('should default to selecting Hewell if feature disabled (even if active case load is different)', async () => {
+      config.features.establishmentSwitcherEnabled = false
+      res.locals.user.activeCaseLoadId = 'BLI'
 
-    populateSelectedEstablishment(req as Request, res as Response, next)
+      const expectedEstablishment: Prison = { prisonId: 'HEI', prisonName: supportedPrisons.HEI }
 
-    expect(req.session.selectedEstablishment).toEqual(alreadySelectedEstablishment)
-    expect(res.locals.selectedEstablishment).toEqual(alreadySelectedEstablishment)
+      await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
+
+      expect(supportedPrisonsService.getSupportedPrisons).toHaveBeenCalledTimes(1)
+      expect(req.session.selectedEstablishment).toStrictEqual(expectedEstablishment)
+      expect(res.locals.selectedEstablishment).toStrictEqual(expectedEstablishment)
+    })
+  })
+
+  describe('when establishment not already set in session', () => {
+    it('should set establishment in session and populate res.locals if active caseload is a supported prison', async () => {
+      res.locals.user.activeCaseLoadId = 'BLI'
+
+      const expectedEstablishment: Prison = { prisonId: 'BLI', prisonName: supportedPrisons.BLI }
+
+      await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
+
+      expect(supportedPrisonsService.getSupportedPrisons).toHaveBeenCalledTimes(1)
+      expect(req.session.selectedEstablishment).toStrictEqual(expectedEstablishment)
+      expect(res.locals.selectedEstablishment).toStrictEqual(expectedEstablishment)
+    })
+
+    it('should redirect to /change-establishment if no establishment set and active caseload is not a supported prison', async () => {
+      res.locals.user.activeCaseLoadId = 'XYZ'
+
+      await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
+
+      expect(supportedPrisonsService.getSupportedPrisons).toHaveBeenCalledTimes(1)
+      expect(res.redirect).toHaveBeenCalledWith('/change-establishment')
+      expect(req.session.selectedEstablishment).toBe(undefined)
+      expect(res.locals.selectedEstablishment).toBe(undefined)
+    })
+
+    it('should redirect to /change-establishment if no establishment set and active caseload is not set', async () => {
+      res.locals.user.activeCaseLoadId = undefined
+
+      await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
+
+      expect(supportedPrisonsService.getSupportedPrisons).toHaveBeenCalledTimes(1)
+      expect(req.session.selectedEstablishment).toBe(undefined)
+      expect(res.locals.selectedEstablishment).toBe(undefined)
+      expect(res.redirect).toHaveBeenCalledWith('/change-establishment')
+    })
+
+    it('should make no changes and not redirect if request path is /change-establishment', async () => {
+      req.originalUrl = '/change-establishment'
+
+      await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
+
+      expect(supportedPrisonsService.getSupportedPrisons).toHaveBeenCalledTimes(0)
+      expect(req.session.selectedEstablishment).toBe(undefined)
+      expect(res.locals.selectedEstablishment).toBe(undefined)
+      expect(res.redirect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when establishment already set in session', () => {
+    it('should populate res.locals with selected establishment without prisons lookup', async () => {
+      req.session.selectedEstablishment = { prisonId: 'HEI', prisonName: supportedPrisons.HEI }
+
+      await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
+
+      expect(supportedPrisonsService.getSupportedPrisons).not.toHaveBeenCalled()
+      expect(res.locals.selectedEstablishment).toStrictEqual(req.session.selectedEstablishment)
+    })
+
+    it('should populate res.locals with already selected establishment without prisons lookup if active caseload changes', async () => {
+      res.locals.user.activeCaseLoadId = 'BLI'
+      req.session.selectedEstablishment = { prisonId: 'HEI', prisonName: supportedPrisons.HEI }
+
+      await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
+
+      expect(supportedPrisonsService.getSupportedPrisons).not.toHaveBeenCalled()
+      expect(res.locals.selectedEstablishment).toStrictEqual(req.session.selectedEstablishment)
+    })
+
+    it('should make no changes and not redirect if request path is /change-establishment', async () => {
+      req.originalUrl = '/change-establishment'
+      res.locals.user.activeCaseLoadId = 'BLI'
+      req.session.selectedEstablishment = { prisonId: 'HEI', prisonName: supportedPrisons.HEI }
+
+      await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
+
+      expect(supportedPrisonsService.getSupportedPrisons).not.toHaveBeenCalled()
+      expect(res.locals.selectedEstablishment).toStrictEqual(req.session.selectedEstablishment)
+    })
   })
 })

--- a/server/middleware/populateSelectedEstablishment.ts
+++ b/server/middleware/populateSelectedEstablishment.ts
@@ -1,11 +1,12 @@
 import type { RequestHandler } from 'express'
 import config from '../config'
 import SupportedPrisonsService from '../services/supportedPrisonsService'
+import asyncMiddleware from './asyncMiddleware'
 
 export default function populateSelectedEstablishment(
   supportedPrisonsService: SupportedPrisonsService,
 ): RequestHandler {
-  return async (req, res, next) => {
+  return asyncMiddleware(async (req, res, next) => {
     // using req.originalUrl rather than ideally req.path as this was causing problems
     // because of middleware sometimes being called twice (expected to be resolved in VB-1430)
     if (req.session.selectedEstablishment === undefined && !req.originalUrl.startsWith('/change-establishment')) {
@@ -26,5 +27,5 @@ export default function populateSelectedEstablishment(
     res.locals.selectedEstablishment = req.session.selectedEstablishment
 
     return next()
-  }
+  })
 }

--- a/server/middleware/populateSelectedEstablishment.ts
+++ b/server/middleware/populateSelectedEstablishment.ts
@@ -15,13 +15,13 @@ export default function populateSelectedEstablishment(
       // Override active caseload with Hewell if establishment switcher feature not enabled
       const activeCaseLoadId = config.features.establishmentSwitcherEnabled ? res.locals.user.activeCaseLoadId : 'HEI'
 
-      if (supportedPrisons[activeCaseLoadId]) {
-        req.session.selectedEstablishment = {
-          prisonId: activeCaseLoadId,
-          prisonName: supportedPrisons[activeCaseLoadId],
-        }
-      } else {
+      if (!supportedPrisons[activeCaseLoadId]) {
         return res.redirect('/change-establishment')
+      }
+
+      req.session.selectedEstablishment = {
+        prisonId: activeCaseLoadId,
+        prisonName: supportedPrisons[activeCaseLoadId],
       }
     }
     res.locals.selectedEstablishment = req.session.selectedEstablishment

--- a/server/routes/changeEstablishment.test.ts
+++ b/server/routes/changeEstablishment.test.ts
@@ -36,7 +36,7 @@ afterEach(() => {
 })
 
 describe('GET /change-establishment', () => {
-  it('should render select establishment page, with default establishment selected', () => {
+  it('should render select establishment page with none selected', () => {
     app = appWithAllRoutes({
       supportedPrisonsServiceOverride: supportedPrisonsService,
       systemTokenOverride: systemToken,
@@ -49,8 +49,9 @@ describe('GET /change-establishment', () => {
         const $ = cheerio.load(res.text)
         expect($('h1').text()).toBe('Select establishment')
         expect($('input[name="establishment"]').eq(0).prop('value')).toBe('HEI')
-        expect($('input[name="establishment"]').eq(0).prop('checked')).toBe(true)
+        expect($('input[name="establishment"]').eq(0).prop('checked')).toBe(false)
         expect($('input[name="establishment"]').eq(1).prop('value')).toBe('BLI')
+        expect($('input[name="establishment"]').eq(1).prop('checked')).toBe(false)
         expect($('input[name="establishment"]').length).toBe(2)
         expect($('form').attr('action')).toBe('/change-establishment?referrer=/search/prisoner/')
       })
@@ -170,7 +171,7 @@ describe('POST /change-establishment', () => {
         expect(auditService.changeEstablishment).toHaveBeenCalledWith({
           previousEstablishment: 'BLI',
           newEstablishment: 'HEI',
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })

--- a/server/routes/changeEstablishment.ts
+++ b/server/routes/changeEstablishment.ts
@@ -7,6 +7,7 @@ import SupportedPrisonsService from '../services/supportedPrisonsService'
 import { clearSession } from './visitorUtils'
 import { safeReturnUrl } from '../utils/utils'
 import AuditService from '../services/auditService'
+import { Prison } from '../@types/bapv'
 
 export default function routes(
   router: Router,
@@ -52,16 +53,20 @@ export default function routes(
 
     clearSession(req)
 
+    const previousEstablishment = req.session.selectedEstablishment?.prisonId
+    const newEstablishment: Prison = {
+      prisonId: req.body.establishment,
+      prisonName: supportedPrisons[req.body.establishment],
+    }
+
+    req.session.selectedEstablishment = Object.assign(req.session.selectedEstablishment ?? {}, newEstablishment)
+
     await auditService.changeEstablishment({
-      previousEstablishment: req.session.selectedEstablishment.prisonId,
-      newEstablishment: req.body.establishment,
+      previousEstablishment,
+      newEstablishment: newEstablishment.prisonId,
       username: res.locals.user?.username,
       operationId: res.locals.appInsightsOperationId,
     })
-
-    const { selectedEstablishment } = req.session
-    selectedEstablishment.prisonId = req.body.establishment
-    selectedEstablishment.prisonName = supportedPrisons[req.body.establishment]
 
     return res.redirect(redirectUrl)
   })

--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -172,7 +172,7 @@ describe('GET /prisoner/A1234BC', () => {
         expect(auditService.viewPrisoner).toHaveBeenCalledWith({
           prisonerId: 'A1234BC',
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -216,7 +216,7 @@ describe('GET /prisoner/A1234BC', () => {
         expect(auditService.viewPrisoner).toHaveBeenCalledWith({
           prisonerId: 'A1234BC',
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -241,7 +241,7 @@ describe('GET /prisoner/A1234BC', () => {
         expect(auditService.viewPrisoner).toHaveBeenCalledWith({
           prisonerId: 'A1234BC',
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -267,7 +267,7 @@ describe('GET /prisoner/A1234BC', () => {
         expect(auditService.viewPrisoner).toHaveBeenCalledWith({
           prisonerId: 'A1234BC',
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -292,7 +292,7 @@ describe('GET /prisoner/A1234BC', () => {
         expect(auditService.viewPrisoner).toHaveBeenCalledWith({
           prisonerId: 'A1234BC',
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -329,7 +329,7 @@ describe('GET /prisoner/A1234BC', () => {
         expect(auditService.viewPrisoner).toHaveBeenCalledWith({
           prisonerId: 'A1234BC',
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -377,7 +377,7 @@ describe('POST /prisoner/A1234BC', () => {
       .expect('location', '/book-a-visit/select-visitors')
       .expect(res => {
         expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledTimes(1)
-        expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', prisonId, undefined)
+        expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', prisonId, 'user1')
         expect(auditService.overrodeZeroVO).not.toHaveBeenCalled()
         expect(clearSession).toHaveBeenCalledTimes(1)
         expect(visitSessionData).toEqual(<VisitSessionData>{
@@ -401,11 +401,11 @@ describe('POST /prisoner/A1234BC', () => {
       .expect('location', '/book-a-visit/select-visitors')
       .expect(res => {
         expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledTimes(1)
-        expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', prisonId, undefined)
+        expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', prisonId, 'user1')
         expect(auditService.overrodeZeroVO).toHaveBeenCalledTimes(1)
         expect(auditService.overrodeZeroVO).toHaveBeenCalledWith({
           prisonerId: 'A1234BC',
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
         expect(clearSession).toHaveBeenCalledTimes(1)
@@ -434,7 +434,7 @@ describe('POST /prisoner/A1234BC', () => {
       .expect('location', '/book-a-visit/select-visitors')
       .expect(res => {
         expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledTimes(1)
-        expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', prisonId, undefined)
+        expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', prisonId, 'user1')
         expect(auditService.overrodeZeroVO).not.toHaveBeenCalled()
         expect(visitSessionData).toEqual(<VisitSessionData>{
           prisoner: {
@@ -456,7 +456,7 @@ describe('POST /prisoner/A1234BC', () => {
       .expect('location', '/prisoner/A1234BC')
       .expect(res => {
         expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledTimes(1)
-        expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', prisonId, undefined)
+        expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', prisonId, 'user1')
         expect(auditService.overrodeZeroVO).not.toHaveBeenCalled()
         expect(visitSessionData).toEqual({})
         expect(flashProvider).toHaveBeenCalledWith('errors', [

--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -104,7 +104,7 @@ describe('Prisoner search page', () => {
             expect(auditService.prisonerSearch).toHaveBeenCalledWith({
               searchTerms: 'A1234BC',
               prisonId,
-              username: undefined,
+              username: 'user1',
               operationId: undefined,
             })
             expect(prisonerSearchService.getPrisoners).toHaveBeenCalledTimes(1)
@@ -159,7 +159,7 @@ describe('Prisoner search page', () => {
             expect(auditService.prisonerSearch).toHaveBeenCalledWith({
               searchTerms: 'A1234BC',
               prisonId,
-              username: undefined,
+              username: 'user1',
               operationId: undefined,
             })
             expect(prisonerSearchService.getPrisoners).toHaveBeenCalledTimes(1)
@@ -199,7 +199,7 @@ describe('Prisoner search page', () => {
             expect(auditService.prisonerSearch).toHaveBeenCalledWith({
               searchTerms: 'A1234BC',
               prisonId,
-              username: undefined,
+              username: 'user1',
               operationId: undefined,
             })
             expect(prisonerSearchService.getPrisoners).toHaveBeenCalledTimes(1)
@@ -252,7 +252,7 @@ describe('Prisoner search page', () => {
           .expect(res => {
             expect(res.text).toContain('Search for a prisoner')
             expect(res.text).toContain('id="search-results-none"')
-            expect(mockGetPrisoners).toHaveBeenCalledWith('A1234BC', prisonId, undefined, 1, true)
+            expect(mockGetPrisoners).toHaveBeenCalledWith('A1234BC', prisonId, 'user1', 1, true)
           })
       })
     })
@@ -434,7 +434,7 @@ describe('Booking search page', () => {
           expect(auditService.visitSearch).toHaveBeenCalledTimes(1)
           expect(auditService.visitSearch).toHaveBeenCalledWith({
             searchTerms: 'ab-bc-cd-de',
-            username: undefined,
+            username: 'user1',
             operationId: undefined,
           })
         })
@@ -469,7 +469,7 @@ describe('Booking search page', () => {
           expect(auditService.visitSearch).toHaveBeenCalledTimes(1)
           expect(auditService.visitSearch).toHaveBeenCalledWith({
             searchTerms: 'ab-bc-cd-de',
-            username: undefined,
+            username: 'user1',
             operationId: undefined,
           })
         })

--- a/server/routes/standardRouter.ts
+++ b/server/routes/standardRouter.ts
@@ -5,15 +5,19 @@ import tokenVerifier from '../data/tokenVerification'
 import populateCurrentUser from '../middleware/populateCurrentUser'
 import populateSelectedEstablishment from '../middleware/populateSelectedEstablishment'
 import type UserService from '../services/userService'
+import SupportedPrisonsService from '../services/supportedPrisonsService'
 
 const testMode = process.env.NODE_ENV === 'test'
 
-export default function standardRouter(userService: UserService): Router {
+export default function standardRouter(
+  userService: UserService,
+  supportedPrisonsService: SupportedPrisonsService,
+): Router {
   const router = Router({ mergeParams: true })
 
   router.use(auth.authenticationMiddleware(tokenVerifier))
   router.use(populateCurrentUser(userService))
-  router.use(populateSelectedEstablishment)
+  router.use(populateSelectedEstablishment(supportedPrisonsService))
 
   // CSRF protection
   if (!testMode) {

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -238,7 +238,7 @@ describe('GET /visit/:reference', () => {
           visitReference: 'ab-cd-ef-gh',
           prisonerId: 'A1234BC',
           prisonId: 'HEI',
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
 
@@ -360,7 +360,7 @@ describe('GET /visit/:reference', () => {
           visitReference: 'ab-cd-ef-gh',
           prisonerId: 'A1234BC',
           prisonId: 'HEI',
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
 
@@ -420,7 +420,7 @@ describe('GET /visit/:reference', () => {
           visitReference: 'ab-cd-ef-gh',
           prisonerId: 'A1234BC',
           prisonId: 'HEI',
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
 
@@ -667,7 +667,7 @@ describe('POST /visit/:reference/cancel', () => {
       .expect(() => {
         expect(visitSessionsService.cancelVisit).toHaveBeenCalledTimes(1)
         expect(visitSessionsService.cancelVisit).toHaveBeenCalledWith({
-          username: undefined,
+          username: 'user1',
           reference: 'ab-cd-ef-gh',
           outcome: <OutcomeDto>{
             outcomeStatus: 'PRISONER_CANCELLED',
@@ -682,7 +682,7 @@ describe('POST /visit/:reference/cancel', () => {
           prisonerId: 'AF34567G',
           prisonId: 'HEI',
           reason: 'PRISONER_CANCELLED: illness',
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
         expect(notificationsService.sendCancellationSms).toHaveBeenCalledTimes(1)

--- a/server/routes/visitJourney/checkYourBooking.test.ts
+++ b/server/routes/visitJourney/checkYourBooking.test.ts
@@ -242,7 +242,7 @@ testJourneys.forEach(journey => {
               startTimestamp: '2022-03-12T09:30:00',
               endTimestamp: '2022-03-12T10:30:00',
               visitRestriction: 'OPEN',
-              username: undefined,
+              username: 'user1',
               operationId: undefined,
             })
             expect(notificationsService[journey.isUpdate ? 'sendUpdateSms' : 'sendBookingSms']).toHaveBeenCalledTimes(1)

--- a/server/routes/visitJourney/dateAndTime.test.ts
+++ b/server/routes/visitJourney/dateAndTime.test.ts
@@ -333,7 +333,7 @@ testJourneys.forEach(journey => {
               startTimestamp: '2022-02-14T11:59:00',
               endTimestamp: '2022-02-14T12:59:00',
               visitRestriction: 'OPEN',
-              username: undefined,
+              username: 'user1',
               operationId: undefined,
             })
           })
@@ -397,7 +397,7 @@ testJourneys.forEach(journey => {
               startTimestamp: '2022-02-14T12:00:00',
               endTimestamp: '2022-02-14T13:05:00',
               visitRestriction: 'OPEN',
-              username: undefined,
+              username: 'user1',
               operationId: undefined,
             })
           })

--- a/server/routes/visitJourney/visitType.test.ts
+++ b/server/routes/visitJourney/visitType.test.ts
@@ -149,7 +149,7 @@ testJourneys.forEach(journey => {
               prisonerId: visitSessionData.prisoner.offenderNo,
               visitRestriction: 'OPEN',
               visitorIds: [visitSessionData.visitors[0].personId.toString()],
-              username: undefined,
+              username: 'user1',
               operationId: undefined,
             })
           })
@@ -169,7 +169,7 @@ testJourneys.forEach(journey => {
               prisonerId: visitSessionData.prisoner.offenderNo,
               visitRestriction: 'CLOSED',
               visitorIds: [visitSessionData.visitors[0].personId.toString()],
-              username: undefined,
+              username: 'user1',
               operationId: undefined,
             })
           })

--- a/server/routes/visits.test.ts
+++ b/server/routes/visits.test.ts
@@ -235,7 +235,7 @@ describe('GET /visits', () => {
         expect(auditService.viewedVisits).toHaveBeenCalledWith({
           viewDate: todayDate,
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -267,7 +267,7 @@ describe('GET /visits', () => {
         expect(auditService.viewedVisits).toHaveBeenCalledWith({
           viewDate: '2022-05-23',
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -299,7 +299,7 @@ describe('GET /visits', () => {
         expect(auditService.viewedVisits).toHaveBeenCalledWith({
           viewDate: '2022-05-23',
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -331,7 +331,7 @@ describe('GET /visits', () => {
         expect(auditService.viewedVisits).toHaveBeenCalledWith({
           viewDate: todayDate,
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -368,7 +368,7 @@ describe('GET /visits', () => {
         expect(auditService.viewedVisits).toHaveBeenCalledWith({
           viewDate: todayDate,
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })
@@ -391,7 +391,7 @@ describe('GET /visits', () => {
         expect(auditService.viewedVisits).toHaveBeenCalledWith({
           viewDate: '2022-05-23',
           prisonId,
-          username: undefined,
+          username: 'user1',
           operationId: undefined,
         })
       })

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -54,6 +54,30 @@ describe('Audit service', () => {
     })
   })
 
+  it('sends a change establishment message, with undefined (not valid in JSON) converted to null', async () => {
+    await auditService.changeEstablishment({
+      previousEstablishment: undefined,
+      newEstablishment: 'BLI',
+      username: 'username',
+      operationId: 'operation-id',
+    })
+
+    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
+    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
+      input: {
+        MessageBody: JSON.stringify({
+          what: 'CHANGE_ESTABLISHMENT',
+          when: fakeDate,
+          operationId: 'operation-id',
+          who: 'username',
+          service: 'book-a-prison-visit-staff-ui',
+          details: '{"previousEstablishment":null,"newEstablishment":"BLI"}',
+        }),
+        QueueUrl,
+      },
+    })
+  })
+
   it('sends a prisoner search audit message', async () => {
     await auditService.prisonerSearch({
       searchTerms: 'Smith',

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -347,7 +347,7 @@ export default class AuditService {
       operationId,
       who,
       service: config.apis.audit.serviceName,
-      details: JSON.stringify(details),
+      details: JSON.stringify(details, this.replaceUndefinedWithNull),
     })
 
     try {
@@ -362,5 +362,9 @@ export default class AuditService {
       logger.error(`Problem sending message to SQS queue (message: ${message})`)
       logger.error(error)
     }
+  }
+
+  private replaceUndefinedWithNull(_key: string, value: unknown) {
+    return typeof value === 'undefined' ? null : value
   }
 }


### PR DESCRIPTION
This change:
* uses the user's caseload (set in DPS) to set the default selected establishment
* redirects the user to choose an establishment if the active caseload is not a supported VSiP prison
* maintains the already-selected prison in VSiP if the caseload in DPS is changed

If `FEATURE_ESTABLISHMENT_SWITCHER_ENABLED` is not enabled then the establishment defaults to `HEI / Hewell` regardless of the user's active caseload.