### PR TITLE
VB-1430 Use services container

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -13,11 +13,6 @@ import timetableRoutes from './routes/timetable'
 import nunjucksSetup from './utils/nunjucksSetup'
 import errorHandler from './errorHandler'
 import standardRouter from './routes/standardRouter'
-import UserService from './services/userService'
-import NotificationsService from './services/notificationsService'
-import PrisonerSearchService from './services/prisonerSearchService'
-import PrisonerProfileService from './services/prisonerProfileService'
-import SupportedPrisonsService from './services/supportedPrisonsService'
 import setUpWebSession from './middleware/setUpWebSession'
 import setUpStaticResources from './middleware/setUpStaticResources'
 import setUpWebSecurity from './middleware/setUpWebSecurity'
@@ -25,14 +20,10 @@ import setUpAuthentication from './middleware/setUpAuthentication'
 import setUpHealthChecks from './middleware/setUpHealthChecks'
 import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
-import PrisonerVisitorsService from './services/prisonerVisitorsService'
-import VisitSessionsService from './services/visitSessionsService'
-import AuditService from './services/auditService'
 import appInsightsOperationId from './middleware/appInsightsOperationId'
-import HmppsAuthClient from './data/hmppsAuthClient'
-import { dataAccess } from './data'
+import type { Services } from './services'
 
