### PR TITLE
VB-1731, overlapping sessions bug fix

### DIFF
--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { VisitSlot } from '../../@types/bapv'
 import AuditService from '../../services/auditService'
 import VisitSessionsService from '../../services/visitSessionsService'
-import { getFlashFormValues, getSelectedSlot, getSlotByStartTimeAndRestriction } from '../visitorUtils'
+import { getFlashFormValues, getSelectedSlot, getSlotByTimeAndRestriction } from '../visitorUtils'
 import getUrlPrefix from './visitJourneyUtils'
 
 export default class DateAndTime {
@@ -30,7 +30,7 @@ export default class DateAndTime {
 
     // first time here on update journey, visitSlot.id will be ''
     if (isUpdate && visitSessionData.visitSlot?.id === '') {
-      matchingSlot = getSlotByStartTimeAndRestriction(
+      matchingSlot = getSlotByTimeAndRestriction(
         slotsList,
         visitSessionData.visitSlot.startTimestamp,
         visitSessionData.visitSlot.endTimestamp,
@@ -64,7 +64,7 @@ export default class DateAndTime {
     if (isUpdate && visitSessionData.originalVisitSlot) {
       // matching on original time but session's current visit restriction to ensure
       // originally selected time slot is available for re-selection even if restriction changes
-      originalVisitSlot = getSlotByStartTimeAndRestriction(
+      originalVisitSlot = getSlotByTimeAndRestriction(
         slotsList,
         visitSessionData.originalVisitSlot.startTimestamp,
         visitSessionData.originalVisitSlot.endTimestamp,

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -33,6 +33,7 @@ export default class DateAndTime {
       matchingSlot = getSlotByStartTimeAndRestriction(
         slotsList,
         visitSessionData.visitSlot.startTimestamp,
+        visitSessionData.visitSlot.endTimestamp,
         visitSessionData.visitRestriction,
       )
 
@@ -66,6 +67,7 @@ export default class DateAndTime {
       originalVisitSlot = getSlotByStartTimeAndRestriction(
         slotsList,
         visitSessionData.originalVisitSlot.startTimestamp,
+        visitSessionData.originalVisitSlot.endTimestamp,
         visitSessionData.visitRestriction,
       )
     }

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express'
 import { Session, SessionData } from 'express-session'
 import { Prison, VisitSlot, VisitSlotList } from '../@types/bapv'
-import { clearSession, getFlashFormValues, getSelectedSlot, getSlotByStartTimeAndRestriction } from './visitorUtils'
+import { clearSession, getFlashFormValues, getSelectedSlot, getSlotByTimeAndRestriction } from './visitorUtils'
 
 const prisonId = 'HEI'
 
@@ -119,27 +119,24 @@ describe('getSelectedSlot', () => {
   })
 })
 
-describe('getSlotByStartTimeAndRestriction', () => {
+describe('getSlotByTimeAndRestriction', () => {
   it('should return a slot given matching start/end timestamp and visit restriction', () => {
-    expect(
-      getSlotByStartTimeAndRestriction(slotsList, '2022-02-14T12:00:00', '2022-02-14T13:05:00', 'OPEN'),
-    ).toHaveProperty('id', '3')
+    expect(getSlotByTimeAndRestriction(slotsList, '2022-02-14T12:00:00', '2022-02-14T13:05:00', 'OPEN')).toHaveProperty(
+      'id',
+      '3',
+    )
   })
 
   it('should return undefined if correct start but incorrect end start time', () => {
-    expect(getSlotByStartTimeAndRestriction(slotsList, '2022-02-14T12:00:00', '2022-02-14T13:00:00', 'OPEN')).toBe(
-      undefined,
-    )
+    expect(getSlotByTimeAndRestriction(slotsList, '2022-02-14T12:00:00', '2022-02-14T13:00:00', 'OPEN')).toBe(undefined)
   })
 
   it('should return undefined if incorrect start but correct end start time', () => {
-    expect(getSlotByStartTimeAndRestriction(slotsList, '2022-02-14T12:05:00', '2022-02-14T13:05:00', 'OPEN')).toBe(
-      undefined,
-    )
+    expect(getSlotByTimeAndRestriction(slotsList, '2022-02-14T12:05:00', '2022-02-14T13:05:00', 'OPEN')).toBe(undefined)
   })
 
   it('should return undefined if correct start/end but wrong restriction', () => {
-    expect(getSlotByStartTimeAndRestriction(slotsList, '2022-02-14T12:00:00', '2022-02-14T13:05:00', 'CLOSED')).toBe(
+    expect(getSlotByTimeAndRestriction(slotsList, '2022-02-14T12:00:00', '2022-02-14T13:05:00', 'CLOSED')).toBe(
       undefined,
     )
   })

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -120,12 +120,28 @@ describe('getSelectedSlot', () => {
 })
 
 describe('getSlotByStartTimeAndRestriction', () => {
-  it('should return a slot given matching start timestamp and visit restriction', () => {
-    expect(getSlotByStartTimeAndRestriction(slotsList, '2022-02-14T12:00:00', 'OPEN')).toHaveProperty('id', '3')
+  it('should return a slot given matching start/end timestamp and visit restriction', () => {
+    expect(
+      getSlotByStartTimeAndRestriction(slotsList, '2022-02-14T12:00:00', '2022-02-14T13:05:00', 'OPEN'),
+    ).toHaveProperty('id', '3')
   })
 
-  it('should return undefined if no slot matches given start timestamp and visit restriction', () => {
-    expect(getSlotByStartTimeAndRestriction(slotsList, '2022-01-01T00:00:00', 'OPEN')).toBe(undefined)
+  it('should return undefined if correct start but incorrect end start time', () => {
+    expect(getSlotByStartTimeAndRestriction(slotsList, '2022-02-14T12:00:00', '2022-02-14T13:00:00', 'OPEN')).toBe(
+      undefined,
+    )
+  })
+
+  it('should return undefined if incorrect start but correct end start time', () => {
+    expect(getSlotByStartTimeAndRestriction(slotsList, '2022-02-14T12:05:00', '2022-02-14T13:05:00', 'OPEN')).toBe(
+      undefined,
+    )
+  })
+
+  it('should return undefined if correct start/end but wrong restriction', () => {
+    expect(getSlotByStartTimeAndRestriction(slotsList, '2022-02-14T12:00:00', '2022-02-14T13:05:00', 'CLOSED')).toBe(
+      undefined,
+    )
   })
 })
 

--- a/server/routes/visitorUtils.ts
+++ b/server/routes/visitorUtils.ts
@@ -14,6 +14,7 @@ export const getSelectedSlot = (slotsList: VisitSlotList, selectedSlot: string):
 export const getSlotByStartTimeAndRestriction = (
   slotsList: VisitSlotList,
   startTimestamp: string,
+  endTimestamp: string,
   visitRestriction: string,
 ): VisitSlot => {
   return Object.values(slotsList)
@@ -21,7 +22,12 @@ export const getSlotByStartTimeAndRestriction = (
     .reduce((allSlots, slot) => {
       return allSlots.concat(slot.slots.morning, slot.slots.afternoon)
     }, [])
-    .find(slot => slot.startTimestamp === startTimestamp && slot.visitRestriction === visitRestriction)
+    .find(
+      slot =>
+        slot.startTimestamp === startTimestamp &&
+        slot.endTimestamp === endTimestamp &&
+        slot.visitRestriction === visitRestriction,
+    )
 }
 
 export const getFlashFormValues = (req: Request): Record<string, string | string[]> => {

--- a/server/routes/visitorUtils.ts
+++ b/server/routes/visitorUtils.ts
@@ -11,7 +11,7 @@ export const getSelectedSlot = (slotsList: VisitSlotList, selectedSlot: string):
     .find(slot => slot.id === selectedSlot)
 }
 
-export const getSlotByStartTimeAndRestriction = (
+export const getSlotByTimeAndRestriction = (
   slotsList: VisitSlotList,
   startTimestamp: string,
   endTimestamp: string,

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -485,6 +485,140 @@ describe('Visit sessions service', () => {
         ],
       })
     })
+
+    it('Should display single slot - ignoring slots with no capacity on current visit restriction (open)', async () => {
+      const sessions: VisitSession[] = [
+        {
+          sessionTemplateId: 10,
+          visitRoomName: 'A1',
+          visitType: 'SOCIAL',
+          prisonId: 'HEI',
+          openVisitCapacity: 15,
+          openVisitBookedCount: 0,
+          closedVisitCapacity: 10,
+          closedVisitBookedCount: 0,
+          startTimestamp: '2022-02-14T09:00:00',
+          endTimestamp: '2022-02-14T10:00:00',
+        },
+        {
+          sessionTemplateId: 11,
+          visitRoomName: 'A1',
+          visitType: 'SOCIAL',
+          prisonId: 'HEI',
+          openVisitCapacity: 0,
+          openVisitBookedCount: 0,
+          closedVisitCapacity: 10,
+          closedVisitBookedCount: 0,
+          startTimestamp: '2022-02-14T10:30:00',
+          endTimestamp: '2022-02-14T11:30:00',
+        },
+      ]
+
+      visitSchedulerApiClient.getVisitSessions.mockResolvedValue(sessions)
+      whereaboutsApiClient.getEvents.mockResolvedValue([])
+      const results = await visitSessionsService.getVisitSessions({
+        username: 'user',
+        offenderNo: 'A1234BC',
+        prisonId,
+        visitRestriction: 'OPEN',
+      })
+
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC', prisonId)
+      expect(results).toEqual(<VisitSlotList>{
+        'February 2022': [
+          {
+            date: 'Monday 14 February',
+            prisonerEvents: {
+              morning: [],
+              afternoon: [],
+            },
+            slots: {
+              morning: [
+                {
+                  id: '1',
+                  prisonId,
+                  startTimestamp: '2022-02-14T09:00:00',
+                  endTimestamp: '2022-02-14T10:00:00',
+                  availableTables: 15,
+                  capacity: 15,
+                  visitRoomName: 'A1',
+                  visitRestriction: 'OPEN',
+                },
+              ],
+              afternoon: [],
+            },
+          },
+        ],
+      })
+    })
+
+    it('Should display single slot - ignoring slots with no capacity on current visit restriction (closed)', async () => {
+      const sessions: VisitSession[] = [
+        {
+          sessionTemplateId: 10,
+          visitRoomName: 'A1',
+          visitType: 'SOCIAL',
+          prisonId: 'HEI',
+          openVisitCapacity: 15,
+          openVisitBookedCount: 0,
+          closedVisitCapacity: 10,
+          closedVisitBookedCount: 0,
+          startTimestamp: '2022-02-14T09:00:00',
+          endTimestamp: '2022-02-14T10:00:00',
+        },
+        {
+          sessionTemplateId: 11,
+          visitRoomName: 'A1',
+          visitType: 'SOCIAL',
+          prisonId: 'HEI',
+          openVisitCapacity: 10,
+          openVisitBookedCount: 0,
+          closedVisitCapacity: 0,
+          closedVisitBookedCount: 0,
+          startTimestamp: '2022-02-14T10:30:00',
+          endTimestamp: '2022-02-14T11:30:00',
+        },
+      ]
+
+      visitSchedulerApiClient.getVisitSessions.mockResolvedValue(sessions)
+      whereaboutsApiClient.getEvents.mockResolvedValue([])
+      const results = await visitSessionsService.getVisitSessions({
+        username: 'user',
+        offenderNo: 'A1234BC',
+        prisonId,
+        visitRestriction: 'CLOSED',
+      })
+
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledTimes(1)
+      expect(visitSchedulerApiClient.getVisitSessions).toHaveBeenCalledWith('A1234BC', prisonId)
+      expect(results).toEqual(<VisitSlotList>{
+        'February 2022': [
+          {
+            date: 'Monday 14 February',
+            prisonerEvents: {
+              morning: [],
+              afternoon: [],
+            },
+            slots: {
+              morning: [
+                {
+                  id: '1',
+                  prisonId,
+                  startTimestamp: '2022-02-14T09:00:00',
+                  endTimestamp: '2022-02-14T10:00:00',
+                  availableTables: 10,
+                  capacity: 10,
+                  visitRoomName: 'A1',
+                  visitRestriction: 'CLOSED',
+                },
+              ],
+              afternoon: [],
+            },
+          },
+        ],
+      })
+    })
   })
 
   describe('reserveVisitSlot', () => {

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -104,10 +104,9 @@ export default class VisitSessionsService {
           earliestStartTime = parsedStartTimestamp
         }
 
+        // slotHasCapacity == true when the slot has capacity for this selected restriction
         const slotHasCapacity =
           visitRestriction === 'OPEN' ? visitSession.openVisitCapacity > 1 : visitSession.closedVisitCapacity > 1
-        // Wrapping the slot push in a capacity check ensures that
-        // there is capacity for the slot (with the current restriction)
         if (slotHasCapacity) {
           // Add new Slot to morning / afternoon grouping
           if (parsedStartTimestamp.getHours() < this.morningCutoff) {

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -103,14 +103,19 @@ export default class VisitSessionsService {
         if (isBefore(parsedStartTimestamp, earliestStartTime)) {
           earliestStartTime = parsedStartTimestamp
         }
-
-        // Add new Slot to morning / afternoon grouping
-        if (parsedStartTimestamp.getHours() < this.morningCutoff) {
-          slotsForDay.slots.morning.push(newSlot)
-        } else {
-          slotsForDay.slots.afternoon.push(newSlot)
+        // Wrapping the slot push in a capacity check ensures that
+        // there is capacity for the slot (with the current restriction)
+        if (
+          (visitRestriction === 'OPEN' && visitSession.openVisitCapacity > 1) ||
+          (visitRestriction === 'CLOSED' && visitSession.closedVisitCapacity > 1)
+        ) {
+          // Add new Slot to morning / afternoon grouping
+          if (parsedStartTimestamp.getHours() < this.morningCutoff) {
+            slotsForDay.slots.morning.push(newSlot)
+          } else {
+            slotsForDay.slots.afternoon.push(newSlot)
+          }
         }
-
         return slotList
       },
       {},

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -103,12 +103,12 @@ export default class VisitSessionsService {
         if (isBefore(parsedStartTimestamp, earliestStartTime)) {
           earliestStartTime = parsedStartTimestamp
         }
+
+        const slotHasCapacity =
+          visitRestriction === 'OPEN' ? visitSession.openVisitCapacity > 1 : visitSession.closedVisitCapacity > 1
         // Wrapping the slot push in a capacity check ensures that
         // there is capacity for the slot (with the current restriction)
-        if (
-          (visitRestriction === 'OPEN' && visitSession.openVisitCapacity > 1) ||
-          (visitRestriction === 'CLOSED' && visitSession.closedVisitCapacity > 1)
-        ) {
+        if (slotHasCapacity) {
           // Add new Slot to morning / afternoon grouping
           if (parsedStartTimestamp.getHours() < this.morningCutoff) {
             slotsForDay.slots.morning.push(newSlot)


### PR DESCRIPTION
## Description
Error caused by overlapping sessions in Cardiff's visit schedule
Caused by the fact there is a session with no capacity for the currently selected visit restriction (the sessions have either open or closed, not both)
Current iteration only pushes the slot on a boolean check,  testing whether the current restriction has any capacity on the slot (initial capacity not available tables)