### PR TITLE
VB-1594: Consolidate prison specific config

### DIFF
--- a/server/constants/prisonConfiguration.test.ts
+++ b/server/constants/prisonConfiguration.test.ts
@@ -1,0 +1,21 @@
+import getPrisonConfiguration from './prisonConfiguration'
+
+describe('Prison configuration', () => {
+  it('should return correct prison configuration for requested prisonId', () => {
+    const prisonConfiguration = getPrisonConfiguration('HEI')
+
+    expect(prisonConfiguration.prisonPhoneNumber).toBe('0300 060 6503')
+    expect(prisonConfiguration.selectVisitorsText.length).toBe(2)
+    expect(prisonConfiguration.visitCapacity.open).toBe(30)
+    expect(prisonConfiguration.visitCapacity.closed).toBe(3)
+  })
+
+  it('should return default prison configuration when none available for requested prisonId', () => {
+    const prisonConfiguration = getPrisonConfiguration('XYZ')
+
+    expect(prisonConfiguration.prisonPhoneNumber).toBe('')
+    expect(prisonConfiguration.selectVisitorsText.length).toBe(0)
+    expect(prisonConfiguration.visitCapacity.open).toBe(null)
+    expect(prisonConfiguration.visitCapacity.closed).toBe(null)
+  })
+})

--- a/server/constants/prisonConfiguration.ts
+++ b/server/constants/prisonConfiguration.ts
@@ -1,0 +1,48 @@
+type PrisonConfiguration = {
+  prisonPhoneNumber: string
+  selectVisitorsText: string[]
+  visitCapacity: {
+    open: number
+    closed: number
+  }
+}
+
+const prisonConfiguration: Record<string, PrisonConfiguration> = {
+  BLI: {
+    prisonPhoneNumber: '0300 060 6510',
+    selectVisitorsText: [
+      'Add up to 3 adults (aged 18 or older). Children can also be added to the visit.',
+      'Contact HMP Bristol when the total number of visitors (adults and children) is more than 3.',
+    ],
+    visitCapacity: {
+      open: 20,
+      closed: 1,
+    },
+  },
+  HEI: {
+    prisonPhoneNumber: '0300 060 6503',
+    selectVisitorsText: [
+      'Add up to 3 people aged 10 and over, and 4 children under 10 years old.',
+      'At least one visitor must be 18 or older.',
+    ],
+    visitCapacity: {
+      open: 30,
+      closed: 3,
+    },
+  },
+}
+
+const defaultConfiguration: PrisonConfiguration = {
+  prisonPhoneNumber: '',
+  selectVisitorsText: [],
+  visitCapacity: {
+    open: null,
+    closed: null,
+  },
+}
+
+const getPrisonConfiguration = (prisonId: string): PrisonConfiguration => {
+  return prisonConfiguration[prisonId] ?? defaultConfiguration
+}
+
+export default getPrisonConfiguration

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -26,6 +26,7 @@ import Confirmation from './visitJourney/confirmation'
 import MainContact from './visitJourney/mainContact'
 import sessionCheckMiddleware from '../middleware/sessionCheckMiddleware'
 import SupportedPrisonsService from '../services/supportedPrisonsService'
