### PR TITLE
VB-1430 Refactor services and tests following data access layer changes

### DIFF
--- a/server/services/notificationsService.test.ts
+++ b/server/services/notificationsService.test.ts
@@ -1,5 +1,5 @@
 import { VisitSlot } from '../@types/bapv'
-import NotificationsApiClient from '../data/notificationsApiClient'
+import { NotificationsApiClient } from '../data'
 import NotificationsService from './notificationsService'
 
 jest.mock('../data/notificationsApiClient')

--- a/server/services/notificationsService.ts
+++ b/server/services/notificationsService.ts
@@ -1,7 +1,7 @@
 import { format } from 'date-fns'
 import { SmsResponse } from 'notifications-node-client'
 import { VisitSlot } from '../@types/bapv'
-import NotificationsApiClient from '../data/notificationsApiClient'
+import { NotificationsApiClient } from '../data'
 
 type NotificationsApiClientBuilder = () => NotificationsApiClient
 

--- a/server/services/prisonerSearchService.test.ts
+++ b/server/services/prisonerSearchService.test.ts
@@ -1,33 +1,36 @@
 import PrisonerSearchService from './prisonerSearchService'
-import PrisonerSearchClient from '../data/prisonerSearchClient'
 import TestData from '../routes/testutils/testData'
-import HmppsAuthClient from '../data/hmppsAuthClient'
+import { HmppsAuthClient, PrisonerSearchClient } from '../data'
 
 jest.mock('../data/hmppsAuthClient')
 jest.mock('../data/prisonerSearchClient')
 
