### PR TITLE
VB-1841: Add Visits timetable date navigation

### DIFF
--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -260,7 +260,7 @@
 
 .bapv-timetable-dates__date {
   flex-basis: 10%;
-  padding: govuk-spacing(2) govuk-spacing(2);
+  padding: govuk-spacing(2);
   text-align: center;
 
   & span {

--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -266,6 +266,7 @@
   & span {
     display: block;
     padding-bottom: govuk-spacing(2);
+    @include govuk-font($size: 19);
   }
 
   & a {
@@ -280,5 +281,5 @@
 .bapv-timetable-dates__date--selected {
   background-color: govuk-colour("blue");
   color: govuk-colour("white");
-  font-weight: $govuk-font-weight-bold;
+  @include govuk-font($size: 24, $weight: "bold");
 }

--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -1,4 +1,4 @@
-.govuk-main-wrapper a:not(.govuk-button, .govuk-tabs__tab):visited,
+.govuk-main-wrapper a:not(.govuk-button, .govuk-tabs__tab, .bapv-timetable-dates__date--selected>a, .moj-pagination__link):visited,
 .location-bar .location-bar__location a:visited {
   color: $govuk-link-colour;
 }
@@ -250,4 +250,35 @@
 
 .bapv-force-overflow {
  overflow-wrap: anywhere;
+}
+
+.bapv-timetable-dates {
+  display: flex;
+  justify-content: space-between;
+  max-width: 600px;
+}
+
+.bapv-timetable-dates__date {
+  flex-basis: 10%;
+  padding: govuk-spacing(2) govuk-spacing(2);
+  text-align: center;
+
+  & span {
+    display: block;
+    padding-bottom: govuk-spacing(2);
+  }
+
+  & a {
+    @include govuk-font($size: 24);
+  }
+
+  & a:hover {
+    text-decoration: none;
+  }
+}
+
+.bapv-timetable-dates__date--selected {
+  background-color: govuk-colour("blue");
+  color: govuk-colour("white");
+  font-weight: $govuk-font-weight-bold;
 }

--- a/server/routes/timetable.test.ts
+++ b/server/routes/timetable.test.ts
@@ -14,9 +14,12 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.resetAllMocks()
+  jest.useRealTimers()
 })
 
 describe('View visits timetable', () => {
+  let fakeDate: string
+
   it('should return a 404 if the feature is disabled', () => {
     config.features.viewTimetableEnabled = false
     app = appWithAllRoutes({})
@@ -24,8 +27,9 @@ describe('View visits timetable', () => {
     return request(app).get('/timetable').expect(404)
   })
 
-  it('should render the visits timetable page', () => {
-    app = appWithAllRoutes({})
+  it('should render the visits timetable page with closest Monday selected by default', () => {
+    fakeDate = '2022-12-27' // a Tuesday
+    jest.useFakeTimers({ advanceTimers: true, now: new Date(fakeDate) })
 
     return request(app)
       .get('/timetable')
@@ -35,8 +39,77 @@ describe('View visits timetable', () => {
 
         expect($('h1').text()).toBe('Visits timetable')
 
+        expect($('#selected-date').text()).toBe('Monday 26 December 2022')
+
+        expect($('.bapv-timetable-dates__date--selected').text().trim()).toMatch(/Mon\s+26 December/)
+        expect($('.bapv-timetable-dates__date a').eq(0).attr('href')).toBe('/timetable?date=2022-12-27')
+        expect($('.bapv-timetable-dates__date a').eq(1).attr('href')).toBe('/timetable?date=2022-12-28')
+        expect($('.bapv-timetable-dates__date a').eq(2).attr('href')).toBe('/timetable?date=2022-12-29')
+        expect($('.bapv-timetable-dates__date a').eq(3).attr('href')).toBe('/timetable?date=2022-12-30')
+        expect($('.bapv-timetable-dates__date a').eq(4).attr('href')).toBe('/timetable?date=2022-12-31')
+        expect($('.bapv-timetable-dates__date a').eq(5).attr('href')).toBe('/timetable?date=2023-01-01')
+
+        expect($('[data-test="previous-week"]').attr('href')).toBe('/timetable?date=2022-12-19')
+        expect($('[data-test="next-week"]').attr('href')).toBe('/timetable?date=2023-01-02')
+
         expect($('[data-test="change-timetable"]').text()).toBe('Request changes to the timetable')
         expect($('[data-test="change-request"]').attr('href')).toBe('LINK_TBC')
+      })
+  })
+
+  it('should render the visits timetable page with requested date selected', () => {
+    fakeDate = '2022-12-30' // a Friday
+    jest.useFakeTimers({ advanceTimers: true, now: new Date(fakeDate) })
+
+    return request(app)
+      .get('/timetable')
+      .query({ date: fakeDate })
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+
+        expect($('h1').text()).toBe('Visits timetable')
+
+        expect($('#selected-date').text()).toBe('Friday 30 December 2022')
+
+        expect($('.bapv-timetable-dates__date a').eq(0).attr('href')).toBe('/timetable?date=2022-12-26')
+        expect($('.bapv-timetable-dates__date a').eq(1).attr('href')).toBe('/timetable?date=2022-12-27')
+        expect($('.bapv-timetable-dates__date a').eq(2).attr('href')).toBe('/timetable?date=2022-12-28')
+        expect($('.bapv-timetable-dates__date a').eq(3).attr('href')).toBe('/timetable?date=2022-12-29')
+        expect($('.bapv-timetable-dates__date--selected').text().trim()).toMatch(/Fri\s+30 December/)
+        expect($('.bapv-timetable-dates__date a').eq(4).attr('href')).toBe('/timetable?date=2022-12-31')
+        expect($('.bapv-timetable-dates__date a').eq(5).attr('href')).toBe('/timetable?date=2023-01-01')
+
+        expect($('[data-test="previous-week"]').attr('href')).toBe('/timetable?date=2022-12-19')
+        expect($('[data-test="next-week"]').attr('href')).toBe('/timetable?date=2023-01-02')
+      })
+  })
+
+  it('should render the visits timetable page with closest Monday selected when invalid date requested', () => {
+    fakeDate = '2022-12-26' // a Monday
+    jest.useFakeTimers({ advanceTimers: true, now: new Date(fakeDate) })
+
+    return request(app)
+      .get('/timetable')
+      .query({ date: 'NOT A DATE!' })
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+
+        expect($('h1').text()).toBe('Visits timetable')
+
+        expect($('#selected-date').text()).toBe('Monday 26 December 2022')
+
+        expect($('.bapv-timetable-dates__date--selected').text().trim()).toMatch(/Mon\s+26 December/)
+        expect($('.bapv-timetable-dates__date a').eq(0).attr('href')).toBe('/timetable?date=2022-12-27')
+        expect($('.bapv-timetable-dates__date a').eq(1).attr('href')).toBe('/timetable?date=2022-12-28')
+        expect($('.bapv-timetable-dates__date a').eq(2).attr('href')).toBe('/timetable?date=2022-12-29')
+        expect($('.bapv-timetable-dates__date a').eq(3).attr('href')).toBe('/timetable?date=2022-12-30')
+        expect($('.bapv-timetable-dates__date a').eq(4).attr('href')).toBe('/timetable?date=2022-12-31')
+        expect($('.bapv-timetable-dates__date a').eq(5).attr('href')).toBe('/timetable?date=2023-01-01')
+
+        expect($('[data-test="previous-week"]').attr('href')).toBe('/timetable?date=2022-12-19')
+        expect($('[data-test="next-week"]').attr('href')).toBe('/timetable?date=2023-01-02')
       })
   })
 })

--- a/server/routes/timetable.test.ts
+++ b/server/routes/timetable.test.ts
@@ -35,7 +35,7 @@ describe('View visits timetable', () => {
 
         expect($('h1').text()).toBe('Visits timetable')
 
-        expect($('h2:nth-of-type(2)').text()).toBe('Request changes to the timetable')
+        expect($('[data-test="change-timetable"]').text()).toBe('Request changes to the timetable')
         expect($('[data-test="change-request"]').attr('href')).toBe('LINK_TBC')
       })
   })

