### PR TITLE
VB-1497: Explicitly set Hewell, Bristol and default capacity values

### DIFF
--- a/server/routes/visits.test.ts
+++ b/server/routes/visits.test.ts
@@ -286,6 +286,30 @@ describe('GET /visits', () => {
       })
   })
 
+  // VB-1497 - checking temporary workaround for capacity counts
+  it('should show default capacity if not Hewell or Bristol', () => {
+    prisonerSearchService.getPrisonersByPrisonerNumbers.mockResolvedValue(prisoners)
+    visitSessionsService.getVisitsByDate.mockResolvedValue(visits)
+
+    app = appWithAllRoutes({
+      prisonerSearchServiceOverride: prisonerSearchService,
+      visitSessionsServiceOverride: visitSessionsService,
+      auditServiceOverride: auditService,
+      systemTokenOverride: systemToken,
+      sessionData: { selectedEstablishment: { prisonId: 'XYZ', prisonName: 'XYZ' } } as SessionData,
+    })
+
+    return request(app)
+      .get('/visits')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('h1').text()).toBe('View visits by date')
+        expect($('[data-test="visit-tables-booked"]').text()).toBe('1 of 0')
+      })
+  })
+
   it('should render visit slot summary page with prisoner list, slot details and menu for choosing other slots, with the chosen slot shown for OPEN', () => {
     prisonerSearchService.getPrisonersByPrisonerNumbers.mockResolvedValue(prisoners)
     visitSessionsService.getVisitsByDate.mockResolvedValue(visits)

--- a/server/routes/visits.ts
+++ b/server/routes/visits.ts
@@ -56,8 +56,14 @@ export default function routes(
     }
 
     // VB-1497 - temporary workaround for capacity counts for Hewell / Bristol
-    const maxSlotDefaults =
-      prisonId === 'HEI' ? { OPEN: 30, CLOSED: 3, UNKNOWN: 30 } : { OPEN: 20, CLOSED: 1, UNKNOWN: 20 }
+    let maxSlotDefaults: { OPEN: number; CLOSED: number; UNKNOWN: number }
+    if (prisonId === 'HEI') {
+      maxSlotDefaults = { OPEN: 30, CLOSED: 3, UNKNOWN: 30 }
+    } else if (prisonId === 'BLI') {
+      maxSlotDefaults = { OPEN: 20, CLOSED: 1, UNKNOWN: 20 }
+    } else {
+      maxSlotDefaults = { OPEN: 0, CLOSED: 0, UNKNOWN: 0 }
+    }
 
     const maxSlots = maxSlotDefaults[visitType] ?? 0
     const firstTabDateString = getParsedDateFromQueryString(firstTabDate as string)

--- a/server/routes/visits.ts
+++ b/server/routes/visits.ts
@@ -56,13 +56,11 @@ export default function routes(
     }
 
     // VB-1497 - temporary workaround for capacity counts for Hewell / Bristol
-    let maxSlotDefaults: { OPEN: number; CLOSED: number; UNKNOWN: number }
+    let maxSlotDefaults = { OPEN: 0, CLOSED: 0, UNKNOWN: 0 }
     if (prisonId === 'HEI') {
       maxSlotDefaults = { OPEN: 30, CLOSED: 3, UNKNOWN: 30 }
     } else if (prisonId === 'BLI') {
       maxSlotDefaults = { OPEN: 20, CLOSED: 1, UNKNOWN: 20 }
-    } else {
-      maxSlotDefaults = { OPEN: 0, CLOSED: 0, UNKNOWN: 0 }
     }
 
     const maxSlots = maxSlotDefaults[visitType] ?? 0


### PR DESCRIPTION
Explicitly set capacity counts for Hewell, Bristol and 'default' on the 'View visits by date' page (change suggested as feedback #439)

(Still a temporary fix while working on how to derive these from session templates.)