### PR TITLE
VB-1497: Visits by date - temp fix for capacity counts

### DIFF
--- a/server/routes/visits.ts
+++ b/server/routes/visits.ts
@@ -55,11 +55,10 @@ export default function routes(
       }
     }
 
-    const maxSlotDefaults = {
-      OPEN: 30,
-      CLOSED: 3,
-      UNKNOWN: 30,
-    }
+    // VB-1497 - temporary workaround for capacity counts for Hewell / Bristol
+    const maxSlotDefaults =
+      prisonId === 'HEI' ? { OPEN: 30, CLOSED: 3, UNKNOWN: 30 } : { OPEN: 20, CLOSED: 1, UNKNOWN: 20 }
+
     const maxSlots = maxSlotDefaults[visitType] ?? 0
     const firstTabDateString = getParsedDateFromQueryString(firstTabDate as string)
 


### PR DESCRIPTION
'View visits by date' page shows capacity counts hard-coded for Hewell. This change caters for Bristol having different values.

This is a temporary workaround until functionality added to calculate the capacity from the session template for the day.