### PR TITLE
VB-2004 Add logging to debug 'undefined' error for additional support

### DIFF
--- a/server/data/prisonerContactRegistryApiClient.ts
+++ b/server/data/prisonerContactRegistryApiClient.ts
@@ -24,7 +24,7 @@ class PrisonerContactRegistryApiClient {
         }).toString(),
       })
     } catch (e) {
-      if (e.data.status !== 404) {
+      if (e.status !== 404) {
         throw e
       }
     }

--- a/server/routes/visitJourney/additionalSupport.ts
+++ b/server/routes/visitJourney/additionalSupport.ts
@@ -63,7 +63,7 @@ export default class AdditionalSupport {
   validate(): ValidationChain[] {
     return [
       body('additionalSupportRequired').custom((value: string) => {
-        if (!/^yes|no$/.test(value)) {
+        if (!/^(yes|no)$/.test(value)) {
           throw new Error('No answer selected')
         }
         return true

--- a/server/routes/visitJourney/additionalSupport.ts
+++ b/server/routes/visitJourney/additionalSupport.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express'
 import { body, ValidationChain, validationResult } from 'express-validator'
+import logger from '../../../logger'
 import { SupportType, VisitorSupport } from '../../data/visitSchedulerApiTypes'
 import VisitSessionsService from '../../services/visitSessionsService'
 import { getFlashFormValues } from '../visitorUtils'
@@ -55,6 +56,15 @@ export default class AdditionalSupport {
             }
             return supportItem
           })
+
+    // Log info to debug VB-2004
+    const debugInfo = {
+      additionalSupportRequired: req.body.additionalSupportRequired,
+      additionalSupport: req.body.additionalSupport,
+      visitorSupport: visitSessionData.visitorSupport,
+      availableSupportTypes: req.session.availableSupportTypes?.length,
+    }
+    logger.info(`choose support visitorSupport debug: ${JSON.stringify(debugInfo)}`)
 
     const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
     return res.redirect(`${urlPrefix}/select-main-contact`)

--- a/server/routes/visitJourney/checkYourBooking.ts
+++ b/server/routes/visitJourney/checkYourBooking.ts
@@ -20,6 +20,13 @@ export default class CheckYourBooking {
     const { visitSessionData } = req.session
     const { offenderNo } = visitSessionData.prisoner
 
+    // Log info to debug VB-2004
+    const debugInfo = {
+      visitorSupport: visitSessionData.visitorSupport,
+      availableSupportTypes: req.session.availableSupportTypes?.length,
+    }
+    logger.info(`check booking visitorSupport debug: ${JSON.stringify(debugInfo)}`)
+
     const additionalSupport = getSupportTypeDescriptions(
       req.session.availableSupportTypes,
       visitSessionData.visitorSupport,


### PR DESCRIPTION
We're getting occasional errors relating to additional support options. They appear on the 'check your booking' page, e.g.
```
TypeError: Cannot read properties of undefined (reading 'map')
    at getSupportTypeDescriptions (/app/dist/server/routes/visitorUtils.js:30:27)
    at CheckYourBooking.get (/app/dist/server/routes/visitJourney/checkYourBooking.js:21:81)
```

This PR adds some logging to try and debug how this is happening. Expected kind of log messages:
```
[Node] 08:41:16.380Z  INFO Book A Prison Visit Staff Ui: choose support visitorSupport debug: {"additionalSupportRequired":"yes","additionalSupport":["WHEELCHAIR"],"visitorSupport":[{"type":"WHEELCHAIR"}],"availableSupportTypes":5}

[Node] 08:41:46.411Z  INFO Book A Prison Visit Staff Ui: check booking visitorSupport debug: {"visitorSupport":[{"type":"WHEELCHAIR"}],"availableSupportTypes":5}

```

Also includes couple of minor fixes:
* tighten a RegExp
* fix catching API error