### PR TITLE
VB-1481: Store prison ID in visit slot (in visitSessionData) and check against selected establishment

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -141,6 +141,7 @@ export type BAPVVisitBalances = VisitBalances & {
 // Visit slots, for representing data derived from VisitSessions
 export type VisitSlot = {
   id: string
+  prisonId: string
   startTimestamp: string
   endTimestamp: string
   availableTables: number

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -319,6 +319,7 @@ describe('visitSchedulerApiClient', () => {
         },
         visitSlot: {
           id: '1',
+          prisonId,
           startTimestamp,
           endTimestamp,
           availableTables: 1,
@@ -363,7 +364,7 @@ describe('visitSchedulerApiClient', () => {
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(201, result)
 
-      const output = await client.reserveVisit(visitSessionData, prisonId)
+      const output = await client.reserveVisit(visitSessionData)
 
       expect(output).toEqual(result)
     })
@@ -601,6 +602,7 @@ describe('visitSchedulerApiClient', () => {
         },
         visitSlot: {
           id: '1',
+          prisonId,
           startTimestamp: '2022-02-14T10:00:00',
           endTimestamp: '2022-02-14T11:00:00',
           availableTables: 1,
@@ -680,7 +682,7 @@ describe('visitSchedulerApiClient', () => {
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(201, result)
 
-      const output = await client.changeBookedVisit(visitSessionData, prisonId)
+      const output = await client.changeBookedVisit(visitSessionData)
 
       expect(output).toEqual(result)
     })

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -417,6 +417,7 @@ describe('visitSchedulerApiClient', () => {
         },
         visitSlot: {
           id: '1',
+          prisonId,
           startTimestamp: result.startTimestamp,
           endTimestamp: result.endTimestamp,
           availableTables: 1,
@@ -511,6 +512,7 @@ describe('visitSchedulerApiClient', () => {
         },
         visitSlot: {
           id: '1',
+          prisonId,
           startTimestamp: result.startTimestamp,
           endTimestamp: result.endTimestamp,
           availableTables: 1,

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -84,12 +84,12 @@ class VisitSchedulerApiClient {
     })
   }
 
-  reserveVisit(visitSessionData: VisitSessionData, prisonId: string): Promise<Visit> {
+  reserveVisit(visitSessionData: VisitSessionData): Promise<Visit> {
     return this.restclient.post({
       path: '/visits/slot/reserve',
       data: <ReserveVisitSlotDto>{
         prisonerId: visitSessionData.prisoner.offenderNo,
-        prisonId,
+        prisonId: visitSessionData.visitSlot.prisonId,
         visitRoom: visitSessionData.visitSlot.visitRoomName,
         visitType: this.visitType,
         visitRestriction: visitSessionData.visitRestriction,
@@ -129,14 +129,14 @@ class VisitSchedulerApiClient {
     return this.restclient.put({ path: `/visits/${applicationReference}/book` })
   }
 
-  changeBookedVisit(visitSessionData: VisitSessionData, prisonId: string): Promise<Visit> {
+  changeBookedVisit(visitSessionData: VisitSessionData): Promise<Visit> {
     const { visitContact, mainContactId } = this.convertMainContactToVisitContact(visitSessionData.mainContact)
 
     return this.restclient.put({
       path: `/visits/${visitSessionData.visitReference}/change`,
       data: <ReserveVisitSlotDto>{
         prisonerId: visitSessionData.prisoner.offenderNo,
-        prisonId,
+        prisonId: visitSessionData.visitSlot.prisonId,
         visitRoom: visitSessionData.visitSlot.visitRoomName,
         visitType: this.visitType,
         visitRestriction: visitSessionData.visitRestriction,

--- a/server/middleware/sessionCheckMiddleware.test.ts
+++ b/server/middleware/sessionCheckMiddleware.test.ts
@@ -29,6 +29,7 @@ const visitorsData: VisitSessionData['visitors'] = [
 ]
 const visitSlot: VisitSessionData['visitSlot'] = {
   id: '1',
+  prisonId: 'HEI',
   startTimestamp: '123',
   endTimestamp: '123',
   availableTables: 1,

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -485,6 +485,7 @@ describe('/visit/:reference', () => {
             },
             visitSlot: {
               id: '',
+              prisonId: 'HEI',
               startTimestamp: '2022-02-09T10:00:00',
               endTimestamp: '2022-02-09T11:15:00',
               availableTables: 0,
@@ -493,6 +494,7 @@ describe('/visit/:reference', () => {
             },
             originalVisitSlot: {
               id: '',
+              prisonId: 'HEI',
               startTimestamp: '2022-02-09T10:00:00',
               endTimestamp: '2022-02-09T11:15:00',
               availableTables: 0,

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -126,6 +126,7 @@ export default function routes(
     clearSession(req)
     const visitSlot: VisitSlot = {
       id: '',
+      prisonId: visit.prisonId,
       startTimestamp: visit.startTimestamp,
       endTimestamp: visit.endTimestamp,
       availableTables: 0,

--- a/server/routes/visitJourney/additionalSupport.test.ts
+++ b/server/routes/visitJourney/additionalSupport.test.ts
@@ -62,6 +62,7 @@ testJourneys.forEach(journey => {
         visitRestriction: 'OPEN',
         visitSlot: {
           id: 'visitId',
+          prisonId: 'HEI',
           startTimestamp: '123',
           endTimestamp: '456',
           availableTables: 1,
@@ -240,6 +241,7 @@ testJourneys.forEach(journey => {
         visitRestriction: 'OPEN',
         visitSlot: {
           id: 'visitId',
+          prisonId: 'HEI',
           startTimestamp: '123',
           endTimestamp: '456',
           availableTables: 1,

--- a/server/routes/visitJourney/checkYourBooking.test.ts
+++ b/server/routes/visitJourney/checkYourBooking.test.ts
@@ -72,6 +72,7 @@ testJourneys.forEach(journey => {
         visitRestriction: 'OPEN',
         visitSlot: {
           id: 'visitId',
+          prisonId: 'HEI',
           startTimestamp: '2022-03-12T09:30:00',
           endTimestamp: '2022-03-12T10:30:00',
           availableTables: 1,

--- a/server/routes/visitJourney/confirmation.test.ts
+++ b/server/routes/visitJourney/confirmation.test.ts
@@ -67,6 +67,7 @@ testJourneys.forEach(journey => {
         visitRestriction: 'OPEN',
         visitSlot: {
           id: 'visitId',
+          prisonId: 'HEI',
           startTimestamp: '2022-03-12T09:30:00',
           endTimestamp: '2022-03-12T10:30:00',
           availableTables: 1,
@@ -149,6 +150,7 @@ testJourneys.forEach(journey => {
           visitRestriction: 'OPEN',
           visitSlot: {
             id: 'visitId',
+            prisonId: 'HEI',
             startTimestamp: '2022-03-12T09:30:00',
             endTimestamp: '2022-03-12T10:30:00',
             availableTables: 1,

--- a/server/routes/visitJourney/dateAndTime.test.ts
+++ b/server/routes/visitJourney/dateAndTime.test.ts
@@ -25,6 +25,8 @@ const visitSessionsService = new VisitSessionsService(
   systemToken,
 ) as jest.Mocked<VisitSessionsService>
 
+const prisonId = 'HEI'
+
 // run tests for booking and update journeys
 const testJourneys = [
   { urlPrefix: '/book-a-visit', isUpdate: false },
@@ -87,6 +89,7 @@ testJourneys.forEach(journey => {
             morning: [
               {
                 id: '1',
+                prisonId,
                 startTimestamp: '2022-02-14T10:00:00',
                 endTimestamp: '2022-02-14T11:00:00',
                 availableTables: 15,
@@ -98,6 +101,7 @@ testJourneys.forEach(journey => {
               },
               {
                 id: '2',
+                prisonId,
                 startTimestamp: '2022-02-14T11:59:00',
                 endTimestamp: '2022-02-14T12:59:00',
                 availableTables: 1,
@@ -109,6 +113,7 @@ testJourneys.forEach(journey => {
             afternoon: [
               {
                 id: '3',
+                prisonId,
                 startTimestamp: '2022-02-14T12:00:00',
                 endTimestamp: '2022-02-14T13:05:00',
                 availableTables: 5,
@@ -221,6 +226,7 @@ testJourneys.forEach(journey => {
       it('should render the available sessions list with the slot in the session selected', () => {
         visitSessionData.visitSlot = {
           id: '3',
+          prisonId,
           startTimestamp: '2022-02-14T12:00:00',
           endTimestamp: '2022-02-14T13:05:00',
           availableTables: 5,
@@ -305,6 +311,7 @@ testJourneys.forEach(journey => {
           .expect(() => {
             expect(visitSessionData.visitSlot).toEqual(<VisitSlot>{
               id: '2',
+              prisonId,
               startTimestamp: '2022-02-14T11:59:00',
               endTimestamp: '2022-02-14T12:59:00',
               availableTables: 1,
@@ -328,7 +335,7 @@ testJourneys.forEach(journey => {
               applicationReference: reservedVisit.applicationReference,
               visitReference: reservedVisit.reference,
               prisonerId: 'A1234BC',
-              prisonId: 'HEI',
+              prisonId,
               visitorIds: ['4323'],
               startTimestamp: '2022-02-14T11:59:00',
               endTimestamp: '2022-02-14T12:59:00',
@@ -342,6 +349,7 @@ testJourneys.forEach(journey => {
       it('should save new choice to session, update visit reservation and redirect to additional support page if existing session data present', () => {
         visitSessionData.visitSlot = {
           id: '1',
+          prisonId,
           startTimestamp: '2022-02-14T10:00:00',
           endTimestamp: '2022-02-14T11:00:00',
           availableTables: 15,
@@ -362,6 +370,7 @@ testJourneys.forEach(journey => {
           .expect(() => {
             expect(visitSessionData.visitSlot).toEqual(<VisitSlot>{
               id: '3',
+              prisonId,
               startTimestamp: '2022-02-14T12:00:00',
               endTimestamp: '2022-02-14T13:05:00',
               availableTables: 5,
@@ -392,7 +401,7 @@ testJourneys.forEach(journey => {
               applicationReference: reservedVisit.applicationReference,
               visitReference: reservedVisit.reference,
               prisonerId: 'A1234BC',
-              prisonId: 'HEI',
+              prisonId,
               visitorIds: ['4323'],
               startTimestamp: '2022-02-14T12:00:00',
               endTimestamp: '2022-02-14T13:05:00',
@@ -443,6 +452,7 @@ describe('Update journey specific warning messages', () => {
   beforeEach(() => {
     currentlyBookedSlot = {
       id: '',
+      prisonId,
       startTimestamp: '2022-10-17T09:00:00',
       endTimestamp: '2022-10-17T10:00:00',
     } as VisitSlot

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -97,7 +97,6 @@ export default class DateAndTime {
 
   async post(req: Request, res: Response): Promise<void> {
     const isUpdate = this.mode === 'update'
-    const { prisonId } = req.session.selectedEstablishment
     const { visitSessionData } = req.session
     const errors = validationResult(req)
 
@@ -119,7 +118,6 @@ export default class DateAndTime {
       const { applicationReference, visitStatus } = await this.visitSessionsService.changeBookedVisit({
         username: res.locals.user?.username,
         visitSessionData,
-        prisonId,
       })
 
       visitSessionData.applicationReference = applicationReference
@@ -128,7 +126,6 @@ export default class DateAndTime {
       const { applicationReference, reference, visitStatus } = await this.visitSessionsService.reserveVisit({
         username: res.locals.user?.username,
         visitSessionData,
-        prisonId,
       })
 
       visitSessionData.applicationReference = applicationReference
@@ -140,7 +137,7 @@ export default class DateAndTime {
       applicationReference: visitSessionData.applicationReference,
       visitReference: visitSessionData.visitReference,
       prisonerId: visitSessionData.prisoner.offenderNo,
-      prisonId,
+      prisonId: visitSessionData.visitSlot.prisonId,
       visitorIds: visitSessionData.visitors.map(visitor => visitor.personId.toString()),
       startTimestamp: visitSessionData.visitSlot.startTimestamp,
       endTimestamp: visitSessionData.visitSlot.endTimestamp,

--- a/server/routes/visitJourney/mainContact.test.ts
+++ b/server/routes/visitJourney/mainContact.test.ts
@@ -69,6 +69,7 @@ testJourneys.forEach(journey => {
         visitRestriction: 'OPEN',
         visitSlot: {
           id: 'visitId',
+          prisonId: 'HEI',
           startTimestamp: '123',
           endTimestamp: '456',
           availableTables: 1,

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -3,6 +3,8 @@ import { Session, SessionData } from 'express-session'
 import { Prison, VisitSlot, VisitSlotList } from '../@types/bapv'
 import { clearSession, getFlashFormValues, getSelectedSlot, getSlotByStartTimeAndRestriction } from './visitorUtils'
 
+const prisonId = 'HEI'
+
 const slotsList: VisitSlotList = {
   'February 2022': [
     {
@@ -15,6 +17,7 @@ const slotsList: VisitSlotList = {
         morning: [
           {
             id: '1',
+            prisonId,
             startTimestamp: '2022-02-14T10:00:00',
             endTimestamp: '2022-02-14T11:00:00',
             availableTables: 15,
@@ -24,6 +27,7 @@ const slotsList: VisitSlotList = {
           },
           {
             id: '2',
+            prisonId,
             startTimestamp: '2022-02-14T11:59:00',
             endTimestamp: '2022-02-14T12:59:00',
             availableTables: 1,
@@ -35,6 +39,7 @@ const slotsList: VisitSlotList = {
         afternoon: [
           {
             id: '3',
+            prisonId,
             startTimestamp: '2022-02-14T12:00:00',
             endTimestamp: '2022-02-14T13:05:00',
             availableTables: 5,
@@ -56,6 +61,7 @@ const slotsList: VisitSlotList = {
         afternoon: [
           {
             id: '4',
+            prisonId,
             startTimestamp: '2022-02-15T16:00:00',
             endTimestamp: '2022-02-15T17:00:00',
             availableTables: 12,
@@ -78,6 +84,7 @@ const slotsList: VisitSlotList = {
         morning: [
           {
             id: '5',
+            prisonId,
             startTimestamp: '2022-03-01T09:30:00',
             endTimestamp: '2022-03-01T10:30:00',
             availableTables: 0,
@@ -96,6 +103,7 @@ describe('getSelectedSlot', () => {
   it('should return the selected slot if it exists in the slotsList', () => {
     expect(getSelectedSlot(slotsList, '4')).toEqual(<VisitSlot>{
       id: '4',
+      prisonId,
       startTimestamp: '2022-02-15T16:00:00',
       endTimestamp: '2022-02-15T17:00:00',
       availableTables: 12,

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -155,6 +155,7 @@ describe('Visit sessions service', () => {
                 morning: [
                   {
                     id: '1',
+                    prisonId,
                     startTimestamp: '2022-02-14T10:00:00',
                     endTimestamp: '2022-02-14T11:00:00',
                     availableTables: 15,
@@ -210,6 +211,7 @@ describe('Visit sessions service', () => {
                 morning: [
                   {
                     id: '1',
+                    prisonId,
                     startTimestamp: '2022-02-14T10:00:00',
                     endTimestamp: '2022-02-14T11:00:00',
                     availableTables: 15,
@@ -249,6 +251,7 @@ describe('Visit sessions service', () => {
                 morning: [
                   {
                     id: '1',
+                    prisonId,
                     startTimestamp: '2022-02-14T10:00:00',
                     endTimestamp: '2022-02-14T11:00:00',
                     availableTables: 15,
@@ -304,6 +307,7 @@ describe('Visit sessions service', () => {
               morning: [
                 {
                   id: '1',
+                  prisonId,
                   startTimestamp: '2022-02-14T10:00:00',
                   endTimestamp: '2022-02-14T11:00:00',
                   availableTables: 8,
@@ -406,6 +410,7 @@ describe('Visit sessions service', () => {
               morning: [
                 {
                   id: '1',
+                  prisonId,
                   startTimestamp: '2022-02-14T10:00:00',
                   endTimestamp: '2022-02-14T11:00:00',
                   availableTables: 15,
@@ -415,6 +420,7 @@ describe('Visit sessions service', () => {
                 },
                 {
                   id: '2',
+                  prisonId,
                   startTimestamp: '2022-02-14T11:59:00',
                   endTimestamp: '2022-02-14T12:59:00',
                   availableTables: 10,
@@ -426,6 +432,7 @@ describe('Visit sessions service', () => {
               afternoon: [
                 {
                   id: '3',
+                  prisonId,
                   startTimestamp: '2022-02-14T12:00:00',
                   endTimestamp: '2022-02-14T13:05:00',
                   availableTables: 5,
@@ -447,6 +454,7 @@ describe('Visit sessions service', () => {
               afternoon: [
                 {
                   id: '4',
+                  prisonId,
                   startTimestamp: '2022-02-15T16:00:00',
                   endTimestamp: '2022-02-15T17:00:00',
                   availableTables: 12,
@@ -469,6 +477,7 @@ describe('Visit sessions service', () => {
               morning: [
                 {
                   id: '5',
+                  prisonId,
                   startTimestamp: '2022-03-01T09:30:00',
                   endTimestamp: '2022-03-01T10:30:00',
                   availableTables: 0,
@@ -496,6 +505,7 @@ describe('Visit sessions service', () => {
         },
         visitSlot: {
           id: '1',
+          prisonId,
           startTimestamp: '2022-02-14T10:00:00',
           endTimestamp: '2022-02-14T11:00:00',
           availableTables: 1,
@@ -565,6 +575,7 @@ describe('Visit sessions service', () => {
         },
         visitSlot: {
           id: 'visitId',
+          prisonId,
           startTimestamp: '2022-02-14T10:00:00',
           endTimestamp: '2022-02-14T11:00:00',
           availableTables: 1,
@@ -670,6 +681,7 @@ describe('Visit sessions service', () => {
         },
         visitSlot: {
           id: 'visitId',
+          prisonId,
           startTimestamp: '2022-02-14T10:00:00',
           endTimestamp: '2022-02-14T11:00:00',
           availableTables: 1,

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -557,7 +557,7 @@ describe('Visit sessions service', () => {
 
       visitSchedulerApiClient.reserveVisit.mockResolvedValue(visit)
       whereaboutsApiClient.getEvents.mockResolvedValue([])
-      const result = await visitSessionsService.reserveVisit({ username: 'user', visitSessionData, prisonId })
+      const result = await visitSessionsService.reserveVisit({ username: 'user', visitSessionData })
 
       expect(visitSchedulerApiClient.reserveVisit).toHaveBeenCalledTimes(1)
       expect(result).toEqual(visit)
@@ -750,7 +750,6 @@ describe('Visit sessions service', () => {
       const result = await visitSessionsService.changeBookedVisit({
         username: 'user',
         visitSessionData,
-        prisonId,
       })
 
       expect(visitSchedulerApiClient.changeBookedVisit).toHaveBeenCalledTimes(1)

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -82,6 +82,7 @@ export default class VisitSessionsService {
 
         const newSlot: VisitSlot = {
           id: (slotIdCounter + 1).toString(),
+          prisonId: visitSession.prisonId,
           startTimestamp: visitSession.startTimestamp,
           endTimestamp: visitSession.endTimestamp,
           availableTables:

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -159,16 +159,14 @@ export default class VisitSessionsService {
   async reserveVisit({
     username,
     visitSessionData,
-    prisonId,
   }: {
     username: string
     visitSessionData: VisitSessionData
-    prisonId: string
   }): Promise<Visit> {
     const token = await this.systemToken(username)
     const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
 
-    const reservation = await visitSchedulerApiClient.reserveVisit(visitSessionData, prisonId)
+    const reservation = await visitSchedulerApiClient.reserveVisit(visitSessionData)
     return reservation
   }
 
@@ -203,16 +201,14 @@ export default class VisitSessionsService {
   async changeBookedVisit({
     username,
     visitSessionData,
-    prisonId,
   }: {
     username: string
     visitSessionData: VisitSessionData
-    prisonId: string
   }): Promise<Visit> {
     const token = await this.systemToken(username)
     const visitSchedulerApiClient = this.visitSchedulerApiClientBuilder(token)
 
-    const visit = await visitSchedulerApiClient.changeBookedVisit(visitSessionData, prisonId)
+    const visit = await visitSchedulerApiClient.changeBookedVisit(visitSessionData)
     return visit
   }
 

--- a/server/views/pages/bookAVisit/dateAndTime.test.ts
+++ b/server/views/pages/bookAVisit/dateAndTime.test.ts
@@ -10,6 +10,8 @@ describe('Views - Date and time of visit', () => {
   let compiledTemplate: Template
   let viewContext: Record<string, unknown>
 
+  const prisonId = 'HEI'
+
   const njkEnv = registerNunjucks()
 
   beforeEach(() => {
@@ -43,6 +45,7 @@ describe('Views - Date and time of visit', () => {
               morning: [
                 {
                   id: '1',
+                  prisonId,
                   startTimestamp: '2022-02-14T10:00:00',
                   endTimestamp: '2022-02-14T11:00:00',
                   availableTables: 15,
@@ -52,6 +55,7 @@ describe('Views - Date and time of visit', () => {
                 },
                 {
                   id: '2',
+                  prisonId,
                   startTimestamp: '2022-02-14T11:59:00',
                   endTimestamp: '2022-02-14T12:59:00',
                   availableTables: 1,
@@ -63,6 +67,7 @@ describe('Views - Date and time of visit', () => {
               afternoon: [
                 {
                   id: '3',
+                  prisonId,
                   startTimestamp: '2022-02-14T12:00:00',
                   endTimestamp: '2022-02-14T13:05:00',
                   availableTables: 5,
@@ -86,6 +91,7 @@ describe('Views - Date and time of visit', () => {
               afternoon: [
                 {
                   id: '4',
+                  prisonId,
                   startTimestamp: '2022-02-15T16:00:00',
                   endTimestamp: '2022-02-15T17:00:00',
                   availableTables: 12,
@@ -110,6 +116,7 @@ describe('Views - Date and time of visit', () => {
               morning: [
                 {
                   id: '5',
+                  prisonId,
                   startTimestamp: '2022-03-01T09:30:00',
                   endTimestamp: '2022-03-01T10:30:00',
                   availableTables: 0, // fully booked
@@ -119,6 +126,7 @@ describe('Views - Date and time of visit', () => {
                 },
                 {
                   id: '6',
+                  prisonId,
                   startTimestamp: '2022-03-01T10:30:00',
                   endTimestamp: '2022-03-01T11:30:00',
                   availableTables: -2, // overbooked
@@ -221,6 +229,7 @@ describe('Views - Date and time of visit', () => {
                 morning: [
                   {
                     id: '1',
+                    prisonId,
                     startTimestamp: '2022-02-14T10:00:00',
                     endTimestamp: '2022-02-14T11:00:00',
                     availableTables: 15,


### PR DESCRIPTION
The existing `visitSessionData` didn't store the `prisonId` associated with the visit and instead relied on the `selectedEstablishment`. When looking up a visit by reference and with a different establishment selected to that of the visit, it was possible to start an update journey for the visit in the context of the 'wrong' prison (VB-1480).

This change adds `prisonId` to the `VisitSlot` type, which gets stored in `visitSessionData.visitSlot` (and `visitSessionData.originalVisitSlot` for update journey). This is then checked against the `selectedEstablishment` wherever `sessionCheckMiddleware` is used to make sure the two don't become mismatched. If they do, the request is redirected back to the home page.

Further work will avoid this kind of situation occurring and/or handling it better by changing how the look up visit by reference works; this PR is intended just to be 'fail-safe' against changing a visit for the 'wrong' prison in any scenario.

(Most of the changes in this PR are just adding the new, required `prisonId` to test data. Main change is in the `sessionCheckMiddleWare`.)