--- a/server/routes/timetable.ts
+++ b/server/routes/timetable.ts
@@ -1,7 +1,9 @@
+import { isMonday, previousMonday } from 'date-fns'
 import type { RequestHandler, Router } from 'express'
 import { NotFound } from 'http-errors'
 import config from '../config'
 import asyncMiddleware from '../middleware/asyncMiddleware'
+import { getParsedDateFromQueryString, getWeekOfDatesStartingMonday } from '../utils/utils'
 
 export default function routes(router: Router): Router {
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
@@ -11,7 +13,20 @@ export default function routes(router: Router): Router {
       throw new NotFound()
     }
 
-    res.render('pages/timetable')
+    const today = new Date()
+    const defaultDate = isMonday(today) ? today : previousMonday(today)
+
+    const { date = '' } = req.query
+    const selectedDate = getParsedDateFromQueryString(date.toString(), defaultDate)
+
+    const { weekOfDates, previousWeek, nextWeek } = getWeekOfDatesStartingMonday(selectedDate)
+
+    res.render('pages/timetable', {
+      selectedDate,
+      weekOfDates,
+      previousWeek,
+      nextWeek,
+    })
   })
 
   return router

--- a/server/routes/visits.test.ts
+++ b/server/routes/visits.test.ts
@@ -8,8 +8,8 @@ import VisitSessionsService from '../services/visitSessionsService'
 import AuditService from '../services/auditService'
 import { appWithAllRoutes, flashProvider } from './testutils/appSetup'
 import { ExtendedVisitInformation, PrisonerDetailsItem, VisitsPageSlot } from '../@types/bapv'
