### PR TITLE
VB-1565, add Bristol+Hewell Prison phone numbers to cancellation

### DIFF
--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -759,7 +759,30 @@ describe('POST /visit/:reference/cancel', () => {
           phoneNumber: cancelledVisit.visitContact.telephone,
           visitSlot: cancelledVisit.startTimestamp,
           prisonName: 'Hewell (HMP)',
-          prisonPhoneNumber: '01234443225',
+          prisonPhoneNumber: '0300 060 6503',
+        })
+      })
+  })
+
+  it('should send the SMS with the correct prison phone number - Bristol', () => {
+    cancelledVisit.prisonId = 'BLI'
+    config.apis.notifications.enabled = true
+
+    return request(app)
+      .post('/visit/ab-cd-ef-gh/cancel')
+      .send('cancel=PRISONER_CANCELLED')
+      .send('reason_prisoner_cancelled=illness')
+      .expect(302)
+      .expect('location', '/visit/cancelled')
+      .expect(() => {
+        expect(visitSessionsService.cancelVisit).toHaveBeenCalledTimes(1)
+        expect(auditService.cancelledVisit).toHaveBeenCalledTimes(1)
+        expect(notificationsService.sendCancellationSms).toHaveBeenCalledTimes(1)
+        expect(notificationsService.sendCancellationSms).toHaveBeenCalledWith({
+          phoneNumber: cancelledVisit.visitContact.telephone,
+          visitSlot: cancelledVisit.startTimestamp,
+          prisonName: 'Bristol (HMP & YOI)',
+          prisonPhoneNumber: '0300 060 6510',
         })
       })
   })

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -323,11 +323,19 @@ export default function routes(
           const supportedPrisons = await supportedPrisonsService.getSupportedPrisons(res.locals.user?.username)
           const prisonName = supportedPrisons[visit.prisonId]
 
+          // Current prison phone number configuration, look to move in the future
+          let prisonPhoneNumber = ''
+          if (prisonName === 'Hewell (HMP)') {
+            prisonPhoneNumber = '0300 060 6503'
+          } else if (prisonName === 'Bristol (HMP & YOI)') {
+            prisonPhoneNumber = '0300 060 6510'
+          }
+
           await notificationsService.sendCancellationSms({
             phoneNumber,
             visitSlot: visit.startTimestamp,
             prisonName,
-            prisonPhoneNumber: '01234443225',
+            prisonPhoneNumber,
           })
           logger.info(`Cancellation SMS sent for ${reference}`)
         } catch (error) {


### PR DESCRIPTION
## Description
Cancellation SMS had test data being sent out as the prison phone number.
Updated the Cancellation SMS function call to include the correct prison phone number, based on which prison the visit was booked for