### PR TITLE
VB-1481: Add selected establishment check to booking summary page

### DIFF
--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -712,11 +712,13 @@ describe('POST /visit/:reference/cancel', () => {
   beforeEach(() => {
     visitSessionsService.cancelVisit = jest.fn().mockResolvedValue(cancelledVisit)
     notificationsService.sendCancellationSms = jest.fn().mockResolvedValue({})
+    supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
 
     app = appWithAllRoutes({
       prisonerSearchServiceOverride: prisonerSearchService,
       visitSessionsServiceOverride: visitSessionsService,
       auditServiceOverride: auditService,
+      supportedPrisonsServiceOverride: supportedPrisonsService,
       systemTokenOverride: systemToken,
       notificationsServiceOverride: notificationsService,
     })

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -320,10 +320,13 @@ export default function routes(
         try {
           const phoneNumber = visit.visitContact.telephone.replace(/\s/g, '')
 
+          const supportedPrisons = await supportedPrisonsService.getSupportedPrisons(res.locals.user?.username)
+          const prisonName = supportedPrisons[visit.prisonId]
+
           await notificationsService.sendCancellationSms({
             phoneNumber,
             visitSlot: visit.startTimestamp,
-            prisonName: req.session.selectedEstablishment.prisonName,
+            prisonName,
             prisonPhoneNumber: '01234443225',
           })
           logger.info(`Cancellation SMS sent for ${reference}`)

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -73,6 +73,15 @@ export default function routes(
         username: res.locals.user?.username,
       })
 
+    if (visit.prisonId !== req.session.selectedEstablishment.prisonId) {
+      const supportedPrisons = await supportedPrisonsService.getSupportedPrisons(res.locals.user?.username)
+
+      return res.render('pages/visit/summary', {
+        visit: { reference: visit.reference },
+        visitPrisonName: supportedPrisons[visit.prisonId],
+      })
+    }
+
     const prisoner: Prisoner = await prisonerSearchService.getPrisonerById(visit.prisonerId, res.locals.user?.username)
     const supportedPrisonIds = await supportedPrisonsService.getSupportedPrisonIds(res.locals.user?.username)
 
@@ -109,6 +118,10 @@ export default function routes(
       reference,
       username: res.locals.user?.username,
     })
+
+    if (visit.prisonId !== req.session.selectedEstablishment.prisonId) {
+      return res.redirect(`/visit/${visit.reference}`)
+    }
 
     const prisoner: Prisoner = await prisonerSearchService.getPrisonerById(visit.prisonerId, res.locals.user?.username)
     const supportedPrisonIds = await supportedPrisonsService.getSupportedPrisonIds(res.locals.user?.username)

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -5,55 +5,59 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {%-from "moj/components/banner/macro.njk" import mojBanner %}
 
-
 {% set pageHeaderTitle = "Booking details" %}
 {% set pageTitle = applicationName + " - " + pageHeaderTitle + " - " + visit.reference %}
-{% if fromVisitSearch %}
-{% set backLinkHref = "/visits?" + fromVisitSearchQuery %}
-{% else %}
-{% set backLinkHref = "/prisoner/" + visit.prisonerId + "/visits" %}
+
+{% if prisoner %}
+  {% if fromVisitSearch %}
+    {% set backLinkHref = "/visits?" + fromVisitSearchQuery %}
+  {% else %}
+    {% set backLinkHref = "/prisoner/" + visit.prisonerId + "/visits" %}
+  {% endif %}
 {% endif %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
 
-      <p class="bapv-secondary-text govuk-!-margin-bottom-0">Booking reference: <span data-test="reference">{{ visit.reference }}</span></p>
+    <p class="bapv-secondary-text govuk-!-margin-bottom-0">Booking reference: <span data-test="reference">{{ visit.reference }}</span></p>
 
-      <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
+    <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
 
-       {% if visit.visitStatus === "CANCELLED" %}
+    {% if prisoner %}
+
+      {% if visit.visitStatus === "CANCELLED" %}
         {% set status = visit.outcomeStatus.split("_") %}
-            {%- for visitNote in visit.visitNotes %}
-              {% if visitNote.type == "VISIT_OUTCOMES" %}
+        {%- for visitNote in visit.visitNotes %}
+          {% if visitNote.type == "VISIT_OUTCOMES" %}
 
-                {% set cancelledBy %}
-                  {% if status[0] === 'ADMINISTRATIVE' %}
-                    {{ 'This visit was cancelled due to an administrative error with the booking.' }}
-                  {% else %}
-                    {{ 'This visit was cancelled by the ' + status[0] | lower + '.' }}
-                  {% endif %}
-                {% endset %}
-
-                {% set cancelledVisitHtml %}
-                  {{ govukWarningText({
-                    classes: "govuk-!-margin-bottom-0 govuk-!-padding-left-4",
-                    html: "<span>" + cancelledBy + "</span><br><span>Reason: " + visitNote.text + "</span>",
-                    iconFallbackText: "Warning",
-                    attributes: {
-                      "data-test": "cancelled-visit-reason"
-                    }
-                  }) }}
-                {% endset %}
-
-                {{ mojBanner({
-                  classes: "govuk-!-padding-left-4",
-                  html: cancelledVisitHtml
-                }) }}
-
+            {% set cancelledBy %}
+              {% if status[0] === 'ADMINISTRATIVE' %}
+                {{ 'This visit was cancelled due to an administrative error with the booking.' }}
+              {% else %}
+                {{ 'This visit was cancelled by the ' + status[0] | lower + '.' }}
               {% endif %}
-          {% endfor %}
-        {% endif %}
+            {% endset %}
+
+            {% set cancelledVisitHtml %}
+              {{ govukWarningText({
+                classes: "govuk-!-margin-bottom-0 govuk-!-padding-left-4",
+                html: "<span>" + cancelledBy + "</span><br><span>Reason: " + visitNote.text + "</span>",
+                iconFallbackText: "Warning",
+                attributes: {
+                  "data-test": "cancelled-visit-reason"
+                }
+              }) }}
+            {% endset %}
+
+            {{ mojBanner({
+              classes: "govuk-!-padding-left-4",
+              html: cancelledVisitHtml
+            }) }}
+
+          {% endif %}
+        {% endfor %}
+      {% endif %}
 
       <h2 class="govuk-heading-m">Prisoner details</h2>
       <ul class="bapv-item-list--horizontal">
@@ -122,7 +126,6 @@
             </form>
           {% endif %}
         {% endif %}
-
       </div>
 
       {% set visitorRows = [] %}
@@ -156,22 +159,22 @@
         captionClasses: "govuk-table__caption--m",
         classes: "bapv-table govuk-!-margin-top-3",
         head: [
-            {
-              text: "Name"
-            },
-            {
-              text: "Date of birth"
-            },
-            {
-              text: "Relationship to prisoner"
-            },
-            {
-              text: "Address"
-            },
-            {
-              text: "Restrictions",
-              classes: "govuk-!-width-one-quarter"
-            }
+          {
+            text: "Name"
+          },
+          {
+            text: "Date of birth"
+          },
+          {
+            text: "Relationship to prisoner"
+          },
+          {
+            text: "Address"
+          },
+          {
+            text: "Restrictions",
+            classes: "govuk-!-width-one-quarter"
+          }
         ],
         rows: visitorRows
       }) }}
@@ -201,6 +204,10 @@
           <span data-test="visit-booked">{{ visit.createdTimestamp | formatDate('EEEE d MMMM yyyy') }} at {{ visit.createdTimestamp | formatTime }}</span>
         </li>
       </ul>
-    </div>
+    {% else %}
+      <p>This booking is not for {{ selectedEstablishment.prisonName }}.</p>
+      <p>To view the booking, change the establishment to {{ visitPrisonName }} and search for it by the booking reference.</p>
+    {% endif %}
   </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
On the booking summary page, do not show visit details if the visit is for a different prison to the user's currently selected establishment. Instead, show message saying what prison the visit is booked for and prompting user to switch establishment and search for it.

Applies the same check on POSTing to this page (i.e. starting a visit update journey).

(Also includes minor tweak to cancellation SMS to look up the prison name from the visit's `prisonId` rather than `selectedEstablishment` to avoid any potential mix-up.)