### PR TITLE
VB-1600, Add reference to cancellation SMS

### DIFF
--- a/server/data/notificationsApiClient.test.ts
+++ b/server/data/notificationsApiClient.test.ts
@@ -51,24 +51,26 @@ describe('GOV.UK Notify client', () => {
   })
 
   describe('sendCancellationSms', () => {
-    const confirmationDetails = {
+    const cancellationDetails = {
       phoneNumber: '07123456789',
       prisonPhoneNumber: '01234443225',
       prisonName: 'Hewell',
       visitTime: '10:00am',
       visitDate: '1 August 2022',
+      reference: 'ab-cd-ef-gh',
     }
 
     it('should call notifications client sendCancellationSms() with the correct booking cancellation parameters', async () => {
-      await notificationsApiClient.sendCancellationSms(confirmationDetails)
+      await notificationsApiClient.sendCancellationSms(cancellationDetails)
 
       expect(mockSendSms).toHaveBeenCalledTimes(1)
-      expect(mockSendSms).toHaveBeenCalledWith(cancellationConfirmation, confirmationDetails.phoneNumber, {
+      expect(mockSendSms).toHaveBeenCalledWith(cancellationConfirmation, cancellationDetails.phoneNumber, {
         personalisation: {
-          prison: confirmationDetails.prisonName,
-          'prison phone number': confirmationDetails.prisonPhoneNumber,
-          time: confirmationDetails.visitTime,
-          date: confirmationDetails.visitDate,
+          prison: cancellationDetails.prisonName,
+          'prison phone number': cancellationDetails.prisonPhoneNumber,
+          time: cancellationDetails.visitTime,
+          date: cancellationDetails.visitDate,
+          reference: cancellationDetails.reference,
         },
       })
     })

--- a/server/data/notificationsApiClient.ts
+++ b/server/data/notificationsApiClient.ts
@@ -51,12 +51,14 @@ class NotificationsApiClient {
     visitTime,
     visitDate,
     prisonPhoneNumber,
+    reference,
   }: {
     phoneNumber: string
     prisonName: string
     visitTime: string
     visitDate: string
     prisonPhoneNumber: string
+    reference: string
   }): Promise<SmsResponse> {
     return this.notificationsApiClient.sendSms(templates.cancellationConfirmation, phoneNumber, {
       personalisation: {
@@ -64,6 +66,7 @@ class NotificationsApiClient {
         time: visitTime,
         date: visitDate,
         'prison phone number': prisonPhoneNumber,
+        reference,
       },
     })
   }

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -760,6 +760,7 @@ describe('POST /visit/:reference/cancel', () => {
           visitSlot: cancelledVisit.startTimestamp,
           prisonName: 'Hewell (HMP)',
           prisonPhoneNumber: '0300 060 6503',
+          reference: 'ab-cd-ef-gh',
         })
       })
   })
@@ -783,6 +784,7 @@ describe('POST /visit/:reference/cancel', () => {
           visitSlot: cancelledVisit.startTimestamp,
           prisonName: 'Bristol (HMP & YOI)',
           prisonPhoneNumber: '0300 060 6510',
+          reference: 'ab-cd-ef-gh',
         })
       })
   })

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -336,6 +336,7 @@ export default function routes(
             visitSlot: visit.startTimestamp,
             prisonName,
             prisonPhoneNumber,
+            reference,
           })
           logger.info(`Cancellation SMS sent for ${reference}`)
         } catch (error) {

--- a/server/services/notificationsService.test.ts
+++ b/server/services/notificationsService.test.ts
@@ -55,6 +55,7 @@ describe('Notifications service', () => {
       prisonName: 'Hewell',
       prisonPhoneNumber: '01234443225',
       visitSlot: '2022-02-14T10:00:00',
+      reference: 'ab-cd-ef-gh',
     }
 
     it('should call the notifications client with the cancellation details', async () => {
@@ -67,6 +68,7 @@ describe('Notifications service', () => {
         prisonName: visitDetails.prisonName,
         visitTime: '10:00am',
         visitDate: '14 February 2022',
+        reference: visitDetails.reference,
       })
     })
   })

--- a/server/services/notificationsService.ts
+++ b/server/services/notificationsService.ts
@@ -40,11 +40,13 @@ export default class NotificationsService {
     prisonName,
     visitSlot,
     prisonPhoneNumber,
+    reference,
   }: {
     phoneNumber: string
     prisonName: string
     visitSlot: string
     prisonPhoneNumber: string
+    reference: string
   }): Promise<SmsResponse> {
     const notificationsApiClient = this.notificationsApiClientBuilder()
     const parsedDate = new Date(visitSlot)
@@ -57,6 +59,7 @@ export default class NotificationsService {
       visitTime,
       visitDate,
       prisonPhoneNumber,
+      reference,
     })
   }
 


### PR DESCRIPTION
## Description
Add visit reference to Cancellation SMS to be used in Gov Notify.
Also changes the naming of a test data in notificationsApiClient.test as it was misleading