### PR TITLE
Pin CircleCI npm to 9.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - checkout
       - run:
           name: Update npm
-          command: 'npm install -g npm@latest'
+          command: 'npm install -g npm@9.2.0'
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:


### PR DESCRIPTION
Pin npm to 9.2.0 because of the issue https://github.com/npm/cli/issues/6051

See Slack thread https://mojdt.slack.com/archives/C69NWE339/p1673607422599409