-import { getParsedDateFromQueryString } from './visitsUtils'
 import TestData from './testutils/testData'
+import { getParsedDateFromQueryString } from '../utils/utils'
 
 jest.mock('../services/prisonerSearchService')
 jest.mock('../services/visitSessionsService')

--- a/server/routes/visits.ts
+++ b/server/routes/visits.ts
@@ -6,8 +6,8 @@ import asyncMiddleware from '../middleware/asyncMiddleware'
 import PrisonerSearchService from '../services/prisonerSearchService'
 import VisitSessionsService from '../services/visitSessionsService'
 import AuditService from '../services/auditService'
-import { getResultsPagingLinks } from '../utils/utils'
-import { getDateTabs, getParsedDateFromQueryString, getSlotsSideMenuData } from './visitsUtils'
+import { getParsedDateFromQueryString, getResultsPagingLinks } from '../utils/utils'
+import { getDateTabs, getSlotsSideMenuData } from './visitsUtils'
 import { SessionCapacity } from '../data/visitSchedulerApiTypes'
 
 export default function routes(

--- a/server/routes/visitsUtils.test.ts
+++ b/server/routes/visitsUtils.test.ts
@@ -1,4 +1,3 @@
-import { format } from 'date-fns'
 import { getDateTabs, getSlotsSideMenuData } from './visitsUtils'
 
 describe('getDateTabs', () => {

--- a/server/routes/visitsUtils.test.ts
+++ b/server/routes/visitsUtils.test.ts
@@ -1,24 +1,5 @@
 import { format } from 'date-fns'
-import { getParsedDateFromQueryString, getDateTabs, getSlotsSideMenuData } from './visitsUtils'
-
-describe('getParsedDateFromQueryString', () => {
-  const today = format(new Date(), 'yyyy-MM-dd')
-
-  ;[
-    {
-      input: '2022-05-22',
-      expected: '2022-05-22',
-    },
-    {
-      input: '2222-00-12',
-      expected: today,
-    },
-  ].forEach(testData => {
-    it(`should output ${testData.expected} when supplied with ${testData.input}`, () => {
-      expect(getParsedDateFromQueryString(testData.input)).toBe(testData.expected)
-    })
-  })
-})
+import { getDateTabs, getSlotsSideMenuData } from './visitsUtils'
 
 describe('getDateTabs', () => {
   const todayString = '2022-05-24'

--- a/server/routes/visitsUtils.ts
+++ b/server/routes/visitsUtils.ts
@@ -1,12 +1,6 @@
 import { format, parse, add } from 'date-fns'
 import { VisitsPageSlot } from '../@types/bapv'
-import { sortByTimestamp } from '../utils/utils'
-
-export const getParsedDateFromQueryString = (dateFromQueryString: string, defaultDate = new Date()): string => {
-  const parsedDate =
-    new Date(dateFromQueryString).toString() === 'Invalid Date' ? defaultDate : new Date(dateFromQueryString)
-  return format(parsedDate, 'yyyy-MM-dd')
-}
+import { getParsedDateFromQueryString, sortByTimestamp } from '../utils/utils'
 
 export const getDateTabs = (
   selectedDate: string,

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -9,6 +9,7 @@ import {
   sortByTimestamp,
   safeReturnUrl,
   getParsedDateFromQueryString,
+  getWeekOfDatesStartingMonday,
 } from './utils'
 import { getResultsPagingLinksTestData, sortByTimestampData } from './utils.testData'
 
@@ -148,6 +149,34 @@ describe('getParsedDateFromQueryString', () => {
   ].forEach(testData => {
     it(`should output ${testData.expected} when supplied with ${testData.input}`, () => {
       expect(getParsedDateFromQueryString(testData.input)).toBe(testData.expected)
+    })
+  })
+})
+
+describe('getWeekOfDatesStartingMonday', () => {
+  const weekOfDates = {
+    weekOfDates: ['2022-12-26', '2022-12-27', '2022-12-28', '2022-12-29', '2022-12-30', '2022-12-31', '2023-01-01'],
+    previousWeek: '2022-12-19',
+    nextWeek: '2023-01-02',
+  }
+
+  it('should return a week of dates starting on the given date when it is a Monday', () => {
+    expect(getWeekOfDatesStartingMonday('2022-12-26')).toStrictEqual(weekOfDates)
+  })
+
+  it('should return a week of dates starting on the previous closest Monday when given a Wednesday', () => {
+    expect(getWeekOfDatesStartingMonday('2022-12-28')).toStrictEqual(weekOfDates)
+  })
+
+  it('should return a week of dates starting on the previous closest Monday when given a Sunday', () => {
+    expect(getWeekOfDatesStartingMonday('2023-01-01')).toStrictEqual(weekOfDates)
+  })
+
+  it('should return an empty array if given an invalid date', () => {
+    expect(getWeekOfDatesStartingMonday('NOT A DATE')).toStrictEqual({
+      weekOfDates: [],
+      previousWeek: '',
+      nextWeek: '',
     })
   })
 })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -141,6 +141,10 @@ describe('getParsedDateFromQueryString', () => {
       input: '2222-00-12',
       expected: today,
     },
+    {
+      input: '!&"-bad-input',
+      expected: today,
+    },
   ].forEach(testData => {
     it(`should output ${testData.expected} when supplied with ${testData.input}`, () => {
       expect(getParsedDateFromQueryString(testData.input)).toBe(testData.expected)

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns'
 import {
   convertToTitleCase,
   getResultsPagingLinks,
@@ -7,6 +8,7 @@ import {
   properCase,
   sortByTimestamp,
   safeReturnUrl,
+  getParsedDateFromQueryString,
 } from './utils'
 import { getResultsPagingLinksTestData, sortByTimestampData } from './utils.testData'
 
@@ -123,6 +125,25 @@ describe('safeReturnUrl', () => {
   ].forEach(testData => {
     it(`should output ${testData.expected} when supplied with ${testData.input}`, () => {
       expect(safeReturnUrl(testData.input)).toBe(testData.expected)
+    })
+  })
+})
+
+describe('getParsedDateFromQueryString', () => {
+  const today = format(new Date(), 'yyyy-MM-dd')
+
+  ;[
+    {
+      input: '2022-05-22',
+      expected: '2022-05-22',
+    },
+    {
+      input: '2222-00-12',
+      expected: today,
+    },
+  ].forEach(testData => {
+    it(`should output ${testData.expected} when supplied with ${testData.input}`, () => {
+      expect(getParsedDateFromQueryString(testData.input)).toBe(testData.expected)
     })
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -148,3 +148,9 @@ export function safeReturnUrl(originalUrl: string) {
     ? '/'
     : originalUrl
 }
+
+export const getParsedDateFromQueryString = (dateFromQueryString: string, defaultDate = new Date()): string => {
+  const parsedDate =
+    new Date(dateFromQueryString).toString() === 'Invalid Date' ? defaultDate : new Date(dateFromQueryString)
+  return format(parsedDate, 'yyyy-MM-dd')
+}

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,4 +1,15 @@
-import { differenceInYears, format, parseISO, addDays, startOfMonth, addMonths } from 'date-fns'
+import {
+  differenceInYears,
+  format,
+  parseISO,
+  addDays,
+  startOfMonth,
+  addMonths,
+  isMonday,
+  previousMonday,
+  addWeeks,
+  subWeeks,
+} from 'date-fns'
 
 export const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
@@ -153,4 +164,23 @@ export const getParsedDateFromQueryString = (dateFromQueryString: string, defaul
   const parsedDate =
     new Date(dateFromQueryString).toString() === 'Invalid Date' ? defaultDate : new Date(dateFromQueryString)
   return format(parsedDate, 'yyyy-MM-dd')
+}
+
+export const getWeekOfDatesStartingMonday = (
+  date: string,
+): { weekOfDates: string[]; previousWeek: string; nextWeek: string } => {
+  const startingDate = new Date(date)
+  if (startingDate.toString() === 'Invalid Date') return { weekOfDates: [], previousWeek: '', nextWeek: '' }
+
+  const dateFormat = 'yyyy-MM-dd'
+  const weekStartDate = isMonday(startingDate) ? startingDate : previousMonday(startingDate)
+
+  const weekOfDates = new Array(7).fill('').map((_day, index) => {
+    return format(addDays(weekStartDate, index), dateFormat)
+  })
+
+  const previousWeek = format(subWeeks(weekStartDate, 1), dateFormat)
+  const nextWeek = format(addWeeks(weekStartDate, 1), dateFormat)
+
+  return { weekOfDates, previousWeek, nextWeek }
 }

--- a/server/views/pages/timetable.njk
+++ b/server/views/pages/timetable.njk
@@ -29,10 +29,10 @@
         </ul>
         <ul class="govuk-list bapv-timetable-dates">
           <li class="moj-pagination__item  moj-pagination__item--prev">
-            <a class="moj-pagination__link" href="/timetable?date={{ previousWeek | formatDate('yyyy-MM-dd') }}">Previous week</a>
+            <a class="moj-pagination__link" href="/timetable?date={{ previousWeek | formatDate('yyyy-MM-dd') }}" data-test="previous-week">Previous week</a>
           </li>
           <li class="moj-pagination__item  moj-pagination__item--next">
-            <a class="moj-pagination__link" href="/timetable?date={{ nextWeek | formatDate('yyyy-MM-dd') }}">Next week</a>
+            <a class="moj-pagination__link" href="/timetable?date={{ nextWeek | formatDate('yyyy-MM-dd') }}" data-test="next-week">Next week</a>
           </li>
         </ul>
       </nav>

--- a/server/views/pages/timetable.njk
+++ b/server/views/pages/timetable.njk
@@ -9,22 +9,57 @@
 
 {% block content %}
   <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
+
+      <nav aria-labelledby="selected-date">
+        <h2 class="govuk-heading-m" id="selected-date">{{ selectedDate | formatDate('EEEE d MMMM yyyy') }}</h2>
+
+        <ul class="govuk-list bapv-timetable-dates govuk-!-margin-bottom-1">
+          {% for day in weekOfDates %}
+            {% set selected = day == selectedDate %}
+            <li class="bapv-timetable-dates__date {{ 'bapv-timetable-dates__date--selected' if selected }}">
+              <span>{{ day | formatDate('E') }}</span>
+                {% if not selected %}<a href="/timetable?date={{ day | formatDate('yyyy-MM-dd') }}">{% endif %}
+                  {{ day | formatDate('d') }}<span class="govuk-visually-hidden"> {{ day | formatDate('MMMM yyyy') }}</span>
+                {% if not selected %}</a>{% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+        <ul class="govuk-list bapv-timetable-dates">
+          <li class="moj-pagination__item  moj-pagination__item--prev">
+            <a class="moj-pagination__link" href="/timetable?date={{ previousWeek | formatDate('yyyy-MM-dd') }}">Previous week</a>
+          </li>
+          <li class="moj-pagination__item  moj-pagination__item--next">
+            <a class="moj-pagination__link" href="/timetable?date={{ nextWeek | formatDate('yyyy-MM-dd') }}">Next week</a>
+          </li>
+        </ul>
+      </nav>
+      
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      <hr>
+      <p>schedule....</p>
+      <hr>
+    </div>
+  </div>
 
-        <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
 
-        <h2 class="govuk-heading-m" data-test="date-heading">Monday DD MMMM 2023</h2>
-
-
-        <h2 class="govuk-heading-m" data-test="date-heading">Request changes to the timetable</h2>
-        <p>You need to provide six weeks' notice to change the timetable. To request a change,
-            <a href="LINK_TBC" target="_blank" data-test="change-request">(LINK TBC!) complete the request form (opens in a new tab)</a>.
-            We will respond within 5 working days.
-        </p>
-        <p>In exceptional circumstances when you need to make a change to the timetable within the next six weeks,
-            email or call the Family Services Contact Centre. They will need to cancel any visits already booked
-            for these dates and tell booking staff to not make further bookings for this visit session.
-        </p>
+      <h2 class="govuk-heading-m" data-test="change-timetable">Request changes to the timetable</h2>
+      <p>You need to provide six weeks' notice to change the timetable. To request a change,
+          <a href="LINK_TBC" target="_blank" data-test="change-request">(LINK TBC!) complete the request form (opens in a new tab)</a>.
+          We will respond within 5 working days.
+      </p>
+      <p>In exceptional circumstances when you need to make a change to the timetable within the next six weeks,
+          email or call the Family Services Contact Centre. They will need to cancel any visits already booked
+          for these dates and tell booking staff to not make further bookings for this visit session.
+      </p>
 
     </div>
   </div>

--- a/server/views/pages/timetable.njk
+++ b/server/views/pages/timetable.njk
@@ -40,13 +40,11 @@
     </div>
   </div>
 
-  <div class="govuk-grid-row">
+  {# <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <hr>
-      <p>schedule....</p>
-      <hr>
+      <!-- schedule -->
     </div>
-  </div>
+  </div> #}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">


### PR DESCRIPTION
Add navigation for selecting the day to view on the 'Visits timetable' page (see screenshot).
* defaults to selecting the Monday of the current week
* navigation to previous / next week (using MoJ pagination styles)
* invalid date selection in URL renders current week
* tests for link generation and page rendering

(Visits timetable page protected by `FEATURE_VIEW_TIMETABLE_ENABLED` flag. Currently only enabled on dev.)

<img width="628" alt="Screenshot 2023-02-21 at 12 36 54" src="https://user-images.githubusercontent.com/1441286/220346910-bba572a6-b6e6-4df0-a919-ce402d71c86e.png">