### PR TITLE
VB-1430 Simplify mocks set up in tests

### DIFF
--- a/server/data/testutils/mocks.ts
+++ b/server/data/testutils/mocks.ts
@@ -1,0 +1,32 @@
+import {
+  HmppsAuthClient,
+  NotificationsApiClient,
+  PrisonApiClient,
+  PrisonerContactRegistryApiClient,
+  PrisonerSearchClient,
+  PrisonRegisterApiClient,
+  VisitSchedulerApiClient,
+  WhereaboutsApiClient,
+} from '..'
+
+jest.mock('..')
+
+export const createMockHmppsAuthClient = () => new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+
+export const createMockNotificationsApiClient = () =>
+  new NotificationsApiClient() as jest.Mocked<NotificationsApiClient>
+
+export const createMockPrisonApiClient = () => new PrisonApiClient(null) as jest.Mocked<PrisonApiClient>
+
+export const createMockPrisonerContactRegistryApiClient = () =>
+  new PrisonerContactRegistryApiClient(null) as jest.Mocked<PrisonerContactRegistryApiClient>
+
+export const createMockPrisonerSearchClient = () => new PrisonerSearchClient(null) as jest.Mocked<PrisonerSearchClient>
+
+export const createMockPrisonRegisterApiClient = () =>
+  new PrisonRegisterApiClient(null) as jest.Mocked<PrisonRegisterApiClient>
+
+export const createMockVisitSchedulerApiClient = () =>
+  new VisitSchedulerApiClient(null) as jest.Mocked<VisitSchedulerApiClient>
+
+export const createMockWhereaboutsApiClient = () => new WhereaboutsApiClient(null) as jest.Mocked<WhereaboutsApiClient>

--- a/server/middleware/populateSelectedEstablishment.test.ts
+++ b/server/middleware/populateSelectedEstablishment.test.ts
@@ -1,21 +1,12 @@
 import { Request, Response } from 'express'
 import { Cookie } from 'express-session'
 import { Prison } from '../@types/bapv'
-import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
+import type { User } from '../data/hmppsAuthClient'
 import TestData from '../routes/testutils/testData'
-import SupportedPrisonsService from '../services/supportedPrisonsService'
+import { createMockSupportedPrisonsService } from '../services/testutils/mocks'
 import populateSelectedEstablishment from './populateSelectedEstablishment'
 
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../services/supportedPrisonsService')
-
-const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-
-const supportedPrisonsService = new SupportedPrisonsService(
-  null,
-  null,
-  hmppsAuthClient,
-) as jest.Mocked<SupportedPrisonsService>
+const supportedPrisonsService = createMockSupportedPrisonsService()
 
 const supportedPrisons = TestData.supportedPrisons()
 supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)

--- a/server/services/notificationsService.test.ts
+++ b/server/services/notificationsService.test.ts
@@ -1,18 +1,15 @@
 import { VisitSlot } from '../@types/bapv'
-import { NotificationsApiClient } from '../data'
+import { createMockNotificationsApiClient } from '../data/testutils/mocks'
 import NotificationsService from './notificationsService'
 
