### PR TITLE
VB-1857: Add integration test for user role check

### DIFF
--- a/integration_tests/integration/login.cy.ts
+++ b/integration_tests/integration/login.cy.ts
@@ -2,6 +2,7 @@ import HomePage from '../pages/home'
 import AuthSignInPage from '../pages/authSignIn'
 import Page from '../pages/page'
 import AuthManageDetailsPage from '../pages/authManageDetails'
+import AuthorisationErrorPage from '../pages/authorisationError'
 
 context('SignIn', () => {
   beforeEach(() => {
@@ -66,5 +67,12 @@ context('SignIn', () => {
     cy.signIn()
 
     homePage.headerUserName().contains('B. Brown')
+  })
+
+  it('User without required role is directed to Authorisation Error page', () => {
+    cy.task('stubSignIn', 'SOME_OTHER_ROLE')
+    cy.signIn({ failOnStatusCode: false })
+    const authorisationErrorPage = Page.verifyOnPage(AuthorisationErrorPage)
+    authorisationErrorPage.message().contains('You are not authorised to use this application')
   })
 })

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -4,12 +4,12 @@ import { Response } from 'superagent'
 import { stubFor, getMatchingRequests } from './wiremock'
 import tokenVerification from './tokenVerification'
 
-const createToken = () => {
+const createToken = (role: string) => {
   const payload = {
     user_name: 'USER1',
     scope: ['read'],
     auth_source: 'nomis',
-    authorities: ['ROLE_MANAGE_PRISON_VISITS'],
+    authorities: [role ?? 'ROLE_MANAGE_PRISON_VISITS'],
     jti: '83b50a10-cca6-41db-985f-e87efb303ddb',
     client_id: 'clientid',
   }
@@ -95,7 +95,7 @@ const manageDetails = () =>
     },
   })
 
-const token = () =>
+const token = (role: string) =>
   stubFor({
     request: {
       method: 'POST',
@@ -108,7 +108,7 @@ const token = () =>
         Location: 'http://localhost:3007/sign-in/callback?code=codexxxx&state=stateyyyy',
       },
       jsonBody: {
-        access_token: createToken(),
+        access_token: createToken(role),
         token_type: 'bearer',
         user_name: 'USER1',
         expires_in: 599,
@@ -157,7 +157,7 @@ const stubUserRoles = () =>
 export default {
   getSignInUrl,
   stubAuthPing: ping,
-  stubSignIn: (): Promise<[Response, Response, Response, Response, Response, Response]> =>
-    Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(), tokenVerification.stubVerifyToken()]),
+  stubSignIn: (role: string): Promise<[Response, Response, Response, Response, Response, Response]> =>
+    Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(role), tokenVerification.stubVerifyToken()]),
   stubAuthUser: (name = 'john smith'): Promise<[Response, Response]> => Promise.all([stubUser(name), stubUserRoles()]),
 }

--- a/integration_tests/pages/authorisationError.ts
+++ b/integration_tests/pages/authorisationError.ts
@@ -1,0 +1,9 @@
+import Page, { PageElement } from './page'
+
+export default class AuthorisationErrorPage extends Page {
+  constructor() {
+    super('Authorisation Error')
+  }
+
+  message = (): PageElement => cy.get('#main-content > p')
+}


### PR DESCRIPTION
Add integration test to cover user without `ROLE_MANAGE_PRISON_VISITS` role being redirected to auth error page.

(Will add something to `server/routes/testutils/appSetup.ts` to cover roles in unit tests once that's refactored as part of VB-1430.)