-const prisonId = 'HEI'
-const search = 'some search'
-const prisonerSearchClient = new PrisonerSearchClient(null) as jest.Mocked<PrisonerSearchClient>
-
-const prisoner = TestData.prisoner()
+const token = 'some token'
 
 describe('Prisoner search service', () => {
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
-  let prisonerSearchClientBuilder
+  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+  const prisonerSearchClient = new PrisonerSearchClient(null) as jest.Mocked<PrisonerSearchClient>
+
   let prisonerSearchService: PrisonerSearchService
 
+  const PrisonerSearchClientFactory = jest.fn()
+
+  const prisonId = 'HEI'
+  const search = 'some search'
+
+  const prisoner = TestData.prisoner()
+
   beforeEach(() => {
-    hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-    prisonerSearchClientBuilder = jest.fn().mockReturnValue(prisonerSearchClient)
-    prisonerSearchService = new PrisonerSearchService(prisonerSearchClientBuilder, hmppsAuthClient)
+    PrisonerSearchClientFactory.mockReturnValue(prisonerSearchClient)
+    prisonerSearchService = new PrisonerSearchService(PrisonerSearchClientFactory, hmppsAuthClient)
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
   })
 
   describe('getPrisoners', () => {
-    afterEach(() => {
-      jest.resetAllMocks()
-    })
-
     describe('prisoner search', () => {
       it('Retrieves and formats user name', async () => {
         prisonerSearchClient.getPrisoners.mockResolvedValue({

--- a/server/services/prisonerVisitorsService.test.ts
+++ b/server/services/prisonerVisitorsService.test.ts
@@ -1,28 +1,29 @@
 import PrisonerVisitorsService from './prisonerVisitorsService'
-import PrisonerContactRegistryApiClient from '../data/prisonerContactRegistryApiClient'
 import { Contact } from '../data/prisonerContactRegistryApiTypes'
 import { VisitorListItem } from '../@types/bapv'
-import HmppsAuthClient from '../data/hmppsAuthClient'
+import { HmppsAuthClient, PrisonerContactRegistryApiClient } from '../data'
 
 jest.mock('../data/hmppsAuthClient')
 jest.mock('../data/prisonerContactRegistryApiClient')
 
-const prisonerContactRegistryApiClient = new PrisonerContactRegistryApiClient(
-  null,
-) as jest.Mocked<PrisonerContactRegistryApiClient>
+const token = 'some token'
 
 describe('Prisoner visitor service', () => {
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
-  let prisonerContactRegistryApiClientBuilder
+  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+  const prisonerContactRegistryApiClient = new PrisonerContactRegistryApiClient(
+    null,
+  ) as jest.Mocked<PrisonerContactRegistryApiClient>
   let prisonerVisitorsService: PrisonerVisitorsService
+
+  const PrisonerContactRegistryApiClientFactory = jest.fn()
 
   describe('getVisitors', () => {
     const offenderNo = 'A1234BC'
 
     beforeEach(() => {
-      hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-      prisonerContactRegistryApiClientBuilder = jest.fn().mockReturnValue(prisonerContactRegistryApiClient)
-      prisonerVisitorsService = new PrisonerVisitorsService(prisonerContactRegistryApiClientBuilder, hmppsAuthClient)
+      PrisonerContactRegistryApiClientFactory.mockReturnValue(prisonerContactRegistryApiClient)
+      prisonerVisitorsService = new PrisonerVisitorsService(PrisonerContactRegistryApiClientFactory, hmppsAuthClient)
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
     })
 
     afterEach(() => {

--- a/server/services/prisonerVisitorsService.ts
+++ b/server/services/prisonerVisitorsService.ts
@@ -1,20 +1,17 @@
 import { VisitorListItem } from '../@types/bapv'
 import { Contact } from '../data/prisonerContactRegistryApiTypes'
-import PrisonerContactRegistryApiClient from '../data/prisonerContactRegistryApiClient'
 import buildVisitorListItem from '../utils/visitorUtils'
-import HmppsAuthClient from '../data/hmppsAuthClient'
-
-type PrisonerContactRegistryApiClientBuilder = (token: string) => PrisonerContactRegistryApiClient
+import { HmppsAuthClient, PrisonerContactRegistryApiClient, RestClientBuilder } from '../data'
 
 export default class PrisonerVisitorsService {
   constructor(
-    private readonly prisonerContactRegistryApiClientBuilder: PrisonerContactRegistryApiClientBuilder,
+    private readonly prisonerContactRegistryApiClientFactory: RestClientBuilder<PrisonerContactRegistryApiClient>,
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
 
   async getVisitors(offenderNo: string, username: string): Promise<VisitorListItem[]> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
-    const prisonerContactRegistryApiClient = this.prisonerContactRegistryApiClientBuilder(token)
+    const prisonerContactRegistryApiClient = this.prisonerContactRegistryApiClientFactory(token)
 
     const allSocialContacts: Contact[] = await prisonerContactRegistryApiClient.getPrisonerSocialContacts(offenderNo)
     const approvedContacts = allSocialContacts.filter(contact => contact.approvedVisitor)

--- a/server/services/supportedPrisonsService.test.ts
+++ b/server/services/supportedPrisonsService.test.ts
@@ -1,38 +1,39 @@
 import SupportedPrisonsService from './supportedPrisonsService'
-import VisitSchedulerApiClient from '../data/visitSchedulerApiClient'
-import PrisonRegisterApiClient from '../data/prisonRegisterApiClient'
 import TestData from '../routes/testutils/testData'
 import { PrisonDto } from '../data/prisonRegisterApiTypes'
-import HmppsAuthClient from '../data/hmppsAuthClient'
+import { HmppsAuthClient, PrisonRegisterApiClient, VisitSchedulerApiClient } from '../data'
 
 jest.mock('../data/hmppsAuthClient')
 jest.mock('../data/visitSchedulerApiClient')
 jest.mock('../data/prisonRegisterApiClient')
 
-const visitSchedulerApiClient = new VisitSchedulerApiClient(null) as jest.Mocked<VisitSchedulerApiClient>
-const prisonRegisterApiClient = new PrisonRegisterApiClient(null) as jest.Mocked<PrisonRegisterApiClient>
+const token = 'some token'
 
 describe('Supported prisons service', () => {
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+  const prisonRegisterApiClient = new PrisonRegisterApiClient(null) as jest.Mocked<PrisonRegisterApiClient>
+  const visitSchedulerApiClient = new VisitSchedulerApiClient(null) as jest.Mocked<VisitSchedulerApiClient>
+
   let supportedPrisonsService: SupportedPrisonsService
-  let visitSchedulerApiClientBuilder
-  let prisonRegisterApiClientBuilder
+
+  const PrisonRegisterApiClientFactory = jest.fn()
+  const VisitSchedulerApiClientFactory = jest.fn()
 
   const allPrisons = TestData.prisons()
   const supportedPrisons = TestData.supportedPrisons()
   const supportedPrisonIds = TestData.supportedPrisonIds()
 
   beforeEach(() => {
-    hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-    visitSchedulerApiClientBuilder = jest.fn().mockReturnValue(visitSchedulerApiClient)
-    prisonRegisterApiClientBuilder = jest.fn().mockReturnValue(prisonRegisterApiClient)
+    PrisonRegisterApiClientFactory.mockReturnValue(prisonRegisterApiClient)
+    VisitSchedulerApiClientFactory.mockReturnValue(visitSchedulerApiClient)
     supportedPrisonsService = new SupportedPrisonsService(
-      visitSchedulerApiClientBuilder,
-      prisonRegisterApiClientBuilder,
+      VisitSchedulerApiClientFactory,
+      PrisonRegisterApiClientFactory,
       hmppsAuthClient,
     )
 
     prisonRegisterApiClient.getPrisons.mockResolvedValue(allPrisons as PrisonDto[])
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
   })
 
   afterEach(() => {

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -8,18 +8,20 @@ jest.mock('../data/prisonApiClient')
 
 const token = 'some token'
 
-afterEach(() => {
-  jest.resetAllMocks()
-})
-
 describe('User service', () => {
   let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  let prisonApiClient: jest.Mocked<PrisonApiClient>
   let userService: UserService
+
+  const PrisonApiClientFactory = jest.fn()
 
   describe('getUser', () => {
     beforeEach(() => {
       hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-      userService = new UserService(hmppsAuthClient, undefined)
+      prisonApiClient = new PrisonApiClient(null) as jest.Mocked<PrisonApiClient>
+      PrisonApiClientFactory.mockReturnValue(prisonApiClient)
+      userService = new UserService(hmppsAuthClient, PrisonApiClientFactory)
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
     })
 
     it('Retrieves and formats user name', async () => {
@@ -37,15 +39,7 @@ describe('User service', () => {
   })
 
   describe('getUserCaseLoadIds', () => {
-    const prisonApiClient = new PrisonApiClient(null) as jest.Mocked<PrisonApiClient>
-    let prisonApiClientBuilder
-
     const usersCaseLoads = TestData.caseLoads()
-
-    beforeEach(() => {
-      prisonApiClientBuilder = jest.fn().mockReturnValue(prisonApiClient)
-      userService = new UserService(hmppsAuthClient, prisonApiClientBuilder)
-    })
 
     it('should return an array of available caseload IDs for current user', async () => {
       prisonApiClient.getUserCaseLoads.mockResolvedValue(usersCaseLoads)
@@ -57,14 +51,6 @@ describe('User service', () => {
   })
 
   describe('setActiveCaseLoad', () => {
-    const prisonApiClient = new PrisonApiClient(null) as jest.Mocked<PrisonApiClient>
-    let prisonApiClientBuilder
-
-    beforeEach(() => {
-      prisonApiClientBuilder = jest.fn().mockReturnValue(prisonApiClient)
-      userService = new UserService(hmppsAuthClient, prisonApiClientBuilder)
-    })
-
     it('should set active case load for current user', async () => {
       prisonApiClient.setActiveCaseLoad.mockResolvedValue()
 

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -1,10 +1,4 @@
 import { NotFound } from 'http-errors'
-import PrisonerContactRegistryApiClient from '../data/prisonerContactRegistryApiClient'
-import VisitSessionsService from './visitSessionsService'
-import VisitSchedulerApiClient from '../data/visitSchedulerApiClient'
-import WhereaboutsApiClient from '../data/whereaboutsApiClient'
-import { VisitSession, Visit, OutcomeDto, PageVisitDto, SessionSchedule } from '../data/visitSchedulerApiTypes'
-import { Address, Contact, AddressUsage, Restriction } from '../data/prisonerContactRegistryApiTypes'
 import {
   VisitSlotList,
   VisitSessionData,
@@ -13,42 +7,54 @@ import {
   ExtendedVisitInformation,
   VisitsPageSlot,
 } from '../@types/bapv'
+import { Address, Contact, AddressUsage, Restriction } from '../data/prisonerContactRegistryApiTypes'
+import { VisitSession, Visit, OutcomeDto, PageVisitDto, SessionSchedule } from '../data/visitSchedulerApiTypes'
 import { ScheduledEvent } from '../data/whereaboutsApiTypes'
 import TestData from '../routes/testutils/testData'
-import HmppsAuthClient from '../data/hmppsAuthClient'
+import VisitSessionsService from './visitSessionsService'
+import {
+  HmppsAuthClient,
+  PrisonerContactRegistryApiClient,
+  VisitSchedulerApiClient,
+  WhereaboutsApiClient,
+} from '../data'
 
 jest.mock('../data/hmppsAuthClient')
 jest.mock('../data/prisonerContactRegistryApiClient')
 jest.mock('../data/visitSchedulerApiClient')
 jest.mock('../data/whereaboutsApiClient')
 
-const prisonerContactRegistryApiClient = new PrisonerContactRegistryApiClient(
-  null,
-) as jest.Mocked<PrisonerContactRegistryApiClient>
-const visitSchedulerApiClient = new VisitSchedulerApiClient(null) as jest.Mocked<VisitSchedulerApiClient>
-const whereaboutsApiClient = new WhereaboutsApiClient(null) as jest.Mocked<WhereaboutsApiClient>
+const token = 'some token'
 
 describe('Visit sessions service', () => {
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
-  let prisonerContactRegistryApiClientBuilder
-  let visitSchedulerApiClientBuilder
-  let whereaboutsApiClientBuilder
+  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+  const prisonerContactRegistryApiClient = new PrisonerContactRegistryApiClient(
+    null,
+  ) as jest.Mocked<PrisonerContactRegistryApiClient>
+  const visitSchedulerApiClient = new VisitSchedulerApiClient(null) as jest.Mocked<VisitSchedulerApiClient>
+  const whereaboutsApiClient = new WhereaboutsApiClient(null) as jest.Mocked<WhereaboutsApiClient>
+
   let visitSessionsService: VisitSessionsService
+
+  const PrisonerContactRegistryApiClientFactory = jest.fn()
+  const VisitSchedulerApiClientFactory = jest.fn()
+  const WhereaboutsApiClientFactory = jest.fn()
 
   const prisonId = 'HEI'
   const availableSupportTypes = TestData.supportTypes()
 
   beforeEach(() => {
-    hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-    prisonerContactRegistryApiClientBuilder = jest.fn().mockReturnValue(prisonerContactRegistryApiClient)
-    visitSchedulerApiClientBuilder = jest.fn().mockReturnValue(visitSchedulerApiClient)
-    whereaboutsApiClientBuilder = jest.fn().mockReturnValue(whereaboutsApiClient)
+    PrisonerContactRegistryApiClientFactory.mockReturnValue(prisonerContactRegistryApiClient)
+    VisitSchedulerApiClientFactory.mockReturnValue(visitSchedulerApiClient)
+    WhereaboutsApiClientFactory.mockReturnValue(whereaboutsApiClient)
+
     visitSessionsService = new VisitSessionsService(
-      prisonerContactRegistryApiClientBuilder,
-      visitSchedulerApiClientBuilder,
-      whereaboutsApiClientBuilder,
+      PrisonerContactRegistryApiClientFactory,
+      VisitSchedulerApiClientFactory,
+      WhereaboutsApiClientFactory,
       hmppsAuthClient,
     )
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
   })
 
   afterEach(() => {


### PR DESCRIPTION
Follow on from #517, and part of implementing changes in https://github.com/ministryofjustice/hmpps-template-typescript/pull/106. 

Following consolidation of the data access layer in #517, this change is to refactor services and their tests to use named imports from `../data` and standardise mocking dependencies in tests.