-export default function createApp(userService: UserService, hmppsAuthClient: HmppsAuthClient): express.Application {
+export default function createApp(services: Services): express.Application {
   const app = express()
 
   app.set('json spaces', 2)
@@ -49,143 +40,14 @@ export default function createApp(userService: UserService, hmppsAuthClient: Hmp
   app.use(authorisationMiddleware(['ROLE_MANAGE_PRISON_VISITS']))
   app.use(appInsightsOperationId)
 
-  const {
-    notificationsApiClientBuilder,
-    prisonApiClientBuilder,
-    prisonerContactRegistryApiClientBuilder,
-    prisonRegisterApiClientBuilder,
-    prisonerSearchClientBuilder,
-    visitSchedulerApiClientBuilder,
-    whereaboutsApiClientBuilder,
-  } = dataAccess()
-
-  const supportedPrisonsService = new SupportedPrisonsService(
-    visitSchedulerApiClientBuilder,
-    prisonRegisterApiClientBuilder,
-    hmppsAuthClient,
-  )
-
-  app.use('/', indexRoutes(standardRouter(userService, supportedPrisonsService)))
-  app.use(
-    '/change-establishment/',
-    establishmentRoutes(
-      standardRouter(userService, supportedPrisonsService),
-      supportedPrisonsService,
-      new AuditService(),
-      userService,
-    ),
-  )
-  app.use(
-    '/search/',
-    searchRoutes(
-      standardRouter(userService, supportedPrisonsService),
-      new PrisonerSearchService(prisonerSearchClientBuilder, hmppsAuthClient),
-      new VisitSessionsService(
-        prisonerContactRegistryApiClientBuilder,
-        visitSchedulerApiClientBuilder,
-        whereaboutsApiClientBuilder,
-        hmppsAuthClient,
-      ),
-      new AuditService(),
-    ),
-  )
-  app.use(
-    '/prisoner/',
-    prisonerRoutes(
-      standardRouter(userService, supportedPrisonsService),
-      new PrisonerProfileService(
-        prisonApiClientBuilder,
-        visitSchedulerApiClientBuilder,
-        prisonerContactRegistryApiClientBuilder,
-        prisonerSearchClientBuilder,
-        supportedPrisonsService,
-        hmppsAuthClient,
-      ),
-      new PrisonerSearchService(prisonerSearchClientBuilder, hmppsAuthClient),
-      new VisitSessionsService(
-        prisonerContactRegistryApiClientBuilder,
-        visitSchedulerApiClientBuilder,
-        whereaboutsApiClientBuilder,
-        hmppsAuthClient,
-      ),
-      new AuditService(),
-    ),
-  )
-  app.use(
-    '/book-a-visit/',
-    bookAVisitRoutes(
-      standardRouter(userService, supportedPrisonsService),
-      new PrisonerVisitorsService(prisonerContactRegistryApiClientBuilder, hmppsAuthClient),
-      new VisitSessionsService(
-        prisonerContactRegistryApiClientBuilder,
-        visitSchedulerApiClientBuilder,
-        whereaboutsApiClientBuilder,
-        hmppsAuthClient,
-      ),
-      new PrisonerProfileService(
-        prisonApiClientBuilder,
-        visitSchedulerApiClientBuilder,
-        prisonerContactRegistryApiClientBuilder,
-        prisonerSearchClientBuilder,
-        supportedPrisonsService,
-        hmppsAuthClient,
-      ),
-      new NotificationsService(notificationsApiClientBuilder),
-      new AuditService(),
-    ),
-  )
-  app.use(
-    '/visit/',
-    visitRoutes(
-      standardRouter(userService, supportedPrisonsService),
-      new PrisonerSearchService(prisonerSearchClientBuilder, hmppsAuthClient),
-      new VisitSessionsService(
-        prisonerContactRegistryApiClientBuilder,
-        visitSchedulerApiClientBuilder,
-        whereaboutsApiClientBuilder,
-        hmppsAuthClient,
-      ),
-      new NotificationsService(notificationsApiClientBuilder),
-      new AuditService(),
-      new PrisonerVisitorsService(prisonerContactRegistryApiClientBuilder, hmppsAuthClient),
-      new PrisonerProfileService(
-        prisonApiClientBuilder,
-        visitSchedulerApiClientBuilder,
-        prisonerContactRegistryApiClientBuilder,
-        prisonerSearchClientBuilder,
-        supportedPrisonsService,
-        hmppsAuthClient,
-      ),
-      supportedPrisonsService,
-    ),
-  )
-  app.use(
-    '/visits/',
-    visitsRoutes(
-      standardRouter(userService, supportedPrisonsService),
-      new PrisonerSearchService(prisonerSearchClientBuilder, hmppsAuthClient),
-      new VisitSessionsService(
-        prisonerContactRegistryApiClientBuilder,
-        visitSchedulerApiClientBuilder,
-        whereaboutsApiClientBuilder,
-        hmppsAuthClient,
-      ),
-      new AuditService(),
-    ),
-  )
-
-  app.use(
-    '/timetable/',
-    timetableRoutes(
-      standardRouter(userService, supportedPrisonsService),
-      new VisitSessionsService(
-        prisonerContactRegistryApiClientBuilder,
-        visitSchedulerApiClientBuilder,
-        whereaboutsApiClientBuilder,
-        hmppsAuthClient,
-      ),
-    ),
-  )
+  app.use('/', indexRoutes(standardRouter(services)))
+  app.use('/book-a-visit/', bookAVisitRoutes(standardRouter(services), services))
+  app.use('/change-establishment/', establishmentRoutes(standardRouter(services), services))
+  app.use('/prisoner/', prisonerRoutes(standardRouter(services), services))
+  app.use('/search/', searchRoutes(standardRouter(services), services))
+  app.use('/timetable/', timetableRoutes(standardRouter(services), services))
+  app.use('/visit/', visitRoutes(standardRouter(services), services))
+  app.use('/visits/', visitsRoutes(standardRouter(services), services))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(process.env.NODE_ENV === 'production'))

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,6 @@
-import { dataAccess } from './data'
 import createApp from './app'
-import UserService from './services/userService'
+import { services } from './services'
 
-const { hmppsAuthClient, prisonApiClientBuilder } = dataAccess()
-const userService = new UserService(hmppsAuthClient, prisonApiClientBuilder)
-
-const app = createApp(userService, hmppsAuthClient)
+const app = createApp(services())
 
 export default app

--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -4,35 +4,26 @@ import * as cheerio from 'cheerio'
 import { SessionData } from 'express-session'
 import { PrisonerProfile, BAPVVisitBalances, VisitInformation, VisitSessionData } from '../@types/bapv'
 import { InmateDetail, VisitBalances } from '../data/prisonApiTypes'
-import PrisonerProfileService from '../services/prisonerProfileService'
-import PrisonerSearchService from '../services/prisonerSearchService'
-import VisitSessionsService from '../services/visitSessionsService'
-import AuditService from '../services/auditService'
 import { appWithAllRoutes, flashProvider } from './testutils/appSetup'
 import { clearSession } from './visitorUtils'
 import TestData from './testutils/testData'
-
-jest.mock('../services/prisonerProfileService')
-jest.mock('../services/prisonerSearchService')
-jest.mock('../services/visitSessionsService')
-jest.mock('../services/auditService')
+import {
+  createMockAuditService,
+  createMockPrisonerProfileService,
+  createMockPrisonerSearchService,
+  createMockVisitSessionsService,
+} from '../services/testutils/mocks'
 
 let app: Express
+
+const auditService = createMockAuditService()
+const prisonerProfileService = createMockPrisonerProfileService()
+const prisonerSearchService = createMockPrisonerSearchService()
+const visitSessionsService = createMockVisitSessionsService()
+
 const prisonId = 'HEI'
 let flashData: Record<string, string[] | Record<string, string>[]>
 let visitSessionData: Partial<VisitSessionData>
-
-const prisonerProfileService = new PrisonerProfileService(
-  null,
-  null,
-  null,
-  null,
-  null,
-  null,
-) as jest.Mocked<PrisonerProfileService>
-const prisonerSearchService = new PrisonerSearchService(null, null) as jest.Mocked<PrisonerSearchService>
-const visitSessionsService = new VisitSessionsService(null, null, null, null) as jest.Mocked<VisitSessionsService>
-const auditService = new AuditService() as jest.Mocked<AuditService>
 
 jest.mock('./visitorUtils', () => ({
   clearSession: jest.fn((req: Express.Request) => {
@@ -49,10 +40,7 @@ beforeEach(() => {
   visitSessionData = {}
 
   app = appWithAllRoutes({
-    prisonerSearchServiceOverride: prisonerSearchService,
-    prisonerProfileServiceOverride: prisonerProfileService,
-    visitSessionsServiceOverride: visitSessionsService,
-    auditServiceOverride: auditService,
+    services: { auditService, prisonerProfileService, prisonerSearchService, visitSessionsService },
     sessionData: {
       visitSessionData,
     } as SessionData,

--- a/server/routes/search.test.ts
+++ b/server/routes/search.test.ts
@@ -3,22 +3,22 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import createError from 'http-errors'
 import { SessionData } from 'express-session'
-import PrisonerSearchService from '../services/prisonerSearchService'
-import VisitSessionsService from '../services/visitSessionsService'
 import { appWithAllRoutes } from './testutils/appSetup'
 import { PrisonerDetailsItem, VisitInformation } from '../@types/bapv'
-import AuditService from '../services/auditService'
 import TestData from './testutils/testData'
-
-jest.mock('../services/prisonerSearchService')
-jest.mock('../services/visitSessionsService')
-jest.mock('../services/auditService')
+import {
+  createMockAuditService,
+  createMockPrisonerSearchService,
+  createMockVisitSessionsService,
+} from '../services/testutils/mocks'
 
 let app: Express
+
+const auditService = createMockAuditService()
+const prisonerSearchService = createMockPrisonerSearchService()
+const visitSessionsService = createMockVisitSessionsService()
+
 const prisonId = 'HEI'
-const prisonerSearchService = new PrisonerSearchService(null, null) as jest.Mocked<PrisonerSearchService>
-const auditService = new AuditService() as jest.Mocked<AuditService>
-const visitSessionsService = new VisitSessionsService(null, null, null, null) as jest.Mocked<VisitSessionsService>
 
 let getPrisonersReturnData: {
   results: Array<PrisonerDetailsItem[]>
@@ -38,11 +38,7 @@ const getPrisonerReturnData = TestData.prisoner()
 let getVisit: VisitInformation
 
 beforeEach(() => {
-  app = appWithAllRoutes({
-    prisonerSearchServiceOverride: prisonerSearchService,
-    visitSessionsServiceOverride: visitSessionsService,
-    auditServiceOverride: auditService,
-  })
+  app = appWithAllRoutes({ services: { auditService, prisonerSearchService, visitSessionsService } })
 })
 
 afterEach(() => {
@@ -452,9 +448,7 @@ describe('Booking search page', () => {
       })
 
       app = appWithAllRoutes({
-        prisonerSearchServiceOverride: prisonerSearchService,
-        visitSessionsServiceOverride: visitSessionsService,
-        auditServiceOverride: auditService,
+        services: { auditService, prisonerSearchService, visitSessionsService },
         sessionData: { selectedEstablishment: { prisonId: 'XYZ' } } as SessionData,
       })
 

--- a/server/routes/standardRouter.ts
+++ b/server/routes/standardRouter.ts
@@ -4,20 +4,16 @@ import auth from '../authentication/auth'
 import tokenVerifier from '../data/tokenVerification'
 import populateCurrentUser from '../middleware/populateCurrentUser'
 import populateSelectedEstablishment from '../middleware/populateSelectedEstablishment'
-import type UserService from '../services/userService'
-import SupportedPrisonsService from '../services/supportedPrisonsService'
+import type { Services } from '../services'
 
 const testMode = process.env.NODE_ENV === 'test'
 
-export default function standardRouter(
-  userService: UserService,
-  supportedPrisonsService: SupportedPrisonsService,
-): Router {
+export default function standardRouter(services: Services): Router {
   const router = Router({ mergeParams: true })
 
   router.use(auth.authenticationMiddleware(tokenVerifier))
-  router.use(populateCurrentUser(userService))
-  router.use(populateSelectedEstablishment(supportedPrisonsService))
+  router.use(populateCurrentUser(services.userService))
+  router.use(populateSelectedEstablishment(services.supportedPrisonsService))
 
   // CSRF protection
   if (!testMode) {

--- a/server/routes/timetable.test.ts
+++ b/server/routes/timetable.test.ts
@@ -3,19 +3,17 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes } from './testutils/appSetup'
 import config from '../config'
-import VisitSessionsService from '../services/visitSessionsService'
 import TestData from './testutils/testData'
-
-jest.mock('../services/visitSessionsService')
+import { createMockVisitSessionsService } from '../services/testutils/mocks'
 
 let app: Express
 
-const visitSessionsService = new VisitSessionsService(null, null, null, null) as jest.Mocked<VisitSessionsService>
+const visitSessionsService = createMockVisitSessionsService()
 
 beforeEach(() => {
   visitSessionsService.getSessionSchedule.mockResolvedValue([])
 
-  app = appWithAllRoutes({ visitSessionsServiceOverride: visitSessionsService })
+  app = appWithAllRoutes({ services: { visitSessionsService } })
 
   config.features.viewTimetableEnabled = true
 })

--- a/server/routes/timetable.ts
+++ b/server/routes/timetable.ts
@@ -3,10 +3,10 @@ import { NotFound } from 'http-errors'
 import config from '../config'
 import sessionTemplateFrequency from '../constants/sessionTemplateFrequency'
 import asyncMiddleware from '../middleware/asyncMiddleware'
-import VisitSessionsService from '../services/visitSessionsService'
+import type { Services } from '../services'
 import { getParsedDateFromQueryString, getWeekOfDatesStartingMonday } from '../utils/utils'
 
-export default function routes(router: Router, visitSessionService: VisitSessionsService): Router {
+export default function routes(router: Router, services: Services): Router {
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   get('/', async (req, res) => {
@@ -21,7 +21,7 @@ export default function routes(router: Router, visitSessionService: VisitSession
     const { weekOfDates, previousWeek, nextWeek } = getWeekOfDatesStartingMonday(selectedDate)
 
     const { prisonId } = req.session.selectedEstablishment
-    const schedules = await visitSessionService.getSessionSchedule({
+    const schedules = await services.visitSessionsService.getSessionSchedule({
       username: res.locals.user?.username,
       prisonId,
       date: selectedDate,

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -5,18 +5,12 @@ import visitCancellationReasons from '../constants/visitCancellationReasons'
 import { Prisoner } from '../data/prisonerOffenderSearchTypes'
 import { OutcomeDto, Visit } from '../data/visitSchedulerApiTypes'
 import asyncMiddleware from '../middleware/asyncMiddleware'
-import PrisonerSearchService from '../services/prisonerSearchService'
-import VisitSessionsService from '../services/visitSessionsService'
-import AuditService from '../services/auditService'
 import { isValidVisitReference } from './validationChecks'
 import { clearSession, getFlashFormValues } from './visitorUtils'
-import NotificationsService from '../services/notificationsService'
 import config from '../config'
 import logger from '../../logger'
 import { VisitorListItem, VisitSessionData, VisitSlot } from '../@types/bapv'
-import PrisonerVisitorsService from '../services/prisonerVisitorsService'
 import SelectVisitors from './visitJourney/selectVisitors'
-import PrisonerProfileService from '../services/prisonerProfileService'
 import VisitType from './visitJourney/visitType'
 import { properCaseFullName } from '../utils/utils'
 import DateAndTime from './visitJourney/dateAndTime'
@@ -25,19 +19,10 @@ import CheckYourBooking from './visitJourney/checkYourBooking'
 import Confirmation from './visitJourney/confirmation'
 import MainContact from './visitJourney/mainContact'
 import sessionCheckMiddleware from '../middleware/sessionCheckMiddleware'
-import SupportedPrisonsService from '../services/supportedPrisonsService'
 import getPrisonConfiguration from '../constants/prisonConfiguration'
+import type { Services } from '../services'
 
-export default function routes(
-  router: Router,
-  prisonerSearchService: PrisonerSearchService,
-  visitSessionsService: VisitSessionsService,
-  notificationsService: NotificationsService,
-  auditService: AuditService,
-  prisonerVisitorsService: PrisonerVisitorsService,
-  prisonerProfileService: PrisonerProfileService,
-  supportedPrisonsService: SupportedPrisonsService,
-): Router {
+export default function routes(router: Router, services: Services): Router {
   const get = (path: string, ...handlers: RequestHandler[]) =>
     router.get(
       path,
@@ -69,13 +54,13 @@ export default function routes(
       visitors,
       additionalSupport,
     }: { visit: Visit; visitors: VisitorListItem[]; additionalSupport: string[] } =
-      await visitSessionsService.getFullVisitDetails({
+      await services.visitSessionsService.getFullVisitDetails({
         reference,
         username: res.locals.user?.username,
       })
 
     if (visit.prisonId !== req.session.selectedEstablishment.prisonId) {
-      const supportedPrisons = await supportedPrisonsService.getSupportedPrisons(res.locals.user?.username)
+      const supportedPrisons = await services.supportedPrisonsService.getSupportedPrisons(res.locals.user?.username)
 
       return res.render('pages/visit/summary', {
         visit: { reference: visit.reference },
@@ -83,12 +68,15 @@ export default function routes(
       })
     }
 
-    const prisoner: Prisoner = await prisonerSearchService.getPrisonerById(visit.prisonerId, res.locals.user?.username)
-    const supportedPrisonIds = await supportedPrisonsService.getSupportedPrisonIds(res.locals.user?.username)
+    const prisoner: Prisoner = await services.prisonerSearchService.getPrisonerById(
+      visit.prisonerId,
+      res.locals.user?.username,
+    )
+    const supportedPrisonIds = await services.supportedPrisonsService.getSupportedPrisonIds(res.locals.user?.username)
 
     const prisonerLocation = getPrisonerLocation(supportedPrisonIds, prisoner)
 
-    await auditService.viewedVisitDetails({
+    await services.auditService.viewedVisitDetails({
       visitReference: reference,
       prisonerId: visit.prisonerId,
       prisonId: visit.prisonId,
@@ -115,7 +103,7 @@ export default function routes(
   post('/:reference', async (req, res) => {
     const reference = getVisitReference(req)
 
-    const { visit }: { visit: Visit } = await visitSessionsService.getFullVisitDetails({
+    const { visit }: { visit: Visit } = await services.visitSessionsService.getFullVisitDetails({
       reference,
       username: res.locals.user?.username,
     })
@@ -124,15 +112,18 @@ export default function routes(
       return res.redirect(`/visit/${visit.reference}`)
     }
 
-    const prisoner: Prisoner = await prisonerSearchService.getPrisonerById(visit.prisonerId, res.locals.user?.username)
-    const supportedPrisonIds = await supportedPrisonsService.getSupportedPrisonIds(res.locals.user?.username)
+    const prisoner: Prisoner = await services.prisonerSearchService.getPrisonerById(
+      visit.prisonerId,
+      res.locals.user?.username,
+    )
+    const supportedPrisonIds = await services.supportedPrisonsService.getSupportedPrisonIds(res.locals.user?.username)
 
     const prisonerLocation = getPrisonerLocation(supportedPrisonIds, prisoner)
 
     const visitorIds = visit.visitors.flatMap(visitor => visitor.nomisPersonId)
     const mainContactVisitor = visit.visitors.find(visitor => visitor.visitContact)
     const mainContactId = mainContactVisitor ? mainContactVisitor.nomisPersonId : null
-    const visitorList = await prisonerVisitorsService.getVisitors(visit.prisonerId, res.locals.user?.username)
+    const visitorList = await services.prisonerVisitorsService.getVisitors(visit.prisonerId, res.locals.user?.username)
     const currentVisitors = visitorList.filter(visitor => visitorIds.includes(visitor.personId))
     const mainContact = currentVisitors.find(visitor => visitor.personId === mainContactId)
 
@@ -176,12 +167,17 @@ export default function routes(
     return res.redirect(`/visit/${reference}/update/select-visitors`)
   })
 
-  const selectVisitors = new SelectVisitors('update', prisonerVisitorsService, prisonerProfileService)
-  const visitType = new VisitType('update', auditService)
-  const dateAndTime = new DateAndTime('update', visitSessionsService, auditService)
-  const additionalSupport = new AdditionalSupport('update', visitSessionsService)
+  const selectVisitors = new SelectVisitors('update', services.prisonerVisitorsService, services.prisonerProfileService)
+  const visitType = new VisitType('update', services.auditService)
+  const dateAndTime = new DateAndTime('update', services.visitSessionsService, services.auditService)
+  const additionalSupport = new AdditionalSupport('update', services.visitSessionsService)
   const mainContact = new MainContact('update')
-  const checkYourBooking = new CheckYourBooking('update', visitSessionsService, auditService, notificationsService)
+  const checkYourBooking = new CheckYourBooking(
+    'update',
+    services.visitSessionsService,
+    services.auditService,
+    services.notificationsService,
+  )
   const confirmation = new Confirmation('update')
 
   get(
@@ -308,9 +304,13 @@ export default function routes(
         text: req.body[reasonFieldName],
       }
 
-      const visit = await visitSessionsService.cancelVisit({ username: res.locals.user?.username, reference, outcome })
+      const visit = await services.visitSessionsService.cancelVisit({
+        username: res.locals.user?.username,
+        reference,
+        outcome,
+      })
 
-      await auditService.cancelledVisit({
+      await services.auditService.cancelledVisit({
         visitReference: reference,
         prisonerId: visit.prisonerId.toString(),
         prisonId: visit.prisonId,
@@ -323,12 +323,12 @@ export default function routes(
         try {
           const phoneNumber = visit.visitContact.telephone.replace(/\s/g, '')
 
-          const supportedPrisons = await supportedPrisonsService.getSupportedPrisons(res.locals.user?.username)
+          const supportedPrisons = await services.supportedPrisonsService.getSupportedPrisons(res.locals.user?.username)
           const prisonName = supportedPrisons[visit.prisonId]
 
           const { prisonPhoneNumber } = getPrisonConfiguration(visit.prisonId)
 
-          await notificationsService.sendCancellationSms({
+          await services.notificationsService.sendCancellationSms({
             phoneNumber,
             visitSlot: visit.startTimestamp,
             prisonName,

--- a/server/routes/visitJourney/dateAndTime.test.ts
+++ b/server/routes/visitJourney/dateAndTime.test.ts
@@ -3,21 +3,17 @@ import request from 'supertest'
 import { SessionData } from 'express-session'
 import * as cheerio from 'cheerio'
 import { VisitSessionData, VisitSlot, VisitSlotList } from '../../@types/bapv'
-import VisitSessionsService from '../../services/visitSessionsService'
-import AuditService from '../../services/auditService'
 import { appWithAllRoutes, flashProvider } from '../testutils/appSetup'
 import { Visit } from '../../data/visitSchedulerApiTypes'
-
-jest.mock('../../services/visitSessionsService')
-jest.mock('../../services/auditService')
+import { createMockAuditService, createMockVisitSessionsService } from '../../services/testutils/mocks'
 
 let sessionApp: Express
-const auditService = new AuditService() as jest.Mocked<AuditService>
+
+const auditService = createMockAuditService()
+const visitSessionsService = createMockVisitSessionsService()
 
 let flashData: Record<'errors' | 'formValues', Record<string, string | string[]>[]>
 let visitSessionData: VisitSessionData
-
-const visitSessionsService = new VisitSessionsService(null, null, null, null) as jest.Mocked<VisitSessionsService>
 
 const prisonId = 'HEI'
 
@@ -57,7 +53,7 @@ beforeEach(() => {
   }
 
   sessionApp = appWithAllRoutes({
-    visitSessionsServiceOverride: visitSessionsService,
+    services: { visitSessionsService },
     sessionData: {
       visitSessionData,
     } as SessionData,
@@ -172,7 +168,7 @@ testJourneys.forEach(journey => {
         visitSessionsService.getVisitSessions.mockResolvedValue({ slotsList: {}, whereaboutsAvailable: true })
 
         sessionApp = appWithAllRoutes({
-          visitSessionsServiceOverride: visitSessionsService,
+          services: { visitSessionsService },
           sessionData: {
             visitSessionData,
           } as SessionData,
@@ -198,7 +194,7 @@ testJourneys.forEach(journey => {
         visitSessionsService.getVisitSessions.mockResolvedValue({ slotsList, whereaboutsAvailable: false })
 
         sessionApp = appWithAllRoutes({
-          visitSessionsServiceOverride: visitSessionsService,
+          services: { visitSessionsService },
           sessionData: {
             visitSessionData,
           } as SessionData,
@@ -286,8 +282,7 @@ testJourneys.forEach(journey => {
         visitSessionsService.changeReservedVisit = jest.fn()
 
         sessionApp = appWithAllRoutes({
-          visitSessionsServiceOverride: visitSessionsService,
-          auditServiceOverride: auditService,
+          services: { auditService, visitSessionsService },
           sessionData: {
             slotsList,
             visitSessionData,

--- a/server/routes/visitJourney/selectVisitors.test.ts
+++ b/server/routes/visitJourney/selectVisitors.test.ts
@@ -4,15 +4,14 @@ import { SessionData } from 'express-session'
 import * as cheerio from 'cheerio'
 import { VisitorListItem, VisitSessionData } from '../../@types/bapv'
 import { OffenderRestriction } from '../../data/prisonApiTypes'
-import PrisonerVisitorsService from '../../services/prisonerVisitorsService'
-import PrisonerProfileService from '../../services/prisonerProfileService'
 import { appWithAllRoutes, flashProvider } from '../testutils/appSetup'
 import { Restriction } from '../../data/prisonerContactRegistryApiTypes'
-
-jest.mock('../../services/prisonerProfileService')
-jest.mock('../../services/prisonerVisitorsService')
+import { createMockPrisonerProfileService, createMockPrisonerVisitorsService } from '../../services/testutils/mocks'
 
 let sessionApp: Express
+
+const prisonerVisitorsService = createMockPrisonerVisitorsService()
+const prisonerProfileService = createMockPrisonerProfileService()
 
 let flashData: Record<'errors' | 'formValues', Record<string, string | string[]>[]>
 let visitSessionData: VisitSessionData
@@ -37,17 +36,6 @@ afterEach(() => {
 testJourneys.forEach(journey => {
   describe(`GET ${journey.urlPrefix}/select-visitors`, () => {
     const visitorList: { visitors: VisitorListItem[] } = { visitors: [] }
-
-    const prisonerVisitorsService = new PrisonerVisitorsService(null, null) as jest.Mocked<PrisonerVisitorsService>
-
-    const prisonerProfileService = new PrisonerProfileService(
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-    ) as jest.Mocked<PrisonerProfileService>
 
     let returnData: VisitorListItem[]
     let restrictions: OffenderRestriction[]
@@ -139,8 +127,7 @@ testJourneys.forEach(journey => {
       prisonerProfileService.getRestrictions.mockResolvedValue(restrictions)
 
       sessionApp = appWithAllRoutes({
-        prisonerProfileServiceOverride: prisonerProfileService,
-        prisonerVisitorsServiceOverride: prisonerVisitorsService,
+        services: { prisonerProfileService, prisonerVisitorsService },
         sessionData: {
           visitorList,
           visitSessionData,
@@ -178,8 +165,7 @@ testJourneys.forEach(journey => {
       prisonerProfileService.getRestrictions.mockResolvedValue(restrictions)
 
       sessionApp = appWithAllRoutes({
-        prisonerProfileServiceOverride: prisonerProfileService,
-        prisonerVisitorsServiceOverride: prisonerVisitorsService,
+        services: { prisonerProfileService, prisonerVisitorsService },
         sessionData: {
           visitorList,
           visitSessionData,
@@ -204,8 +190,7 @@ testJourneys.forEach(journey => {
       prisonerProfileService.getRestrictions.mockResolvedValue([])
 
       sessionApp = appWithAllRoutes({
-        prisonerProfileServiceOverride: prisonerProfileService,
-        prisonerVisitorsServiceOverride: prisonerVisitorsService,
+        services: { prisonerProfileService, prisonerVisitorsService },
         sessionData: {
           visitorList,
           visitSessionData,
@@ -432,8 +417,7 @@ testJourneys.forEach(journey => {
 
       it('should display prison specific content for Bristol', () => {
         sessionApp = appWithAllRoutes({
-          prisonerProfileServiceOverride: prisonerProfileService,
-          prisonerVisitorsServiceOverride: prisonerVisitorsService,
+          services: { prisonerProfileService, prisonerVisitorsService },
           sessionData: {
             selectedEstablishment: { prisonId: 'BLI', prisonName: '' },
             visitorList,
@@ -454,8 +438,7 @@ testJourneys.forEach(journey => {
 
       it('should display no prison specific content for a prison that is not configured', () => {
         sessionApp = appWithAllRoutes({
-          prisonerProfileServiceOverride: prisonerProfileService,
-          prisonerVisitorsServiceOverride: prisonerVisitorsService,
+          services: { prisonerProfileService, prisonerVisitorsService },
           sessionData: {
             selectedEstablishment: { prisonId: 'XYZ', prisonName: '' },
             visitorList,

--- a/server/routes/visitJourney/visitType.test.ts
+++ b/server/routes/visitJourney/visitType.test.ts
@@ -3,13 +3,12 @@ import request from 'supertest'
 import { SessionData } from 'express-session'
 import * as cheerio from 'cheerio'
 import { VisitSessionData } from '../../@types/bapv'
-import AuditService from '../../services/auditService'
 import { appWithAllRoutes, flashProvider } from '../testutils/appSetup'
-
-jest.mock('../../services/auditService')
+import { createMockAuditService } from '../../services/testutils/mocks'
 
 let sessionApp: Express
-const auditService = new AuditService() as jest.Mocked<AuditService>
+
+const auditService = createMockAuditService()
 
 let flashData: Record<'errors' | 'formValues', Record<string, string | string[]>[]>
 let visitSessionData: VisitSessionData
@@ -65,7 +64,7 @@ testJourneys.forEach(journey => {
       }
 
       sessionApp = appWithAllRoutes({
-        auditServiceOverride: auditService,
+        services: { auditService },
         sessionData: {
           visitSessionData,
         } as SessionData,

--- a/server/routes/visits.test.ts
+++ b/server/routes/visits.test.ts
@@ -3,35 +3,30 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { format } from 'date-fns'
 import { SessionData } from 'express-session'
-import PrisonerSearchService from '../services/prisonerSearchService'
-import VisitSessionsService from '../services/visitSessionsService'
-import AuditService from '../services/auditService'
 import { appWithAllRoutes, flashProvider } from './testutils/appSetup'
 import { ExtendedVisitInformation, PrisonerDetailsItem, VisitsPageSlot } from '../@types/bapv'
 import TestData from './testutils/testData'
 import { getParsedDateFromQueryString } from '../utils/utils'
-
-jest.mock('../services/prisonerSearchService')
-jest.mock('../services/visitSessionsService')
-jest.mock('../services/auditService')
+import {
+  createMockAuditService,
+  createMockPrisonerSearchService,
+  createMockVisitSessionsService,
+} from '../services/testutils/mocks'
 
 let app: Express
-let flashData: Record<string, string[] | Record<string, string>[]>
 
-const prisonerSearchService = new PrisonerSearchService(null, null) as jest.Mocked<PrisonerSearchService>
-const visitSessionsService = new VisitSessionsService(null, null, null, null) as jest.Mocked<VisitSessionsService>
-const auditService = new AuditService() as jest.Mocked<AuditService>
+const auditService = createMockAuditService()
+const prisonerSearchService = createMockPrisonerSearchService()
+const visitSessionsService = createMockVisitSessionsService()
+
+let flashData: Record<string, string[] | Record<string, string>[]>
 
 beforeEach(() => {
   flashData = { errors: [], formValues: [] }
   flashProvider.mockImplementation(key => {
     return flashData[key]
   })
-  app = appWithAllRoutes({
-    prisonerSearchServiceOverride: prisonerSearchService,
-    visitSessionsServiceOverride: visitSessionsService,
-    auditServiceOverride: auditService,
-  })
+  app = appWithAllRoutes({ services: { auditService, prisonerSearchService, visitSessionsService } })
 })
 
 afterEach(() => {
@@ -251,9 +246,7 @@ describe('GET /visits', () => {
     visitSessionsService.getVisitsByDate.mockResolvedValue(visits)
 
     app = appWithAllRoutes({
-      prisonerSearchServiceOverride: prisonerSearchService,
-      visitSessionsServiceOverride: visitSessionsService,
-      auditServiceOverride: auditService,
+      services: { auditService, prisonerSearchService, visitSessionsService },
       sessionData: { selectedEstablishment: { prisonId: 'XYZ', prisonName: 'XYZ' } } as SessionData,
     })
 

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,0 +1,78 @@
+import { dataAccess } from '../data'
+import AuditService from './auditService'
+import NotificationsService from './notificationsService'
+import PrisonerProfileService from './prisonerProfileService'
+import PrisonerSearchService from './prisonerSearchService'
+import PrisonerVisitorsService from './prisonerVisitorsService'
+import SupportedPrisonsService from './supportedPrisonsService'
+import UserService from './userService'
+import VisitSessionsService from './visitSessionsService'
+
+export const services = () => {
+  const {
+    hmppsAuthClient,
+    notificationsApiClientBuilder,
+    prisonApiClientBuilder,
+    prisonerContactRegistryApiClientBuilder,
+    prisonRegisterApiClientBuilder,
+    prisonerSearchClientBuilder,
+    visitSchedulerApiClientBuilder,
+    whereaboutsApiClientBuilder,
+  } = dataAccess()
+
+  const auditService = new AuditService()
+
+  const notificationsService = new NotificationsService(notificationsApiClientBuilder)
+
+  const supportedPrisonsService = new SupportedPrisonsService(
+    visitSchedulerApiClientBuilder,
+    prisonRegisterApiClientBuilder,
+    hmppsAuthClient,
+  )
+
+  const prisonerProfileService = new PrisonerProfileService(
+    prisonApiClientBuilder,
+    visitSchedulerApiClientBuilder,
+    prisonerContactRegistryApiClientBuilder,
+    prisonerSearchClientBuilder,
+    supportedPrisonsService,
+    hmppsAuthClient,
+  )
+
+  const prisonerSearchService = new PrisonerSearchService(prisonerSearchClientBuilder, hmppsAuthClient)
+
+  const prisonerVisitorsService = new PrisonerVisitorsService(prisonerContactRegistryApiClientBuilder, hmppsAuthClient)
+
+  const userService = new UserService(hmppsAuthClient, prisonApiClientBuilder)
+
+  const visitSessionsService = new VisitSessionsService(
+    prisonerContactRegistryApiClientBuilder,
+    visitSchedulerApiClientBuilder,
+    whereaboutsApiClientBuilder,
+    hmppsAuthClient,
+  )
+
+  return {
+    auditService,
+    notificationsService,
+    prisonerProfileService,
+    prisonerSearchService,
+    prisonerVisitorsService,
+    supportedPrisonsService,
+    userService,
+    visitSessionsService,
+  }
+}
+
+export type Services = ReturnType<typeof services>
+
+export {
+  AuditService,
+  NotificationsService,
+  PrisonerProfileService,
+  PrisonerSearchService,
+  PrisonerVisitorsService,
+  SupportedPrisonsService,
+  UserService,
+  VisitSessionsService,
+}

--- a/server/services/testutils/mocks.ts
+++ b/server/services/testutils/mocks.ts
@@ -1,0 +1,33 @@
+import {
+  AuditService,
+  NotificationsService,
+  PrisonerProfileService,
+  PrisonerSearchService,
+  PrisonerVisitorsService,
+  SupportedPrisonsService,
+  UserService,
+  VisitSessionsService,
+} from '..'
+
+jest.mock('..')
+
+export const createMockAuditService = () => new AuditService(null, null, null, null) as jest.Mocked<AuditService>
+
+export const createMockNotificationsService = () => new NotificationsService(null) as jest.Mocked<NotificationsService>
+
+export const createMockPrisonerProfileService = () =>
+  new PrisonerProfileService(null, null, null, null, null, null) as jest.Mocked<PrisonerProfileService>
+
+export const createMockPrisonerSearchService = () =>
+  new PrisonerSearchService(null, null) as jest.Mocked<PrisonerSearchService>
+
+export const createMockPrisonerVisitorsService = () =>
+  new PrisonerVisitorsService(null, null) as jest.Mocked<PrisonerVisitorsService>
+
+export const createMockSupportedPrisonsService = () =>
+  new SupportedPrisonsService(null, null, null) as jest.Mocked<SupportedPrisonsService>
+
+export const createMockUserService = () => new UserService(null, null) as jest.Mocked<UserService>
+
+export const createMockVisitSessionsService = () =>
+  new VisitSessionsService(null, null, null, null) as jest.Mocked<VisitSessionsService>


### PR DESCRIPTION
Follow on from #518, and part of implementing changes in https://github.com/ministryofjustice/hmpps-template-typescript/pull/106.

This change rewires the app to use a `Services` container so dependencies can be passed around more easily and without the need for so much duplication and disruption when services are changed. A lot of changes here, but basically all repetition of the same change to main and corresponding test file.
