### PR TITLE
VB-1421: Set case load for DPS when changing establishment

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -12,7 +12,7 @@ import visitsRoutes from './routes/visits'
 import nunjucksSetup from './utils/nunjucksSetup'
 import errorHandler from './errorHandler'
 import standardRouter from './routes/standardRouter'
-import type UserService from './services/userService'
+import UserService from './services/userService'
 import { prisonerSearchClientBuilder } from './data/prisonerSearchClient'
 import { notificationsApiClientBuilder } from './data/notificationsApiClient'
 import { visitSchedulerApiClientBuilder } from './data/visitSchedulerApiClient'
@@ -67,6 +67,7 @@ export default function createApp(userService: UserService): express.Application
       standardRouter(userService, supportedPrisonsService),
       supportedPrisonsService,
       new AuditService(),
+      userService,
     ),
   )
   app.use(

--- a/server/data/prisonApiClient.test.ts
+++ b/server/data/prisonApiClient.test.ts
@@ -117,6 +117,21 @@ describe('prisonApiClient', () => {
     })
   })
 
+  describe('setActiveCaseLoad', () => {
+    it('should set active case load for current user', async () => {
+      const caseLoadId = 'HEI'
+
+      fakePrisonApi
+        .put('/api/users/me/activeCaseLoad', { caseLoadId })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, {})
+
+      const output = await client.setActiveCaseLoad('HEI')
+
+      expect(output).toEqual({})
+    })
+  })
+
   describe('getVisitBalances', () => {
     it('should return visitBalances for a SENTENCED prisoner', async () => {
       const offenderNo = 'A1234BC'

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -37,6 +37,13 @@ class PrisonApiClient {
     })
   }
 
+  async setActiveCaseLoad(caseLoadId: string): Promise<void> {
+    return this.restclient.put({
+      path: '/api/users/me/activeCaseLoad',
+      data: { caseLoadId },
+    })
+  }
+
   async getVisitBalances(offenderNo: string): Promise<VisitBalances | null> {
     try {
       return await this.restclient.get({

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,11 +1,13 @@
 import createApp from './app'
 import HmppsAuthClient from './data/hmppsAuthClient'
+import { prisonApiClientBuilder } from './data/prisonApiClient'
+import systemToken from './data/authClient'
 import { createRedisClient } from './data/redisClient'
 import TokenStore from './data/tokenStore'
 import UserService from './services/userService'
 
 const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient({ legacyMode: false })))
-const userService = new UserService(hmppsAuthClient)
+const userService = new UserService(hmppsAuthClient, prisonApiClientBuilder, systemToken)
 
 const app = createApp(userService)
 

--- a/server/routes/changeEstablishment.test.ts
+++ b/server/routes/changeEstablishment.test.ts
@@ -174,6 +174,7 @@ describe('POST /change-establishment', () => {
           username: 'user1',
           operationId: undefined,
         })
+        // @TODO should also check setActiveCaseLoad is called (awaiting VB-1430)
       })
   })
 
@@ -190,6 +191,7 @@ describe('POST /change-establishment', () => {
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
         expect(auditService.changeEstablishment).toHaveBeenCalledTimes(1)
       })
+    // @TODO should also check setActiveCaseLoad is called (awaiting VB-1430)
   })
 
   it('should redirect to valid page when passed in querystring', () => {

--- a/server/routes/changeEstablishment.ts
+++ b/server/routes/changeEstablishment.ts
@@ -8,11 +8,13 @@ import { clearSession } from './visitorUtils'
 import { safeReturnUrl } from '../utils/utils'
 import AuditService from '../services/auditService'
 import { Prison } from '../@types/bapv'
+import UserService from '../services/userService'
 
 export default function routes(
   router: Router,
   supportedPrisonsService: SupportedPrisonsService,
   auditService: AuditService,
+  userService: UserService,
 ): Router {
   const get = (path: string, ...handlers: RequestHandler[]) =>
     router.get(
@@ -67,6 +69,8 @@ export default function routes(
       username: res.locals.user?.username,
       operationId: res.locals.appInsightsOperationId,
     })
+
+    await userService.setActiveCaseLoad(newEstablishment.prisonId, res.locals.user?.username)
 
     return res.redirect(redirectUrl)
   })

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -45,7 +45,7 @@ export const flashProvider = jest.fn()
 
 class MockUserService extends UserService {
   constructor() {
-    super(undefined)
+    super(undefined, undefined, undefined)
   }
 
   async getUser(token: string) {
@@ -53,6 +53,10 @@ class MockUserService extends UserService {
       token,
       ...user,
     }
+  }
+
+  async setActiveCaseLoad(_caseLoadId: string, _username: string) {
+    return Promise.resolve()
   }
 }
 
@@ -142,6 +146,7 @@ function appSetup({
       standardRouter(new MockUserService(), new MockSupportedPrisonsService()),
       supportedPrisonsService,
       auditService,
+      new MockUserService(),
     ),
   )
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,16 +1,36 @@
 import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
+import PrisonApiClient from '../data/prisonApiClient'
+import { SystemToken } from '../@types/bapv'
+import logger from '../../logger'
 
 interface UserDetails {
   name: string
   displayName: string
 }
 
+type PrisonApiClientBuilder = (token: string) => PrisonApiClient
 export default class UserService {
-  constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
+  constructor(
+    private readonly hmppsAuthClient: HmppsAuthClient,
+    private readonly prisonApiClientBuilder: PrisonApiClientBuilder,
+    private readonly systemToken: SystemToken,
+  ) {}
 
   async getUser(token: string): Promise<UserDetails> {
     const user = await this.hmppsAuthClient.getUser(token)
     return { ...user, displayName: convertToTitleCase(user.name) }
+  }
+
+  async setActiveCaseLoad(caseLoadId: string, username: string): Promise<void> {
+    const token = await this.systemToken(username)
+    const prisonApiClient = this.prisonApiClientBuilder(token)
+
+    logger.info(`Setting case load to ${caseLoadId} for ${username}`)
+    try {
+      await prisonApiClient.setActiveCaseLoad(caseLoadId)
+    } catch (error) {
+      logger.error(`Couldn't set user case load to ${caseLoadId}`, error)
+    }
   }
 }


### PR DESCRIPTION
When changing establishment, also update the user's active case load so that this is reflected in, for example, DPS. Achieves this by calling `/api/users/me/activeCaseLoad` in the [Prison API](https://api-dev.prison.service.justice.gov.uk/swagger-ui/index.html#/users/updateMyActiveCaseLoad).

Caveats:
* if you are already logged into DPS and change establishment within VSiP, the selected establishment won't change in DPS until you next log in because the currently active case load is only looked up on login
* likewise, once logged into VSiP, any change of case load in DPS won't affect VSiP until next login