### PR TITLE
Revert "Pin CircleCI npm to 9.2.0"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - checkout
       - run:
           name: Update npm
-          command: 'npm install -g npm@9.2.0'
+          command: 'npm install -g npm@latest'
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:


### PR DESCRIPTION
Reverts ministryofjustice/book-a-prison-visit-staff-ui#466

Issue with `npm` that required us to pin the version now looks to be fixed (https://github.com/npm/cli/releases/tag/v9.3.1)