### PR TITLE
VB-1416, add prisoners information slot change message

### DIFF
--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -25,7 +25,7 @@ export default class DateAndTime {
       prisonId,
     })
 
-    let restrictionChangeMessage = ''
+    let slotChangeReason = ''
     let matchingSlot
 
     // first time here on update journey, visitSlot.id will be ''
@@ -45,15 +45,19 @@ export default class DateAndTime {
         visitSessionData.visitSlot.id = matchingSlot.id
       }
 
+      if (!matchingSlot) {
+        slotChangeReason = `A new visit time must be selected. A change to the prisoner's information means the original time slot is no longer suitable`
+      }
+
       if (visitSessionData.visitRestriction !== visitSessionData.originalVisitSlot.visitRestriction) {
         if (matchingSlot && matchingSlot.availableTables > 0) {
-          restrictionChangeMessage = visitSessionData.closedVisitReason
+          slotChangeReason = visitSessionData.closedVisitReason
             ? `This is now a closed visit due to a ${visitSessionData.closedVisitReason} restriction. `
             : 'This is now an open visit. '
-          restrictionChangeMessage += 'The visit time can stay the same.'
+          slotChangeReason += 'The visit time can stay the same.'
         } else {
-          restrictionChangeMessage = 'A new visit time must be selected as this is now '
-          restrictionChangeMessage += visitSessionData.closedVisitReason
+          slotChangeReason = 'A new visit time must be selected as this is now '
+          slotChangeReason += visitSessionData.closedVisitReason
             ? `a closed visit due to a ${visitSessionData.closedVisitReason} restriction.`
             : 'an open visit.'
         }
@@ -93,7 +97,7 @@ export default class DateAndTime {
       slotsList,
       formValues,
       slotsPresent,
-      restrictionChangeMessage,
+      slotChangeReason,
       originalVisitSlot,
       urlPrefix: getUrlPrefix(isUpdate, visitSessionData.visitReference),
     })

--- a/server/views/pages/bookAVisit/dateAndTime.njk
+++ b/server/views/pages/bookAVisit/dateAndTime.njk
@@ -75,11 +75,11 @@
       }) }}
     {% endif %}
 
-    {% if restrictionChangeMessage %}
+    {% if slotChangeReason %}
       {% set restrictionChangeReasonHtml %}
           {{ govukWarningText({
             classes: "govuk-!-margin-bottom-0",
-            html: '<span class="govuk-!-font-size-24">' + restrictionChangeMessage + '</span>',
+            html: '<span class="govuk-!-font-size-24">' + slotChangeReason + '</span>',
             iconFallbackText: "Warning",
             attributes: {
               "data-test": "restriction-change-reason"

--- a/server/views/pages/bookAVisit/dateAndTime.test.ts
+++ b/server/views/pages/bookAVisit/dateAndTime.test.ts
@@ -201,8 +201,7 @@ describe('Views - Date and time of visit', () => {
     viewContext = {
       prisonerName: 'John Smith',
       visitRestriction: 'CLOSED',
-      restrictionChangeMessage:
-        'This is now a closed visit due to a visitor restriction. The visit time can stay the same.',
+      slotChangeReason: 'This is now a closed visit due to a visitor restriction. The visit time can stay the same.',
     }
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
@@ -211,6 +210,22 @@ describe('Views - Date and time of visit', () => {
     expect($('[data-test="closed-visit-reason"]').length).toBe(0)
     expect($('[data-test="restriction-change-reason"]').text()).toContain(
       'This is now a closed visit due to a visitor restriction. The visit time can stay the same.',
+    )
+  })
+
+  it('should display restriction change message, not the closed visit reason', () => {
+    viewContext = {
+      prisonerName: 'John Smith',
+      visitRestriction: 'OPEN',
+      slotChangeReason: `A new visit time must be selected. A change to the prisoner's information means the original time slot is no longer suitable`,
+    }
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+    expect($('[data-test="visit-restriction"]').text()).toBe('Open')
+    expect($('[data-test="closed-visit-reason"]').length).toBe(0)
+    expect($('[data-test="restriction-change-reason"]').text()).toContain(
+      `A new visit time must be selected. A change to the prisoner's information means the original time slot is no longer suitable`,
     )
   })
 


### PR DESCRIPTION
## Description
In the scenario where the front end is insure why the slot has changed, just that a slot can no longer be matched on the update journey ( Non-association, change of IEP, moving location) the new message will be displayed.

Awaiting personal testing tomorrow, as requires complex changes to prisoner on NOMIS