### PR TITLE
VB-1927 Don't show user name if NOT_KNOWN

### DIFF
--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -134,6 +134,8 @@ describe('/visit/:reference', () => {
 
   describe('GET /visit/:reference', () => {
     it('should render full booking summary page with prisoner, visit and visitor details, with default back link', () => {
+      visitHistoryDetails.createdBy = 'NOT_KNOWN' // test case for old / migrated data
+
       return request(app)
         .get('/visit/ab-cd-ef-gh')
         .expect(200)
@@ -172,9 +174,7 @@ describe('/visit/:reference', () => {
           expect($('[data-test="visit-comment"]').eq(0).text()).toBe('Example of a visit comment')
           expect($('[data-test="visitor-concern"]').eq(0).text()).toBe('Example of a visitor concern')
           expect($('[data-test="additional-support"]').text()).toBe('Wheelchair ramp, custom request')
-          expect($('[data-test="visit-booked"]').text().replace(/\s+/g, ' ')).toBe(
-            'Saturday 1 January 2022 at 9am by User One',
-          )
+          expect($('[data-test="visit-booked"]').text().trim()).toBe('Saturday 1 January 2022 at 9am')
           expect($('[data-test="visit-updated"]').text().replace(/\s+/g, ' ')).toBe(
             'Saturday 1 January 2022 at 10am by User Two',
           )

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -202,14 +202,14 @@
         <li>
           <strong>Visit booked</strong>
           <span data-test="visit-booked">{{ visitHistoryDetails.createdDateAndTime | formatDate('EEEE d MMMM yyyy') }} at {{ visitHistoryDetails.createdDateAndTime | formatTime }}
-            {{ 'by ' + visitHistoryDetails.createdBy if visitHistoryDetails.createdBy }}</span>
+            {{ 'by ' + visitHistoryDetails.createdBy if (visitHistoryDetails.createdBy and visitHistoryDetails.createdBy != 'NOT_KNOWN') }}</span>
         </li>
 
         {% if visitHistoryDetails.updatedDateAndTime %}
           <li>
             <strong>Visit updated</strong>
             <span data-test="visit-updated">{{ visitHistoryDetails.updatedDateAndTime | formatDate('EEEE d MMMM yyyy') }} at {{ visitHistoryDetails.updatedDateAndTime | formatTime }}
-              {{ 'by ' + visitHistoryDetails.updatedBy if visitHistoryDetails.updatedBy }}</span>
+              {{ 'by ' + visitHistoryDetails.updatedBy if (visitHistoryDetails.updatedBy and visitHistoryDetails.updatedBy != 'NOT_KNOWN') }}</span>
           </li>
         {% endif %}
 
@@ -217,7 +217,7 @@
           <li>
             <strong>Visit cancelled</strong>
             <span data-test="visit-cancelled">{{ visitHistoryDetails.cancelledDateAndTime | formatDate('EEEE d MMMM yyyy') }} at {{ visitHistoryDetails.cancelledDateAndTime | formatTime }}
-              {{ 'by ' + visitHistoryDetails.cancelledBy if visitHistoryDetails.cancelledBy }}</span>
+              {{ 'by ' + visitHistoryDetails.cancelledBy if (visitHistoryDetails.cancelledBy and visitHistoryDetails.cancelledBy != 'NOT_KNOWN') }}</span>
           </li>
         {% endif %}
 


### PR DESCRIPTION
If details of user who booked / updated / created is not available (e.g. old data) then don't display anything. The API returns `NOT_KNOWN` in these cases, so this change catches this value.