### PR TITLE
VB-1835: Don't allow VisitRestriction to be UNKNOWN on VisitSlot

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -167,7 +167,7 @@ export type VisitSlot = {
   availableTables: number
   capacity: number
   visitRoomName: string
-  visitRestriction: Visit['visitRestriction']
+  visitRestriction: 'OPEN' | 'CLOSED'
   sessionConflicts?: VisitSession['sessionConflicts']
 }
 
@@ -210,7 +210,7 @@ export type VisitSessionData = {
   }
   visitSlot?: VisitSlot
   originalVisitSlot?: VisitSlot
-  visitRestriction?: Visit['visitRestriction']
+  visitRestriction?: 'OPEN' | 'CLOSED'
   visitors?: VisitorListItem[]
   visitorSupport?: VisitorSupport[]
   mainContact?: {

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -138,6 +138,8 @@ export default function routes(
 
     // clean then load session
     clearSession(req)
+    const visitRestriction =
+      visit.visitRestriction === 'OPEN' || visit.visitRestriction === 'CLOSED' ? visit.visitRestriction : undefined
     const visitSlot: VisitSlot = {
       id: '',
       prisonId: visit.prisonId,
@@ -146,7 +148,7 @@ export default function routes(
       availableTables: 0,
       capacity: undefined,
       visitRoomName: visit.visitRoom,
-      visitRestriction: visit.visitRestriction,
+      visitRestriction,
     }
     const visitSessionData: VisitSessionData = {
       prisoner: {
@@ -157,7 +159,7 @@ export default function routes(
       },
       visitSlot,
       originalVisitSlot: visitSlot,
-      visitRestriction: visit.visitRestriction,
+      visitRestriction,
       visitors: currentVisitors,
       visitorSupport: visit.visitorSupport,
       mainContact: {


### PR DESCRIPTION
Minor tweak to improve types. `VisitSlot.visitRestriction` and `visitSessionData.visitRestriction` are used in the context of the booking journey and should only ever be `'OPEN' | 'CLOSED'`. 

A `Visit` can have `visitRestriction` of `UNKNOWN` but this should only be relevant of viewing old migrated visits that can't be updated.  