### PR TITLE
VB-2073 Fix some warnings from CodeQL scan

### DIFF
--- a/server/routes/changeEstablishment.ts
+++ b/server/routes/changeEstablishment.ts
@@ -52,7 +52,7 @@ export default function routes({ auditService, supportedPrisonsService, userServ
     const errors = validationResult(req)
     if (!errors.isEmpty()) {
       req.flash('errors', errors.array() as [])
-      return res.redirect(req.originalUrl)
+      return res.redirect('/change-establishment')
     }
 
     clearSession(req)

--- a/server/routes/prisoner.ts
+++ b/server/routes/prisoner.ts
@@ -57,7 +57,7 @@ export default function routes({
 
       if (!errors.isEmpty()) {
         req.flash('errors', errors.array() as [])
-        return res.redirect(req.originalUrl)
+        return res.redirect(`/prisoner/${offenderNo}`)
       }
 
       await auditService.overrodeZeroVO({

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -291,14 +291,14 @@ export default function routes({
       }
 
       const errors = validationResult(req)
+      const reference = getVisitReference(req)
 
       if (!errors.isEmpty()) {
         req.flash('errors', errors.array() as [])
         req.flash('formValues', req.body)
-        return res.redirect(req.originalUrl)
+        return res.redirect(`/visit/${reference}/cancel`)
       }
 
-      const reference = getVisitReference(req)
       const outcome: OutcomeDto = {
         outcomeStatus: req.body.cancel,
         text: req.body[reasonFieldName],

--- a/server/routes/visitJourney/additionalSupport.ts
+++ b/server/routes/visitJourney/additionalSupport.ts
@@ -39,10 +39,12 @@ export default class AdditionalSupport {
     const { visitSessionData } = req.session
     const errors = validationResult(req)
 
+    const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
+
     if (!errors.isEmpty()) {
       req.flash('errors', errors.array() as [])
       req.flash('formValues', req.body)
-      return res.redirect(req.originalUrl)
+      return res.redirect(`${urlPrefix}/additional-support`)
     }
 
     visitSessionData.visitorSupport =
@@ -56,7 +58,6 @@ export default class AdditionalSupport {
             return supportItem
           })
 
-    const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
     return res.redirect(`${urlPrefix}/select-main-contact`)
   }
 

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -99,10 +99,12 @@ export default class DateAndTime {
     const { visitSessionData } = req.session
     const errors = validationResult(req)
 
+    const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
+
     if (!errors.isEmpty()) {
       req.flash('errors', errors.array() as [])
       req.flash('formValues', req.body)
-      return res.redirect(req.originalUrl)
+      return res.redirect(`${urlPrefix}/select-date-and-time`)
     }
 
     visitSessionData.visitSlot = getSelectedSlot(req.session.slotsList, req.body['visit-date-and-time'])
@@ -145,7 +147,6 @@ export default class DateAndTime {
       operationId: res.locals.appInsightsOperationId,
     })
 
-    const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
     return res.redirect(`${urlPrefix}/additional-support`)
   }
 

--- a/server/routes/visitJourney/mainContact.ts
+++ b/server/routes/visitJourney/mainContact.ts
@@ -36,10 +36,12 @@ export default class MainContact {
     const { visitSessionData } = req.session
     const errors = validationResult(req)
 
+    const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
+
     if (!errors.isEmpty()) {
       req.flash('errors', errors.array() as [])
       req.flash('formValues', req.body)
-      return res.redirect(req.originalUrl)
+      return res.redirect(`${urlPrefix}/select-main-contact`)
     }
 
     const selectedContact = req.session.visitorList.visitors.find(
@@ -52,7 +54,6 @@ export default class MainContact {
       contactName: selectedContact === undefined ? req.body.someoneElseName : undefined,
     }
 
-    const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
     return res.redirect(`${urlPrefix}/check-your-booking`)
   }
 

--- a/server/routes/visitJourney/selectVisitors.ts
+++ b/server/routes/visitJourney/selectVisitors.ts
@@ -54,10 +54,12 @@ export default class SelectVisitors {
     const { visitSessionData } = req.session
     const errors = validationResult(req)
 
+    const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
+
     if (!errors.isEmpty()) {
       req.flash('errors', errors.array() as [])
       req.flash('formValues', req.body)
-      return res.redirect(req.originalUrl)
+      return res.redirect(`${urlPrefix}/select-visitors`)
     }
 
     const selectedIds = [].concat(req.body.visitors)
@@ -88,8 +90,6 @@ export default class SelectVisitors {
     const closedVisitPrisoner = visitSessionData.prisoner.restrictions.some(
       restriction => restriction.restrictionType === 'CLOSED',
     )
-
-    const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
 
     return !closedVisitVisitors && closedVisitPrisoner
       ? res.redirect(`${urlPrefix}/visit-type`)

--- a/server/routes/visitJourney/visitType.ts
+++ b/server/routes/visitJourney/visitType.ts
@@ -26,9 +26,11 @@ export default class VisitType {
     const { visitSessionData } = req.session
     const errors = validationResult(req)
 
+    const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
+
     if (!errors.isEmpty()) {
       req.flash('errors', errors.array() as [])
-      return res.redirect(req.originalUrl)
+      return res.redirect(`${urlPrefix}/visit-type`)
     }
 
     visitSessionData.visitRestriction = req.body.visitType
@@ -41,7 +43,6 @@ export default class VisitType {
       operationId: res.locals.appInsightsOperationId,
     })
 
-    const urlPrefix = getUrlPrefix(isUpdate, visitSessionData.visitReference)
     return res.redirect(`${urlPrefix}/select-date-and-time`)
   }
 


### PR DESCRIPTION
Address issues from CodeQL scan warnings of `Untrusted URL redirection` because of using `req.originalUrl` as the basis of redirects. E.g. https://github.com/ministryofjustice/book-a-prison-visit-staff-ui/security/code-scanning/6