+import getPrisonConfiguration from '../constants/prisonConfiguration'
 
 export default function routes(
   router: Router,
@@ -323,13 +324,7 @@ export default function routes(
           const supportedPrisons = await supportedPrisonsService.getSupportedPrisons(res.locals.user?.username)
           const prisonName = supportedPrisons[visit.prisonId]
 
-          // Current prison phone number configuration, look to move in the future
-          let prisonPhoneNumber = ''
-          if (prisonName === 'Hewell (HMP)') {
-            prisonPhoneNumber = '0300 060 6503'
-          } else if (prisonName === 'Bristol (HMP & YOI)') {
-            prisonPhoneNumber = '0300 060 6510'
-          }
+          const { prisonPhoneNumber } = getPrisonConfiguration(visit.prisonId)
 
           await notificationsService.sendCancellationSms({
             phoneNumber,

--- a/server/routes/visitJourney/selectVisitors.ts
+++ b/server/routes/visitJourney/selectVisitors.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from 'express'
 import { body, ValidationChain, validationResult } from 'express-validator'
 import { VisitorListItem } from '../../@types/bapv'
+import getPrisonConfiguration from '../../constants/prisonConfiguration'
 import PrisonerProfileService from '../../services/prisonerProfileService'
 import PrisonerVisitorsService from '../../services/prisonerVisitorsService'
 import { getFlashFormValues } from '../visitorUtils'
@@ -32,6 +33,7 @@ export default class SelectVisitors {
 
     visitSessionData.prisoner.restrictions = restrictions
 
+    const { selectVisitorsText } = getPrisonConfiguration(req.session.selectedEstablishment.prisonId)
     const formValues = getFlashFormValues(req)
     if (!Object.keys(formValues).length && visitSessionData.visitors) {
       formValues.visitors = visitSessionData.visitors.map(visitor => visitor.personId.toString())
@@ -45,6 +47,7 @@ export default class SelectVisitors {
       prisonerName: visitSessionData.prisoner.name,
       visitorList,
       restrictions,
+      selectVisitorsText,
       formValues,
       urlPrefix: getUrlPrefix(isUpdate, visitSessionData.visitReference),
       backLink: returnAddress,

--- a/server/routes/visits.test.ts
+++ b/server/routes/visits.test.ts
@@ -248,7 +248,6 @@ describe('GET /visits', () => {
       })
   })
 
-  // VB-1497 - checking temporary workaround for capacity counts
   it('should show the correct capacity for Bristol', () => {
     prisonerSearchService.getPrisonersByPrisonerNumbers.mockResolvedValue(prisoners)
     visitSessionsService.getVisitsByDate.mockResolvedValue(visits)
@@ -289,8 +288,7 @@ describe('GET /visits', () => {
       })
   })
 
-  // VB-1497 - checking temporary workaround for capacity counts
-  it('should show default capacity if not Hewell or Bristol', () => {
+  it('should not show capacity if not a configured prison (i.e. Hewell or Bristol)', () => {
     prisonerSearchService.getPrisonersByPrisonerNumbers.mockResolvedValue(prisoners)
     visitSessionsService.getVisitsByDate.mockResolvedValue(visits)
 
@@ -309,7 +307,7 @@ describe('GET /visits', () => {
       .expect(res => {
         const $ = cheerio.load(res.text)
         expect($('h1').text()).toBe('View visits by date')
-        expect($('[data-test="visit-tables-booked"]').text()).toBe('1 of 0')
+        expect($('[data-test="visit-tables-booked"]').text()).toBe('1')
       })
   })
 
@@ -359,7 +357,7 @@ describe('GET /visits', () => {
         expect($('.govuk-back-link').attr('href')).toBe('/')
         expect($('[data-test="visit-room"]').text()).toBe('Visit type unknown')
         expect($('[data-test="visit-time"]').text()).toBe('10am to 11am')
-        expect($('[data-test="visit-tables-booked"]').text()).toBe('1 of 30')
+        expect($('[data-test="visit-tables-booked"]').text()).toBe('1')
         expect($('[data-test="visit-visitors-total"]').text()).toBe('2')
         expect($('[data-test="visit-adults"]').text()).toBe('1')
         expect($('[data-test="visit-children"]').text()).toBe('1')

--- a/server/routes/visits.ts
+++ b/server/routes/visits.ts
@@ -7,6 +7,7 @@ import VisitSessionsService from '../services/visitSessionsService'
 import AuditService from '../services/auditService'
 import { getResultsPagingLinks } from '../utils/utils'
 import { getDateTabs, getParsedDateFromQueryString, getSlotsSideMenuData } from './visitsUtils'
+import getPrisonConfiguration from '../constants/prisonConfiguration'
 
 export default function routes(
   router: Router,
@@ -55,15 +56,21 @@ export default function routes(
       }
     }
 
-    // VB-1497 - temporary workaround for capacity counts for Hewell / Bristol
-    let maxSlotDefaults = { OPEN: 0, CLOSED: 0, UNKNOWN: 0 }
-    if (prisonId === 'HEI') {
-      maxSlotDefaults = { OPEN: 30, CLOSED: 3, UNKNOWN: 30 }
-    } else if (prisonId === 'BLI') {
-      maxSlotDefaults = { OPEN: 20, CLOSED: 1, UNKNOWN: 20 }
+    let maxSlots: number
+    const prisonConfiguration = getPrisonConfiguration(prisonId)
+    switch (visitType) {
+      case 'OPEN':
+        maxSlots = prisonConfiguration.visitCapacity.open
+        break
+
+      case 'CLOSED':
+        maxSlots = prisonConfiguration.visitCapacity.closed
+        break
+
+      default:
+        maxSlots = null
     }
 
-    const maxSlots = maxSlotDefaults[visitType] ?? 0
     const firstTabDateString = getParsedDateFromQueryString(firstTabDate as string)
 
     const slotFilter = time === '' ? slots.firstSlotTime : time

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -120,13 +120,9 @@
       </p>
       {% endif %}
 
-      {% if selectedEstablishment.prisonId === 'HEI' %}
-        <p data-test="visitor-information-1">Add up to 3 people aged 10 and over, and 4 children under 10 years old.</p>
-        <p data-test="visitor-information-2">At least one visitor must be 18 or older.</p>
-      {% elseif selectedEstablishment.prisonId === 'BLI' %}
-        <p data-test="visitor-information-1">Add up to 3 adults (aged 18 or older). Children can also be added to the visit.</p>
-        <p data-test="visitor-information-2">Contact HMP Bristol when the total number of visitors (adults and children) is more than 3.</p>
-      {% endif %}
+      {% for textItem in selectVisitorsText %}
+        <p data-test="visitor-information-{{ loop.index }}">{{ textItem }}</p>
+      {% endfor %}
 
       <form action="{{ urlPrefix }}/select-visitors" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/server/views/pages/visits/summary.njk
+++ b/server/views/pages/visits/summary.njk
@@ -120,7 +120,7 @@
         {% endif %}
         <span data-test="visit-time">{{ slotTime }}</span>
       </h2>
-      <p><span data-test="visit-tables-booked">{{ numberOfResults }} of {{ maxSlots }}</span> tables booked</p>
+      <p><span data-test="visit-tables-booked">{{ numberOfResults }}{% if maxSlots %} of {{ maxSlots }}{% endif %}</span> tables booked</p>
       <p><span data-test="visit-visitors-total">{{ totals.visitors }}</span> visitor{% if totals.visitors != 1 %}s{% endif %} (<span data-test="visit-adults">{{ totals.adults }}</span> adult{% if totals.adults != 1 %}s{% endif %} and <span data-test="visit-children">{{ totals.children }}</span> child{% if (totals.children != 1) %}ren{% endif %})</p>
         {% set pagination %}
           {{ mojPagination({


### PR DESCRIPTION
* Consolidate prison-specific information (phone number, advisory text for visitors numbers, slot capacities) into a simple lookup function.
* It defaults to empty values if a prison hasn't been configured, meaning that new supported prisons can be tested before specific configuration information is available
* Update code and tests to use this information

This change means that adding appropriate configuration information for new prisons now only requires adding entries to `server/constants/prisonConfiguration.ts` rather than changing custom code in multiple places. (Longer-term this may be reworked as the orchestration service may end up proving some of this information.)