### PR TITLE
VB-1540, remove supportTypes duplication, added to testObject

### DIFF
--- a/server/data/__testutils/testObjects.ts
+++ b/server/data/__testutils/testObjects.ts
@@ -1,5 +1,6 @@
 import { Prison } from '../../@types/bapv'
 import { CaseLoad } from '../prisonApiTypes'
+import { SupportType } from '../visitSchedulerApiTypes'
 
 export const createCaseLoads = ({
   caseLoads = [
@@ -41,3 +42,28 @@ export const createSupportedPrisons = ({
 } = {}): Record<string, string> => prisons
 
 export const createSupportedPrisonIds = ({ prisonIds = ['HEI', 'BLI'] } = {}): string[] => prisonIds
+
+export const createSupportTypes = ({
+  supportTypes = [
+    {
+      type: 'WHEELCHAIR',
+      description: 'Wheelchair ramp',
+    },
+    {
+      type: 'INDUCTION_LOOP',
+      description: 'Portable induction loop for people with hearing aids',
+    },
+    {
+      type: 'BSL_INTERPRETER',
+      description: 'British Sign Language (BSL) Interpreter',
+    },
+    {
+      type: 'MASK_EXEMPT',
+      description: 'Face covering exemption',
+    },
+    {
+      type: 'OTHER',
+      description: 'Other',
+    },
+  ] as SupportType[],
+} = {}): SupportType[] => supportTypes

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -3,13 +3,13 @@ import { VisitSessionData } from '../@types/bapv'
 import config from '../config'
 import VisitSchedulerApiClient, { visitSchedulerApiClientBuilder } from './visitSchedulerApiClient'
 import {
-  SupportType,
   Visit,
   OutcomeDto,
   VisitSession,
   ReserveVisitSlotDto,
   ChangeVisitSlotRequestDto,
 } from './visitSchedulerApiTypes'
+import { createSupportTypes } from './__testutils/testObjects'
 
 describe('visitSchedulerApiClient', () => {
   let fakeVisitSchedulerApi: nock.Scope
@@ -44,16 +44,7 @@ describe('visitSchedulerApiClient', () => {
 
   describe('getAvailableSupportOptions', () => {
     it('should return an array of available support types', async () => {
-      const results: SupportType[] = [
-        {
-          type: 'WHEELCHAIR',
-          description: 'Wheelchair ramp',
-        },
-        {
-          type: 'OTHER',
-          description: 'Other',
-        },
-      ]
+      const results = createSupportTypes()
 
       fakeVisitSchedulerApi.get('/visit-support').matchHeader('authorization', `Bearer ${token}`).reply(200, results)
 

--- a/server/routes/visitJourney/additionalSupport.test.ts
+++ b/server/routes/visitJourney/additionalSupport.test.ts
@@ -4,7 +4,8 @@ import { SessionData } from 'express-session'
 import * as cheerio from 'cheerio'
 import { VisitSessionData } from '../../@types/bapv'
 import { appWithAllRoutes, flashProvider } from '../testutils/appSetup'
-import { SupportType, VisitorSupport } from '../../data/visitSchedulerApiTypes'
+import { VisitorSupport } from '../../data/visitSchedulerApiTypes'
+import { createSupportTypes } from '../../data/__testutils/testObjects'
 
 let sessionApp: Express
 const systemToken = async (user: string): Promise<string> => `${user}-token-1`
@@ -15,28 +16,7 @@ let visitSessionData: VisitSessionData
 // run tests for booking and update journeys
 const testJourneys = [{ urlPrefix: '/book-a-visit' }, { urlPrefix: '/visit/ab-cd-ef-gh/update' }]
 
-const availableSupportTypes: SupportType[] = [
-  {
-    type: 'WHEELCHAIR',
-    description: 'Wheelchair ramp',
-  },
-  {
-    type: 'INDUCTION_LOOP',
-    description: 'Portable induction loop for people with hearing aids',
-  },
-  {
-    type: 'BSL_INTERPRETER',
-    description: 'British Sign Language (BSL) Interpreter',
-  },
-  {
-    type: 'MASK_EXEMPT',
-    description: 'Face covering exemption',
-  },
-  {
-    type: 'OTHER',
-    description: 'Other',
-  },
-]
+const availableSupportTypes = createSupportTypes()
 
 beforeEach(() => {
   flashData = { errors: [], formValues: [] }

--- a/server/routes/visitJourney/checkYourBooking.test.ts
+++ b/server/routes/visitJourney/checkYourBooking.test.ts
@@ -6,9 +6,10 @@ import { VisitSessionData } from '../../@types/bapv'
 import VisitSessionsService from '../../services/visitSessionsService'
 import AuditService from '../../services/auditService'
 import { appWithAllRoutes, flashProvider } from '../testutils/appSetup'
-import { SupportType, Visit } from '../../data/visitSchedulerApiTypes'
+import { Visit } from '../../data/visitSchedulerApiTypes'
 import config from '../../config'
 import NotificationsService from '../../services/notificationsService'
+import { createSupportTypes } from '../../data/__testutils/testObjects'
 
 jest.mock('../../services/visitSessionsService')
 jest.mock('../../services/auditService')
@@ -25,28 +26,7 @@ const testJourneys = [
   { urlPrefix: '/visit/ab-cd-ef-gh/update', isUpdate: true },
 ]
 
-const availableSupportTypes: SupportType[] = [
-  {
-    type: 'WHEELCHAIR',
-    description: 'Wheelchair ramp',
-  },
-  {
-    type: 'INDUCTION_LOOP',
-    description: 'Portable induction loop for people with hearing aids',
-  },
-  {
-    type: 'BSL_INTERPRETER',
-    description: 'British Sign Language (BSL) Interpreter',
-  },
-  {
-    type: 'MASK_EXEMPT',
-    description: 'Face covering exemption',
-  },
-  {
-    type: 'OTHER',
-    description: 'Other',
-  },
-]
+const availableSupportTypes = createSupportTypes()
 
 beforeEach(() => {
   flashData = { errors: [], formValues: [] }

--- a/server/routes/visitJourney/confirmation.test.ts
+++ b/server/routes/visitJourney/confirmation.test.ts
@@ -4,8 +4,8 @@ import { SessionData } from 'express-session'
 import * as cheerio from 'cheerio'
 import { VisitSessionData } from '../../@types/bapv'
 import { appWithAllRoutes, flashProvider } from '../testutils/appSetup'
-import { SupportType } from '../../data/visitSchedulerApiTypes'
 import * as visitorUtils from '../visitorUtils'
+import { createSupportTypes } from '../../data/__testutils/testObjects'
 
 let sessionApp: Express
 const systemToken = async (user: string): Promise<string> => `${user}-token-1`
@@ -19,28 +19,7 @@ const testJourneys = [
   { urlPrefix: '/visit/ab-cd-ef-gh/update', isUpdate: true },
 ]
 
-const availableSupportTypes: SupportType[] = [
-  {
-    type: 'WHEELCHAIR',
-    description: 'Wheelchair ramp',
-  },
-  {
-    type: 'INDUCTION_LOOP',
-    description: 'Portable induction loop for people with hearing aids',
-  },
-  {
-    type: 'BSL_INTERPRETER',
-    description: 'British Sign Language (BSL) Interpreter',
-  },
-  {
-    type: 'MASK_EXEMPT',
-    description: 'Face covering exemption',
-  },
-  {
-    type: 'OTHER',
-    description: 'Other',
-  },
-]
+const availableSupportTypes = createSupportTypes()
 
 beforeEach(() => {
   flashData = { errors: [], formValues: [] }

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -3,7 +3,7 @@ import PrisonerContactRegistryApiClient from '../data/prisonerContactRegistryApi
 import VisitSessionsService from './visitSessionsService'
 import VisitSchedulerApiClient from '../data/visitSchedulerApiClient'
 import WhereaboutsApiClient from '../data/whereaboutsApiClient'
-import { VisitSession, Visit, SupportType, OutcomeDto } from '../data/visitSchedulerApiTypes'
+import { VisitSession, Visit, OutcomeDto } from '../data/visitSchedulerApiTypes'
 import { Address, Contact, AddressUsage, Restriction } from '../data/prisonerContactRegistryApiTypes'
 import {
   VisitSlotList,
@@ -14,6 +14,7 @@ import {
   VisitsPageSlot,
 } from '../@types/bapv'
 import { ScheduledEvent } from '../data/whereaboutsApiTypes'
+import { createSupportTypes } from '../data/__testutils/testObjects'
 
 jest.mock('../data/prisonerContactRegistryApiClient')
 jest.mock('../data/visitSchedulerApiClient')
@@ -33,16 +34,7 @@ describe('Visit sessions service', () => {
   let systemToken
 
   const prisonId = 'HEI'
-  const availableSupportTypes: SupportType[] = [
-    {
-      type: 'WHEELCHAIR',
-      description: 'Wheelchair ramp',
-    },
-    {
-      type: 'OTHER',
-      description: 'Other',
-    },
-  ]
+  const availableSupportTypes = createSupportTypes()
 
   beforeEach(() => {
     systemToken = async (user: string): Promise<string> => `${user}-token-1`


### PR DESCRIPTION
createSupportTypes() can now be called in place of all availableSupportType declarations. 
No generator feature was used as these are always currently just carbon copy definitions of available support types