### PR TITLE
VB-1840 Style location group names as a list

### DIFF
--- a/integration_tests/integration/visitTimetable.cy.ts
+++ b/integration_tests/integration/visitTimetable.cy.ts
@@ -46,14 +46,22 @@ context('View visit schedule timetable', () => {
     visitTimetablePage.scheduleTime(0).contains('10am to 11:30am')
     visitTimetablePage.scheduleType(0).contains('Open')
     visitTimetablePage.scheduleCapacity(0).contains('20 tables')
-    visitTimetablePage.scheduleAttendees(0).contains('Enhanced prisoners in Group 1, Group 2')
+    visitTimetablePage.scheduleAttendees(0).within(() => {
+      cy.contains('Enhanced prisoners in:')
+      cy.contains('Group 1')
+      cy.contains('Group 2')
+    })
     visitTimetablePage.scheduleFrequency(0).contains('Fortnightly')
     visitTimetablePage.scheduleEndDate(0).contains('Not entered')
 
     visitTimetablePage.scheduleTime(1).contains('10am to 11:30am')
     visitTimetablePage.scheduleType(1).contains('Closed')
     visitTimetablePage.scheduleCapacity(1).contains('5 tables')
-    visitTimetablePage.scheduleAttendees(1).contains('Enhanced prisoners in Group 1, Group 2')
+    visitTimetablePage.scheduleAttendees(1).within(() => {
+      cy.contains('Enhanced prisoners in:')
+      cy.contains('Group 1')
+      cy.contains('Group 2')
+    })
     visitTimetablePage.scheduleFrequency(1).contains('Fortnightly')
     visitTimetablePage.scheduleEndDate(1).contains('Not entered')
 

--- a/server/routes/timetable.test.ts
+++ b/server/routes/timetable.test.ts
@@ -177,7 +177,8 @@ describe('View visits timetable', () => {
         // Row 1
         expect($('[data-test="schedule-frequency-1"]').text()).toBe('Fortnightly')
         // Row 2
-        expect($('[data-test="schedule-attendees-2"]').text()).toBe('Group 1, Group 2')
+        expect($('[data-test="schedule-attendees-2"] li').eq(0).text()).toBe('Group 1')
+        expect($('[data-test="schedule-attendees-2"] li').eq(1).text()).toBe('Group 2')
         // Row 3 + 4
         expect($('[data-test="schedule-type-3"]').text()).toBe('Open')
         expect($('[data-test="schedule-capacity-3"]').text()).toBe('11 tables')
@@ -185,7 +186,8 @@ describe('View visits timetable', () => {
         expect($('[data-test="schedule-capacity-4"]').text()).toBe('22 tables')
         // Row 5
         expect($('[data-test="schedule-time-5"]').text()).toBe('3pm to 3:45pm')
-        expect($('[data-test="schedule-attendees-5"]').text()).toBe('Enhanced prisoners in Group 1')
+        expect($('[data-test="schedule-attendees-5"] > span').text()).toBe('Enhanced prisoners in:')
+        expect($('[data-test="schedule-attendees-5"] li').eq(0).text()).toBe('Group 1')
         // Row 6
         expect($('[data-test="schedule-attendees-6"]').text()).toBe('Enhanced prisoners only')
         expect($('[data-test="schedule-end-date-6"]').text()).toBe('31 December 2025')

--- a/server/views/pages/timetable.njk
+++ b/server/views/pages/timetable.njk
@@ -15,7 +15,7 @@
     {% endif %}
     <ul class="govuk-list govuk-!-margin-bottom-0{{ " govuk-!-margin-top-2" if enhanced }}">
       {% for name in prisonerLocationGroupNames %}
-        <li class="{{ "govuk-!-margin-bottom-2" if not loop.last else "govuk-!-margin-bottom-0" }}">{{ name }}</li>
+        <li class="{{ "govuk-!-margin-bottom-0" if loop.last }}">{{ name }}</li>
       {% endfor %}
     </ul>
   {% else %}

--- a/server/views/pages/timetable.njk
+++ b/server/views/pages/timetable.njk
@@ -10,7 +10,14 @@
 
 {% macro attendees(enhanced, prisonerLocationGroupNames) %}
   {% if prisonerLocationGroupNames | length %}
-    {{- "Enhanced prisoners in " if enhanced}}{{ prisonerLocationGroupNames | join(", ") -}}
+    {% if enhanced %}
+      <span>Enhanced prisoners in:</span>
+    {% endif %}
+    <ul class="govuk-list govuk-!-margin-bottom-0{{ " govuk-!-margin-top-2" if enhanced }}">
+      {% for name in prisonerLocationGroupNames %}
+        <li class="{{ "govuk-!-margin-bottom-2" if not loop.last else "govuk-!-margin-bottom-0" }}">{{ name }}</li>
+      {% endfor %}
+    </ul>
   {% else %}
     {{- "Enhanced prisoners only" if enhanced else "All prisoners" -}}
   {% endif %}


### PR DESCRIPTION
Styling location groups as a single comma separated string looks confusing because the names themselves have commas inside..

This change renders the group names as a list.