### PR TITLE
VB-1481: Store prison ID in visit session data and check against selected establishment

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -188,6 +188,7 @@ export type VisitSessionData = {
     restrictions?: OffenderRestriction[]
     previousRestrictions?: OffenderRestriction[]
   }
+  prisonId: string
   visitSlot?: VisitSlot
   originalVisitSlot?: VisitSlot
   visitRestriction?: Visit['visitRestriction']

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -317,6 +317,7 @@ describe('visitSchedulerApiClient', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
+        prisonId,
         visitSlot: {
           id: '1',
           startTimestamp,
@@ -363,9 +364,9 @@ describe('visitSchedulerApiClient', () => {
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(201, result)
 
-      const output = await client.reserveVisit(visitSessionData, prisonId)
+      const output = await client.reserveVisit(visitSessionData)
 
-      expect(output).toEqual(result)
+      expect(output).toStrictEqual(result)
     })
   })
 
@@ -415,6 +416,7 @@ describe('visitSchedulerApiClient', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
+        prisonId,
         visitSlot: {
           id: '1',
           startTimestamp: result.startTimestamp,
@@ -509,6 +511,7 @@ describe('visitSchedulerApiClient', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
+        prisonId,
         visitSlot: {
           id: '1',
           startTimestamp: result.startTimestamp,
@@ -597,6 +600,7 @@ describe('visitSchedulerApiClient', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
+        prisonId,
         visitSlot: {
           id: '1',
           startTimestamp: '2022-02-14T10:00:00',
@@ -678,9 +682,9 @@ describe('visitSchedulerApiClient', () => {
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(201, result)
 
-      const output = await client.changeBookedVisit(visitSessionData, prisonId)
+      const output = await client.changeBookedVisit(visitSessionData)
 
-      expect(output).toEqual(result)
+      expect(output).toStrictEqual(result)
     })
   })
 

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -84,12 +84,12 @@ class VisitSchedulerApiClient {
     })
   }
 
-  reserveVisit(visitSessionData: VisitSessionData, prisonId: string): Promise<Visit> {
+  reserveVisit(visitSessionData: VisitSessionData): Promise<Visit> {
     return this.restclient.post({
       path: '/visits/slot/reserve',
       data: <ReserveVisitSlotDto>{
         prisonerId: visitSessionData.prisoner.offenderNo,
-        prisonId,
+        prisonId: visitSessionData.prisonId,
         visitRoom: visitSessionData.visitSlot.visitRoomName,
         visitType: this.visitType,
         visitRestriction: visitSessionData.visitRestriction,
@@ -129,14 +129,14 @@ class VisitSchedulerApiClient {
     return this.restclient.put({ path: `/visits/${applicationReference}/book` })
   }
 
-  changeBookedVisit(visitSessionData: VisitSessionData, prisonId: string): Promise<Visit> {
+  changeBookedVisit(visitSessionData: VisitSessionData): Promise<Visit> {
     const { visitContact, mainContactId } = this.convertMainContactToVisitContact(visitSessionData.mainContact)
 
     return this.restclient.put({
       path: `/visits/${visitSessionData.visitReference}/change`,
       data: <ReserveVisitSlotDto>{
         prisonerId: visitSessionData.prisoner.offenderNo,
-        prisonId,
+        prisonId: visitSessionData.prisonId,
         visitRoom: visitSessionData.visitSlot.visitRoomName,
         visitType: this.visitType,
         visitRestriction: visitSessionData.visitRestriction,

--- a/server/middleware/sessionCheckMiddleware.ts
+++ b/server/middleware/sessionCheckMiddleware.ts
@@ -10,6 +10,10 @@ export default function sessionCheckMiddleware({ stage }: { stage: number }): Re
       return res.redirect('/search/prisoner/?error=missing-session')
     }
 
+    if (req.session.selectedEstablishment.prisonId !== visitSessionData.prisonId) {
+      return res.redirect('/?error=establishment-mismatch')
+    }
+
     if (reference && visitSessionData.visitReference !== reference) {
       return res.redirect('/?error=reference-mismatch')
     }

--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -380,13 +380,14 @@ describe('POST /prisoner/A1234BC', () => {
         expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', prisonId, 'user1')
         expect(auditService.overrodeZeroVO).not.toHaveBeenCalled()
         expect(clearSession).toHaveBeenCalledTimes(1)
-        expect(visitSessionData).toEqual(<VisitSessionData>{
+        expect(visitSessionData).toStrictEqual(<VisitSessionData>{
           prisoner: {
             name: 'Smith, John',
             offenderNo: 'A1234BC',
             dateOfBirth: '2 April 1975',
             location: '1-1-C-028, Hewell (HMP)',
           },
+          prisonId,
         })
       })
   })
@@ -409,13 +410,14 @@ describe('POST /prisoner/A1234BC', () => {
           operationId: undefined,
         })
         expect(clearSession).toHaveBeenCalledTimes(1)
-        expect(visitSessionData).toEqual(<VisitSessionData>{
+        expect(visitSessionData).toStrictEqual(<VisitSessionData>{
           prisoner: {
             name: 'Smith, John',
             offenderNo: 'A1234BC',
             dateOfBirth: '2 April 1975',
             location: '1-1-C-028, Hewell (HMP)',
           },
+          prisonId,
         })
       })
   })
@@ -436,13 +438,14 @@ describe('POST /prisoner/A1234BC', () => {
         expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledTimes(1)
         expect(prisonerProfileService.getPrisonerAndVisitBalances).toHaveBeenCalledWith('A1234BC', prisonId, 'user1')
         expect(auditService.overrodeZeroVO).not.toHaveBeenCalled()
-        expect(visitSessionData).toEqual(<VisitSessionData>{
+        expect(visitSessionData).toStrictEqual(<VisitSessionData>{
           prisoner: {
             name: 'Smith, John',
             offenderNo: 'A1234BC',
             dateOfBirth: '2 April 1975',
             location: '1-1-C-028, Hewell (HMP)',
           },
+          prisonId,
         })
       })
   })

--- a/server/routes/prisoner.ts
+++ b/server/routes/prisoner.ts
@@ -70,7 +70,7 @@ export default function routes(
     }
 
     clearSession(req)
-    const visitSessionData: VisitSessionData = req.session.visitSessionData ?? { prisoner: undefined }
+    const visitSessionData: VisitSessionData = req.session.visitSessionData ?? { prisoner: undefined, prisonId }
 
     visitSessionData.prisoner = {
       name: properCaseFullName(`${inmateDetail.lastName}, ${inmateDetail.firstName}`),
@@ -80,6 +80,7 @@ export default function routes(
         ? `${inmateDetail.assignedLivingUnit.description}, ${inmateDetail.assignedLivingUnit.agencyName}`
         : '',
     }
+    visitSessionData.prisonId = prisonId
 
     req.session.visitSessionData = visitSessionData
 

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -83,6 +83,7 @@ describe('/visit/:reference', () => {
     cellLocation: '1-1-C-028',
     restrictedPatient: false,
   }
+  const prisonId = 'HEI'
 
   let visit: Visit
 
@@ -123,7 +124,7 @@ describe('/visit/:reference', () => {
       applicationReference: 'aaa-bbb-ccc',
       reference: 'ab-cd-ef-gh',
       prisonerId: 'A1234BC',
-      prisonId: 'HEI',
+      prisonId,
       visitRoom: 'visit room',
       visitType: 'SOCIAL',
       visitStatus: 'BOOKED',
@@ -173,7 +174,7 @@ describe('/visit/:reference', () => {
     prisonerVisitorsService.getVisitors.mockResolvedValue(visitors)
     supportedPrisonsService.getSupportedPrisonIds.mockResolvedValue(['HEI'])
 
-    visitSessionData = { prisoner: undefined }
+    visitSessionData = { prisoner: undefined, prisonId }
 
     app = appWithAllRoutes({
       prisonerSearchServiceOverride: prisonerSearchService,
@@ -233,7 +234,7 @@ describe('/visit/:reference', () => {
           expect($('[data-test="visitor-concern"]').eq(0).text()).toBe('Example of a visitor concern')
           expect($('[data-test="additional-support"]').text()).toBe('Wheelchair ramp, custom request')
           expect($('[data-test="visit-booked"]').text()).toBe('Monday 14 February 2022 at 10am')
-          expect(visitSessionData).toEqual({ prisoner: undefined })
+          expect(visitSessionData).toStrictEqual({ prisoner: undefined, prisonId })
 
           expect(auditService.viewedVisitDetails).toHaveBeenCalledTimes(1)
           expect(auditService.viewedVisitDetails).toHaveBeenCalledWith({
@@ -483,6 +484,7 @@ describe('/visit/:reference', () => {
               dateOfBirth: '1975-04-02',
               location: '1-1-C-028, Hewell (HMP)',
             },
+            prisonId,
             visitSlot: {
               id: '',
               startTimestamp: '2022-02-09T10:00:00',

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -140,6 +140,7 @@ export default function routes(
         dateOfBirth: prisoner.dateOfBirth,
         location: prisonerLocation,
       },
+      prisonId: visit.prisonId,
       visitSlot,
       originalVisitSlot: visitSlot,
       visitRestriction: visit.visitRestriction,

--- a/server/routes/visitJourney/additionalSupport.test.ts
+++ b/server/routes/visitJourney/additionalSupport.test.ts
@@ -15,6 +15,8 @@ let visitSessionData: VisitSessionData
 // run tests for booking and update journeys
 const testJourneys = [{ urlPrefix: '/book-a-visit' }, { urlPrefix: '/visit/ab-cd-ef-gh/update' }]
 
+const prisonId = 'HEI'
+
 const availableSupportTypes: SupportType[] = [
   {
     type: 'WHEELCHAIR',
@@ -59,6 +61,7 @@ testJourneys.forEach(journey => {
           dateOfBirth: '25 May 1988',
           location: 'location place',
         },
+        prisonId,
         visitRestriction: 'OPEN',
         visitSlot: {
           id: 'visitId',
@@ -237,6 +240,7 @@ testJourneys.forEach(journey => {
           dateOfBirth: '25 May 1988',
           location: 'location place',
         },
+        prisonId,
         visitRestriction: 'OPEN',
         visitSlot: {
           id: 'visitId',

--- a/server/routes/visitJourney/checkYourBooking.test.ts
+++ b/server/routes/visitJourney/checkYourBooking.test.ts
@@ -25,6 +25,8 @@ const testJourneys = [
   { urlPrefix: '/visit/ab-cd-ef-gh/update', isUpdate: true },
 ]
 
+const prisonId = 'HEI'
+
 const availableSupportTypes: SupportType[] = [
   {
     type: 'WHEELCHAIR',
@@ -69,6 +71,7 @@ testJourneys.forEach(journey => {
           dateOfBirth: '25 May 1988',
           location: 'location place',
         },
+        prisonId,
         visitRestriction: 'OPEN',
         visitSlot: {
           id: 'visitId',

--- a/server/routes/visitJourney/confirmation.test.ts
+++ b/server/routes/visitJourney/confirmation.test.ts
@@ -19,6 +19,8 @@ const testJourneys = [
   { urlPrefix: '/visit/ab-cd-ef-gh/update', isUpdate: true },
 ]
 
+const prisonId = 'HEI'
+
 const availableSupportTypes: SupportType[] = [
   {
     type: 'WHEELCHAIR',
@@ -64,6 +66,7 @@ testJourneys.forEach(journey => {
           dateOfBirth: '25 May 1988',
           location: 'location place',
         },
+        prisonId,
         visitRestriction: 'OPEN',
         visitSlot: {
           id: 'visitId',
@@ -146,6 +149,7 @@ testJourneys.forEach(journey => {
             dateOfBirth: '25 May 1988',
             location: 'location place',
           },
+          prisonId,
           visitRestriction: 'OPEN',
           visitSlot: {
             id: 'visitId',

--- a/server/routes/visitJourney/dateAndTime.test.ts
+++ b/server/routes/visitJourney/dateAndTime.test.ts
@@ -25,6 +25,8 @@ const visitSessionsService = new VisitSessionsService(
   systemToken,
 ) as jest.Mocked<VisitSessionsService>
 
+const prisonId = 'HEI'
+
 // run tests for booking and update journeys
 const testJourneys = [
   { urlPrefix: '/book-a-visit', isUpdate: false },
@@ -44,6 +46,7 @@ beforeEach(() => {
       dateOfBirth: '25 May 1988',
       location: 'location place',
     },
+    prisonId,
     visitRestriction: 'OPEN',
     visitors: [
       {
@@ -328,7 +331,7 @@ testJourneys.forEach(journey => {
               applicationReference: reservedVisit.applicationReference,
               visitReference: reservedVisit.reference,
               prisonerId: 'A1234BC',
-              prisonId: 'HEI',
+              prisonId,
               visitorIds: ['4323'],
               startTimestamp: '2022-02-14T11:59:00',
               endTimestamp: '2022-02-14T12:59:00',
@@ -392,7 +395,7 @@ testJourneys.forEach(journey => {
               applicationReference: reservedVisit.applicationReference,
               visitReference: reservedVisit.reference,
               prisonerId: 'A1234BC',
-              prisonId: 'HEI',
+              prisonId,
               visitorIds: ['4323'],
               startTimestamp: '2022-02-14T12:00:00',
               endTimestamp: '2022-02-14T13:05:00',

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -119,7 +119,6 @@ export default class DateAndTime {
       const { applicationReference, visitStatus } = await this.visitSessionsService.changeBookedVisit({
         username: res.locals.user?.username,
         visitSessionData,
-        prisonId,
       })
 
       visitSessionData.applicationReference = applicationReference
@@ -128,7 +127,6 @@ export default class DateAndTime {
       const { applicationReference, reference, visitStatus } = await this.visitSessionsService.reserveVisit({
         username: res.locals.user?.username,
         visitSessionData,
-        prisonId,
       })
 
       visitSessionData.applicationReference = applicationReference

--- a/server/routes/visitJourney/mainContact.test.ts
+++ b/server/routes/visitJourney/mainContact.test.ts
@@ -66,6 +66,7 @@ testJourneys.forEach(journey => {
           dateOfBirth: '25 May 1988',
           location: 'location place',
         },
+        prisonId: 'HEI',
         visitRestriction: 'OPEN',
         visitSlot: {
           id: 'visitId',

--- a/server/routes/visitJourney/selectVisitors.test.ts
+++ b/server/routes/visitJourney/selectVisitors.test.ts
@@ -18,6 +18,8 @@ const systemToken = async (user: string): Promise<string> => `${user}-token-1`
 let flashData: Record<'errors' | 'formValues', Record<string, string | string[]>[]>
 let visitSessionData: VisitSessionData
 
+const prisonId = 'HEI'
+
 // run tests for booking and update journeys
 const testJourneys = [
   { urlPrefix: '/book-a-visit', isUpdate: false },
@@ -134,6 +136,7 @@ testJourneys.forEach(journey => {
           dateOfBirth: '25 May 1988',
           location: 'location place',
         },
+        prisonId,
         visitRestriction: 'OPEN',
         visitReference: 'ab-cd-ef-gh',
       }
@@ -441,6 +444,8 @@ testJourneys.forEach(journey => {
       ]
       prisons.forEach(prison => {
         it(`should display prison specific content, related to ${prison.prisonName}`, () => {
+          visitSessionData.prisonId = prison.prisonId
+
           sessionApp = appWithAllRoutes({
             prisonerProfileServiceOverride: prisonerProfileService,
             prisonerVisitorsServiceOverride: prisonerVisitorsService,
@@ -559,6 +564,7 @@ testJourneys.forEach(journey => {
           location: 'location place',
           restrictions: [],
         },
+        prisonId,
         visitRestriction: 'OPEN',
         visitReference,
       }

--- a/server/routes/visitJourney/visitType.test.ts
+++ b/server/routes/visitJourney/visitType.test.ts
@@ -49,6 +49,7 @@ testJourneys.forEach(journey => {
             },
           ],
         },
+        prisonId: 'HEI',
         visitRestriction: 'OPEN',
         visitors: [
           {

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -3,6 +3,7 @@ import { Session, SessionData } from 'express-session'
 import { Prison, VisitSlot, VisitSlotList } from '../@types/bapv'
 import { clearSession, getFlashFormValues, getSelectedSlot, getSlotByStartTimeAndRestriction } from './visitorUtils'
 
+const prisonId = 'HEI'
 const slotsList: VisitSlotList = {
   'February 2022': [
     {
@@ -155,7 +156,7 @@ describe('clearSession', () => {
     visitorList: { visitors: [] },
     adultVisitors: { adults: [] },
     slotsList: {},
-    visitSessionData: { prisoner: undefined },
+    visitSessionData: { prisoner: undefined, prisonId },
     selectedEstablishment: { prisonId: 'HEI', prisonName: 'Hewell (HMP)' } as Prison,
   }
 

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -494,6 +494,7 @@ describe('Visit sessions service', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
+        prisonId,
         visitSlot: {
           id: '1',
           startTimestamp: '2022-02-14T10:00:00',
@@ -546,11 +547,10 @@ describe('Visit sessions service', () => {
       }
 
       visitSchedulerApiClient.reserveVisit.mockResolvedValue(visit)
-      whereaboutsApiClient.getEvents.mockResolvedValue([])
-      const result = await visitSessionsService.reserveVisit({ username: 'user', visitSessionData, prisonId })
+      const result = await visitSessionsService.reserveVisit({ username: 'user', visitSessionData })
 
       expect(visitSchedulerApiClient.reserveVisit).toHaveBeenCalledTimes(1)
-      expect(result).toEqual(visit)
+      expect(result).toStrictEqual(visit)
     })
   })
 
@@ -563,6 +563,7 @@ describe('Visit sessions service', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
+        prisonId,
         visitSlot: {
           id: 'visitId',
           startTimestamp: '2022-02-14T10:00:00',
@@ -628,7 +629,6 @@ describe('Visit sessions service', () => {
       }
 
       visitSchedulerApiClient.changeReservedVisit.mockResolvedValue(visit)
-      whereaboutsApiClient.getEvents.mockResolvedValue([])
 
       const result = await visitSessionsService.changeReservedVisit({
         username: 'user',
@@ -636,7 +636,7 @@ describe('Visit sessions service', () => {
       })
 
       expect(visitSchedulerApiClient.changeReservedVisit).toHaveBeenCalledTimes(1)
-      expect(result).toEqual(visit)
+      expect(result).toStrictEqual(visit)
     })
   })
 
@@ -651,11 +651,11 @@ describe('Visit sessions service', () => {
       }
 
       visitSchedulerApiClient.bookVisit.mockResolvedValue(visit as Visit)
-      whereaboutsApiClient.getEvents.mockResolvedValue([])
+
       const result = await visitSessionsService.bookVisit({ username: 'user', applicationReference })
 
       expect(visitSchedulerApiClient.bookVisit).toHaveBeenCalledTimes(1)
-      expect(result).toEqual(visit)
+      expect(result).toStrictEqual(visit)
     })
   })
 
@@ -668,6 +668,7 @@ describe('Visit sessions service', () => {
           dateOfBirth: '23 May 1988',
           location: 'somewhere',
         },
+        prisonId,
         visitSlot: {
           id: 'visitId',
           startTimestamp: '2022-02-14T10:00:00',
@@ -733,13 +734,8 @@ describe('Visit sessions service', () => {
       }
 
       visitSchedulerApiClient.changeBookedVisit.mockResolvedValue(returnedVisit)
-      whereaboutsApiClient.getEvents.mockResolvedValue([])
 
-      const result = await visitSessionsService.changeBookedVisit({
-        username: 'user',
-        visitSessionData,
-        prisonId,
-      })
+      const result = await visitSessionsService.changeBookedVisit({ username: 'user', visitSessionData })
 
       expect(visitSchedulerApiClient.changeBookedVisit).toHaveBeenCalledTimes(1)
       expect(result).toEqual(returnedVisit)

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -158,16 +158,14 @@ export default class VisitSessionsService {
   async reserveVisit({
     username,
     visitSessionData,
-    prisonId,
   }: {
     username: string
     visitSessionData: VisitSessionData
-    prisonId: string
   }): Promise<Visit> {
     const token = await this.systemToken(username)
     const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
 
-    const reservation = await visitSchedulerApiClient.reserveVisit(visitSessionData, prisonId)
+    const reservation = await visitSchedulerApiClient.reserveVisit(visitSessionData)
     return reservation
   }
 
@@ -202,16 +200,14 @@ export default class VisitSessionsService {
   async changeBookedVisit({
     username,
     visitSessionData,
-    prisonId,
   }: {
     username: string
     visitSessionData: VisitSessionData
-    prisonId: string
   }): Promise<Visit> {
     const token = await this.systemToken(username)
     const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
 
-    const visit = await visitSchedulerApiClient.changeBookedVisit(visitSessionData, prisonId)
+    const visit = await visitSchedulerApiClient.changeBookedVisit(visitSessionData)
     return visit
   }
 


### PR DESCRIPTION
The existing `visitSessionData` didn't store the `prisonId` associated with the visit and instead relied on the `selectedEstablishment`. When looking up a visit by reference and with a different establishment selected to that of the visit, it was possible to start an update journey for the visit in the context of the 'wrong' prison (VB-1480).

This change stores the `prisonId` in `visitSessionData` at the start of the booking / update journey. This is then checked against the `selectedEstablishment` wherever `sessionCheckMiddleware` is used to make sure the two don't become mismatched. If they do, the request is redirected back to the home page.

Further work is expected to avoid this kind of situation occurring and/or handling it better by changing how the look up visit by reference works; this PR is intended just to be 'fail-safe' against changing a visit for the 'wrong' prison in any scenario.

(Most of the changes in this PR are just adding the new, required `prisonId` to test data. Main change is in the `sessionCheckMiddleWare`.)