-jest.mock('../data/notificationsApiClient')
-
-const notificationsApiClient = new NotificationsApiClient() as jest.Mocked<NotificationsApiClient>
-
 describe('Notifications service', () => {
-  let notificationsApiClientBuilder: () => NotificationsApiClient
+  const notificationsApiClient = createMockNotificationsApiClient()
+  const NotificationsApiClientFactory = jest.fn()
   let notificationsService: NotificationsService
 
   beforeEach(() => {
-    notificationsApiClientBuilder = jest.fn().mockReturnValue(notificationsApiClient)
-    notificationsService = new NotificationsService(notificationsApiClientBuilder)
+    NotificationsApiClientFactory.mockReturnValue(notificationsApiClient)
+    notificationsService = new NotificationsService(NotificationsApiClientFactory)
   })
 
   afterEach(() => {

--- a/server/services/prisonerProfileService.test.ts
+++ b/server/services/prisonerProfileService.test.ts
@@ -4,34 +4,25 @@ import { Alert, PagePrisonerBookingSummary, VisitBalances, OffenderRestrictions 
 import { PrisonerAlertItem, PrisonerProfile } from '../@types/bapv'
 import { PageVisitDto } from '../data/visitSchedulerApiTypes'
 import { Contact } from '../data/prisonerContactRegistryApiTypes'
-import SupportedPrisonsService from './supportedPrisonsService'
 import TestData from '../routes/testutils/testData'
 import {
-  HmppsAuthClient,
-  PrisonApiClient,
-  PrisonerContactRegistryApiClient,
-  PrisonerSearchClient,
-  VisitSchedulerApiClient,
-} from '../data'
-
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/prisonApiClient')
-jest.mock('../data/prisonerContactRegistryApiClient')
-jest.mock('../data/prisonerSearchClient')
-jest.mock('../data/visitSchedulerApiClient')
-jest.mock('./supportedPrisonsService')
+  createMockHmppsAuthClient,
+  createMockPrisonApiClient,
+  createMockPrisonerContactRegistryApiClient,
+  createMockPrisonerSearchClient,
+  createMockVisitSchedulerApiClient,
+} from '../data/testutils/mocks'
+import { createMockSupportedPrisonsService } from './testutils/mocks'
 
 const token = 'some token'
 
 describe('Prisoner profile service', () => {
-  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-  const prisonApiClient = new PrisonApiClient(null) as jest.Mocked<PrisonApiClient>
-  const prisonerContactRegistryApiClient = new PrisonerContactRegistryApiClient(
-    null,
-  ) as jest.Mocked<PrisonerContactRegistryApiClient>
-  const prisonerSearchClient = new PrisonerSearchClient(null) as jest.Mocked<PrisonerSearchClient>
-  const visitSchedulerApiClient = new VisitSchedulerApiClient(null) as jest.Mocked<VisitSchedulerApiClient>
-  const supportedPrisonsService = new SupportedPrisonsService(null, null, null) as jest.Mocked<SupportedPrisonsService>
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const prisonApiClient = createMockPrisonApiClient()
+  const prisonerContactRegistryApiClient = createMockPrisonerContactRegistryApiClient()
+  const prisonerSearchClient = createMockPrisonerSearchClient()
+  const visitSchedulerApiClient = createMockVisitSchedulerApiClient()
+  const supportedPrisonsService = createMockSupportedPrisonsService()
 
   let prisonerProfileService: PrisonerProfileService
 

--- a/server/services/prisonerSearchService.test.ts
+++ b/server/services/prisonerSearchService.test.ts
@@ -1,15 +1,12 @@
 import PrisonerSearchService from './prisonerSearchService'
 import TestData from '../routes/testutils/testData'
-import { HmppsAuthClient, PrisonerSearchClient } from '../data'
-
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/prisonerSearchClient')
+import { createMockHmppsAuthClient, createMockPrisonerSearchClient } from '../data/testutils/mocks'
 
 const token = 'some token'
 
 describe('Prisoner search service', () => {
-  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-  const prisonerSearchClient = new PrisonerSearchClient(null) as jest.Mocked<PrisonerSearchClient>
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const prisonerSearchClient = createMockPrisonerSearchClient()
 
   let prisonerSearchService: PrisonerSearchService
 

--- a/server/services/prisonerVisitorsService.test.ts
+++ b/server/services/prisonerVisitorsService.test.ts
@@ -1,18 +1,13 @@
 import PrisonerVisitorsService from './prisonerVisitorsService'
 import { Contact } from '../data/prisonerContactRegistryApiTypes'
 import { VisitorListItem } from '../@types/bapv'
-import { HmppsAuthClient, PrisonerContactRegistryApiClient } from '../data'
-
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/prisonerContactRegistryApiClient')
+import { createMockHmppsAuthClient, createMockPrisonerContactRegistryApiClient } from '../data/testutils/mocks'
 
 const token = 'some token'
 
 describe('Prisoner visitor service', () => {
-  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-  const prisonerContactRegistryApiClient = new PrisonerContactRegistryApiClient(
-    null,
-  ) as jest.Mocked<PrisonerContactRegistryApiClient>
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const prisonerContactRegistryApiClient = createMockPrisonerContactRegistryApiClient()
   let prisonerVisitorsService: PrisonerVisitorsService
 
   const PrisonerContactRegistryApiClientFactory = jest.fn()

--- a/server/services/supportedPrisonsService.test.ts
+++ b/server/services/supportedPrisonsService.test.ts
@@ -1,18 +1,18 @@
 import SupportedPrisonsService from './supportedPrisonsService'
 import TestData from '../routes/testutils/testData'
 import { PrisonDto } from '../data/prisonRegisterApiTypes'
-import { HmppsAuthClient, PrisonRegisterApiClient, VisitSchedulerApiClient } from '../data'
-
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/visitSchedulerApiClient')
-jest.mock('../data/prisonRegisterApiClient')
+import {
+  createMockHmppsAuthClient,
+  createMockPrisonRegisterApiClient,
+  createMockVisitSchedulerApiClient,
+} from '../data/testutils/mocks'
 
 const token = 'some token'
 
 describe('Supported prisons service', () => {
-  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-  const prisonRegisterApiClient = new PrisonRegisterApiClient(null) as jest.Mocked<PrisonRegisterApiClient>
-  const visitSchedulerApiClient = new VisitSchedulerApiClient(null) as jest.Mocked<VisitSchedulerApiClient>
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const prisonRegisterApiClient = createMockPrisonRegisterApiClient()
+  const visitSchedulerApiClient = createMockVisitSchedulerApiClient()
 
   let supportedPrisonsService: SupportedPrisonsService
 

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,24 +1,19 @@
 import UserService from './userService'
-import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
-import PrisonApiClient from '../data/prisonApiClient'
 import TestData from '../routes/testutils/testData'
-
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/prisonApiClient')
+import { createMockHmppsAuthClient, createMockPrisonApiClient } from '../data/testutils/mocks'
+import type { User } from '../data/hmppsAuthClient'
 
 const token = 'some token'
 
 describe('User service', () => {
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
-  let prisonApiClient: jest.Mocked<PrisonApiClient>
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const prisonApiClient = createMockPrisonApiClient()
   let userService: UserService
 
   const PrisonApiClientFactory = jest.fn()
 
   describe('getUser', () => {
     beforeEach(() => {
-      hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-      prisonApiClient = new PrisonApiClient(null) as jest.Mocked<PrisonApiClient>
       PrisonApiClientFactory.mockReturnValue(prisonApiClient)
       userService = new UserService(hmppsAuthClient, PrisonApiClientFactory)
       hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -13,26 +13,19 @@ import { ScheduledEvent } from '../data/whereaboutsApiTypes'
 import TestData from '../routes/testutils/testData'
 import VisitSessionsService from './visitSessionsService'
 import {
-  HmppsAuthClient,
-  PrisonerContactRegistryApiClient,
-  VisitSchedulerApiClient,
-  WhereaboutsApiClient,
-} from '../data'
-
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/prisonerContactRegistryApiClient')
-jest.mock('../data/visitSchedulerApiClient')
-jest.mock('../data/whereaboutsApiClient')
+  createMockHmppsAuthClient,
+  createMockPrisonerContactRegistryApiClient,
+  createMockVisitSchedulerApiClient,
+  createMockWhereaboutsApiClient,
+} from '../data/testutils/mocks'
 
 const token = 'some token'
 
 describe('Visit sessions service', () => {
-  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-  const prisonerContactRegistryApiClient = new PrisonerContactRegistryApiClient(
-    null,
-  ) as jest.Mocked<PrisonerContactRegistryApiClient>
-  const visitSchedulerApiClient = new VisitSchedulerApiClient(null) as jest.Mocked<VisitSchedulerApiClient>
-  const whereaboutsApiClient = new WhereaboutsApiClient(null) as jest.Mocked<WhereaboutsApiClient>
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const prisonerContactRegistryApiClient = createMockPrisonerContactRegistryApiClient()
+  const visitSchedulerApiClient = createMockVisitSchedulerApiClient()
+  const whereaboutsApiClient = createMockWhereaboutsApiClient()
 
   let visitSessionsService: VisitSessionsService
 


### PR DESCRIPTION
Add helper functions to create mock API clients to simplify and avoid repetition in test set up.