### PR TITLE
VB-2004 Increase web session timeout to 120 mins

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -47,7 +47,7 @@ export default {
   },
   session: {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),
-    expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 20)),
+    expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)),
   },
   dpsHome: get('DPS_URL', 'https://digital-dev.prison.service.justice.gov.uk/', requiredInProduction),
   apis: {


### PR DESCRIPTION
Set web session timeout to 120 mins to reflect template default and be more in line with other apps. Hopefully will reduce number of errors relating to users having expired session.