### PR TITLE
VB-1547: Trim whitespace - visit cancellation reason & main contact name

### DIFF
--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -730,7 +730,7 @@ describe('POST /visit/:reference/cancel', () => {
     return request(app)
       .post('/visit/ab-cd-ef-gh/cancel')
       .send('cancel=PRISONER_CANCELLED')
-      .send('reason_prisoner_cancelled=illness')
+      .send('reason_prisoner_cancelled=++illness++')
       .expect(302)
       .expect('location', '/visit/cancelled')
       .expect(() => {
@@ -824,10 +824,13 @@ describe('POST /visit/:reference/cancel', () => {
             location: 'body',
             msg: 'Enter a reason for the cancellation',
             param: 'reason_prisoner_cancelled',
-            value: undefined,
+            value: '',
           },
         ])
-        expect(flashProvider).toHaveBeenCalledWith('formValues', { cancel: 'PRISONER_CANCELLED' })
+        expect(flashProvider).toHaveBeenCalledWith('formValues', {
+          cancel: 'PRISONER_CANCELLED',
+          reason_prisoner_cancelled: '',
+        })
         expect(auditService.cancelledVisit).not.toHaveBeenCalled()
       })
   })

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -288,7 +288,7 @@ export default function routes(
     async (req, res) => {
       const reasonFieldName = `reason_${req.body.cancel}`.toLowerCase()
       if (validationResult(req).isEmpty()) {
-        await body(reasonFieldName).notEmpty().withMessage('Enter a reason for the cancellation').run(req)
+        await body(reasonFieldName).trim().notEmpty().withMessage('Enter a reason for the cancellation').run(req)
       }
 
       const errors = validationResult(req)

--- a/server/routes/visitJourney/mainContact.test.ts
+++ b/server/routes/visitJourney/mainContact.test.ts
@@ -222,7 +222,7 @@ testJourneys.forEach(journey => {
         return request(sessionApp)
           .post(`${journey.urlPrefix}/select-main-contact`)
           .send('contact=123')
-          .send('phoneNumber=0114+1234+567')
+          .send('phoneNumber=+0114+1234+567+')
           .expect(302)
           .expect('location', `${journey.urlPrefix}/check-your-booking`)
           .expect(() => {
@@ -242,7 +242,7 @@ testJourneys.forEach(journey => {
         return request(sessionApp)
           .post(`${journey.urlPrefix}/select-main-contact`)
           .send('contact=someoneElse')
-          .send('someoneElseName=another+person')
+          .send('someoneElseName=++another+person++')
           .send('phoneNumber=0114+7654+321')
           .expect(302)
           .expect('location', `${journey.urlPrefix}/check-your-booking`)
@@ -287,9 +287,9 @@ testJourneys.forEach(journey => {
           .expect(() => {
             expect(flashProvider).toHaveBeenCalledWith('errors', [
               { location: 'body', msg: 'No main contact selected', param: 'contact', value: undefined },
-              { location: 'body', msg: 'Enter a phone number', param: 'phoneNumber', value: undefined },
+              { location: 'body', msg: 'Enter a phone number', param: 'phoneNumber', value: '' },
             ])
-            expect(flashProvider).toHaveBeenCalledWith('formValues', {})
+            expect(flashProvider).toHaveBeenCalledWith('formValues', { phoneNumber: '', someoneElseName: '' })
           })
       })
 
@@ -333,6 +333,7 @@ testJourneys.forEach(journey => {
             expect(flashProvider).toHaveBeenCalledWith('formValues', {
               contact: 'non-existant',
               phoneNumber: 'abc123',
+              someoneElseName: '',
             })
           })
       })

--- a/server/routes/visitJourney/mainContact.ts
+++ b/server/routes/visitJourney/mainContact.ts
@@ -65,24 +65,28 @@ export default class MainContact {
 
         return true
       }),
-      body('someoneElseName').custom((value: string, { req }) => {
-        if (value === '' && req.body.contact === 'someoneElse') {
-          throw new Error('Enter the name of the main contact')
-        }
+      body('someoneElseName')
+        .trim()
+        .custom((value: string, { req }) => {
+          if (value === '' && req.body.contact === 'someoneElse') {
+            throw new Error('Enter the name of the main contact')
+          }
 
-        return true
-      }),
-      body('phoneNumber').custom((value: string) => {
-        if (!value) {
-          throw new Error('Enter a phone number')
-        }
+          return true
+        }),
+      body('phoneNumber')
+        .trim()
+        .custom((value: string) => {
+          if (!value) {
+            throw new Error('Enter a phone number')
+          }
 
-        if (!/^(?:0|\+?44)(?:\d\s?){9,10}$/.test(value)) {
-          throw new Error('Enter a valid UK phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192')
-        }
+          if (!/^(?:0|\+?44)(?:\d\s?){9,10}$/.test(value)) {
+            throw new Error('Enter a valid UK phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192')
+          }
 
-        return true
-      }),
+          return true
+        }),
     ]
   }
 }


### PR DESCRIPTION
Trim whitespace so it isn't sent back to the visit scheduler when:
* entering a visit cancellation reason
* entering a custom main contact name