### PR TITLE
VB-2081 Update types and remove workaround for enums as strings

### DIFF
--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -137,13 +137,15 @@ export interface components {
       /**
        * @description Visit Type
        * @example SOCIAL
+       * @enum {string}
        */
-      visitType: string
+      visitType: 'SOCIAL'
       /**
        * @description Visit Restriction
        * @example OPEN
+       * @enum {string}
        */
-      visitRestriction: string
+      visitRestriction: 'OPEN' | 'CLOSED' | 'UNKNOWN'
       /**
        * Format: date-time
        * @description The date and time of the visit
@@ -226,23 +228,46 @@ export interface components {
       /**
        * @description Visit Type
        * @example SOCIAL
+       * @enum {string}
        */
-      visitType: string
+      visitType: 'SOCIAL'
       /**
        * @description Visit Status
        * @example RESERVED
+       * @enum {string}
        */
-      visitStatus: string
+      visitStatus: 'RESERVED' | 'CHANGING' | 'BOOKED' | 'CANCELLED'
       /**
        * @description Outcome Status
        * @example VISITOR_CANCELLED
+       * @enum {string}
        */
-      outcomeStatus?: string
+      outcomeStatus?:
+        | 'ADMINISTRATIVE_CANCELLATION'
+        | 'ADMINISTRATIVE_ERROR'
+        | 'BATCH_CANCELLATION'
+        | 'CANCELLATION'
+        | 'COMPLETED_NORMALLY'
+        | 'ESTABLISHMENT_CANCELLED'
+        | 'NOT_RECORDED'
+        | 'NO_VISITING_ORDER'
+        | 'PRISONER_CANCELLED'
+        | 'PRISONER_COMPLETED_EARLY'
+        | 'PRISONER_REFUSED_TO_ATTEND'
+        | 'TERMINATED_BY_STAFF'
+        | 'VISITOR_CANCELLED'
+        | 'VISITOR_COMPLETED_EARLY'
+        | 'VISITOR_DECLINED_ENTRY'
+        | 'VISITOR_DID_NOT_ARRIVE'
+        | 'VISITOR_FAILED_SECURITY_CHECKS'
+        | 'VISIT_ORDER_CANCELLED'
+        | 'SUPERSEDED_CANCELLATION'
       /**
        * @description Visit Restriction
        * @example OPEN
+       * @enum {string}
        */
-      visitRestriction: string
+      visitRestriction: 'OPEN' | 'CLOSED' | 'UNKNOWN'
       /**
        * Format: date-time
        * @description The date and time of the visit
@@ -291,8 +316,9 @@ export interface components {
       /**
        * @description Note type
        * @example VISITOR_CONCERN
+       * @enum {string}
        */
-      type: string
+      type: 'VISITOR_CONCERN' | 'VISIT_OUTCOMES' | 'VISIT_COMMENT' | 'STATUS_CHANGED_REASON'
       /**
        * @description Note text
        * @example Visitor is concerned that his mother in-law is coming!
@@ -307,8 +333,28 @@ export interface components {
       /**
        * @description Outcome Status
        * @example VISITOR_CANCELLED
+       * @enum {string}
        */
-      outcomeStatus: string
+      outcomeStatus:
+        | 'ADMINISTRATIVE_CANCELLATION'
+        | 'ADMINISTRATIVE_ERROR'
+        | 'BATCH_CANCELLATION'
+        | 'CANCELLATION'
+        | 'COMPLETED_NORMALLY'
+        | 'ESTABLISHMENT_CANCELLED'
+        | 'NOT_RECORDED'
+        | 'NO_VISITING_ORDER'
+        | 'PRISONER_CANCELLED'
+        | 'PRISONER_COMPLETED_EARLY'
+        | 'PRISONER_REFUSED_TO_ATTEND'
+        | 'TERMINATED_BY_STAFF'
+        | 'VISITOR_CANCELLED'
+        | 'VISITOR_COMPLETED_EARLY'
+        | 'VISITOR_DECLINED_ENTRY'
+        | 'VISITOR_DID_NOT_ARRIVE'
+        | 'VISITOR_FAILED_SECURITY_CHECKS'
+        | 'VISIT_ORDER_CANCELLED'
+        | 'SUPERSEDED_CANCELLATION'
       /**
        * @description Outcome text
        * @example Because he got covid
@@ -319,8 +365,9 @@ export interface components {
       /**
        * @description Visit Restriction
        * @example OPEN
+       * @enum {string}
        */
-      visitRestriction?: string
+      visitRestriction?: 'OPEN' | 'CLOSED' | 'UNKNOWN'
       /**
        * Format: date-time
        * @description The date and time of the visit
@@ -398,9 +445,9 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
-      last?: boolean
       pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
@@ -408,10 +455,10 @@ export interface components {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject']
-      /** Format: int32 */
-      pageSize?: number
       paged?: boolean
       unpaged?: boolean
+      /** Format: int32 */
+      pageSize?: number
       /** Format: int32 */
       pageNumber?: number
     }
@@ -491,7 +538,7 @@ export interface components {
        */
       endTimestamp: string
       /** @description Session conflicts */
-      sessionConflicts?: string[]
+      sessionConflicts?: ('NON_ASSOCIATION' | 'DOUBLE_BOOKED')[]
     }
     /** @description Session Capacity */
     SessionCapacityDto: {
@@ -534,10 +581,16 @@ export interface components {
        */
       prisonerLocationGroupNames?: string[]
       /**
+       * @description prisoner category groups
+       * @example Category A Prisoners
+       */
+      prisonerCategoryGroupNames?: string[]
+      /**
        * @description The session template frequency
        * @example BI_WEEKLY
+       * @enum {string}
        */
-      sessionTemplateFrequency: string
+      sessionTemplateFrequency: 'BI_WEEKLY' | 'WEEKLY' | 'ONE_OFF'
       /**
        * Format: date
        * @description The end date of sessionTemplate

--- a/server/@types/prison-api.d.ts
+++ b/server/@types/prison-api.d.ts
@@ -890,13 +890,6 @@ export interface paths {
      */
     get: operations['getMyLocations']
   }
-  '/api/users/me/caseNoteTypes': {
-    /**
-     * List of all case note types (with sub-types) accessible to current user (and based on working caseload).
-     * @description List of all case note types (with sub-types) accessible to current user (and based on working caseload).
-     */
-    get: operations['getMyCaseNoteTypes']
-  }
   '/api/users/me/caseLoads': {
     /**
      * List of caseloads accessible to current user.
@@ -1005,20 +998,6 @@ export interface paths {
      * @description List of reference codes for reference domain ordered by code ascending. The list is an un-paged flat list<p>This endpoint uses the REPLICA database.</p>
      */
     get: operations['getReferenceCodesByDomain_1']
-  }
-  '/api/reference-domains/caseNoteTypes': {
-    /**
-     * List of all used case note types (with sub-types).
-     * @description List of all used case note types (with sub-types).<p>This endpoint uses the REPLICA database.</p>
-     */
-    get: operations['getCaseNoteTypes']
-  }
-  '/api/reference-domains/caseNoteSources': {
-    /**
-     * List of case note source codes.
-     * @description List of case note source codes.<p>This endpoint uses the REPLICA database.</p>
-     */
-    get: operations['getCaseNoteSources']
   }
   '/api/reference-domains/alertTypes': {
     /**
@@ -1149,6 +1128,9 @@ export interface paths {
      * For example Bristol has wings, spurs and landings, but this endpoint will only return wings and landings as spurs are not mapped in NOMIS.
      * Another example is Moorland where 5-1-B-014 in NOMIS is Wing 5, Landing 1, Cell B and Cell 014, whereas in reality it should be Houseblock 5, Spur 1, Wing B and Cell 014 instead.
      * This endpoint will therefore also return different information from Whereabouts API as that service re-maps the NOMIS layout to include spurs etc.</p>
+     * <p>If the current location is temporary (reception, court, tap, cell swap or early conditional licence) then the previous permanent location is also returned, provided
+     * that the location is at the same prison and they haven't moved to a different prison in the meantime.</p>
+     * <p>Requires a relationship (via caseload) with the prisoner or VIEW_PRISONER_DATA role.</p>
      */
     get: operations['getHousingLocation']
   }
@@ -1169,20 +1151,6 @@ export interface paths {
      * @description Active Contacts including restrictions, using latest offender booking  and including inactive contacts by default
      */
     get: operations['getOffenderContacts']
-  }
-  '/api/offenders/{offenderNo}/case-notes/{caseNoteId}': {
-    /**
-     * Offender case note detail.
-     * @description Retrieve an single offender case note
-     */
-    get: operations['getOffenderCaseNote']
-  }
-  '/api/offenders/{offenderNo}/case-notes/v2': {
-    /**
-     * Offender case notes
-     * @description Retrieve an offenders case notes for latest booking<p>This endpoint uses the REPLICA database.</p>
-     */
-    get: operations['getOffenderCaseNotes']
   }
   '/api/offenders/{offenderNo}/bookings/latest/alerts': {
     /**
@@ -1741,16 +1709,9 @@ export interface paths {
   '/api/bookings/{bookingId}/cell-history': {
     /**
      * Gets cell history for an offender booking
-     * @description Default sort order is by assignment date descending<p>This endpoint uses the REPLICA database.</p>
+     * @description Default sort order is by assignment date descending.  Requires a relationship (via caseload) with the prisoner or VIEW_PRISONER_DATA role.<p>This endpoint uses the REPLICA database.</p>
      */
     get: operations['getBedAssignmentsHistory_1']
-  }
-  '/api/bookings/{bookingId}/caseNotes': {
-    /**
-     * Offender case notes.
-     * @description Offender case notes.<p>This endpoint uses the REPLICA database.</p>
-     */
-    get: operations['getOffenderCaseNotes_1']
   }
   '/api/bookings/{bookingId}/caseNotes/{type}/{subType}/count': {
     /**
@@ -1758,13 +1719,6 @@ export interface paths {
      * @description Count of case notes<p>This endpoint uses the REPLICA database.</p>
      */
     get: operations['getCaseNoteCount']
-  }
-  '/api/bookings/{bookingId}/caseNotes/{caseNoteId}': {
-    /**
-     * Offender case note detail.
-     * @description Offender case note detail.
-     */
-    get: operations['getOffenderCaseNote_1']
   }
   '/api/bookings/{bookingId}/balances': {
     /**
@@ -7490,10 +7444,10 @@ export interface components {
       establishmentName: string
     }
     PagePrisonerInformation: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['PrisonerInformation'][]
@@ -7501,9 +7455,9 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       last?: boolean
       empty?: boolean
     }
@@ -7513,10 +7467,10 @@ export interface components {
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
       pageSize?: number
-      unpaged?: boolean
       paged?: boolean
       /** Format: int32 */
       pageNumber?: number
+      unpaged?: boolean
     }
     SortObject: {
       empty?: boolean
@@ -8179,6 +8133,7 @@ export interface components {
        */
       recordStaffId?: number
     }
+    /** @description Previous permanent housing levels at the same prison without moving to a different prison inbetween */
     HousingLocation: {
       /**
        * Format: int32
@@ -8204,7 +8159,10 @@ export interface components {
       description?: string
     }
     OffenderLocation: {
+      /** @description Current housing levels or null if not currently in prison */
       levels?: components['schemas']['HousingLocation'][]
+      /** @description Previous permanent housing levels at the same prison without moving to a different prison inbetween */
+      lastPermanentLevels?: components['schemas']['HousingLocation'][]
     }
     /** @description Damage obligation for an offender */
     OffenderDamageObligationModel: {
@@ -8389,102 +8347,6 @@ export interface components {
       expiryDate?: string
       /** @description true if applied globally to the contact or false if applied in the context of a visit */
       globalRestriction: boolean
-    }
-    /** @description Case Note */
-    CaseNote: {
-      /**
-       * Format: int64
-       * @description Case Note Id (unique)
-       * @example 12311312
-       */
-      caseNoteId: number
-      /**
-       * Format: int64
-       * @description Booking Id of offender
-       * @example 512321
-       */
-      bookingId: number
-      /**
-       * @description Case Note Type
-       * @example KA
-       */
-      type: string
-      /**
-       * @description Case Note Type Description
-       * @example Key Worker Activity
-       */
-      typeDescription?: string
-      /**
-       * @description Case Note Sub Type
-       * @example KS
-       */
-      subType: string
-      /**
-       * @description Case Note Sub Type Description
-       * @example Key Worker Session
-       */
-      subTypeDescription?: string
-      /**
-       * @description Source Type
-       * @example INST
-       */
-      source: string
-      /**
-       * @description Date and Time of Case Note creation
-       * @example 2021-07-05T10:35:17
-       */
-      creationDateTime: string
-      /**
-       * @description Date and Time of when case note contact with offender was made
-       * @example 2021-07-05T10:35:17
-       */
-      occurrenceDateTime: string
-      /**
-       * Format: int64
-       * @description Id of staff member who created case note
-       * @example 321241
-       */
-      staffId: number
-      /**
-       * @description Name of staff member who created case note (lastname, firstname)
-       * @example Smith, John
-       */
-      authorName: string
-      /**
-       * @description Case Note Text
-       * @example This is some text
-       */
-      text: string
-      /**
-       * @description The initial case note information that was entered
-       * @example This is some text
-       */
-      originalNoteText: string
-      /**
-       * @description Agency Code where Case Note was made.
-       * @example MDI
-       */
-      agencyId?: string
-      /** @description Ordered list of amendments to the case note (oldest first) */
-      amendments: components['schemas']['CaseNoteAmendment'][]
-    }
-    /** @description Case Note Amendment */
-    CaseNoteAmendment: {
-      /**
-       * @description Date and Time of Case Note creation
-       * @example 2021-07-05T10:35:17
-       */
-      creationDateTime: string
-      /**
-       * @description Name of the user amending the case note (lastname, firstname)
-       * @example Smith, John
-       */
-      authorName: string
-      /**
-       * @description Additional Case Note Information
-       * @example Some Additional Text
-       */
-      additionalNoteText: string
     }
     /** @description Court case details */
     CourtSentences: {
@@ -9661,10 +9523,10 @@ export interface components {
       additionalAnswers?: string[]
     }
     PageOffenceDto: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['OffenceDto'][]
@@ -9672,9 +9534,9 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       last?: boolean
       empty?: boolean
     }
@@ -10353,10 +10215,10 @@ export interface components {
       numberAllocated: number
     }
     PageOffenderNumber: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['OffenderNumber'][]
@@ -10364,9 +10226,9 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       last?: boolean
       empty?: boolean
     }
@@ -10460,10 +10322,10 @@ export interface components {
       addresses: components['schemas']['AddressDto'][]
     }
     PageEmployment: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Employment'][]
@@ -10471,17 +10333,17 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       last?: boolean
       empty?: boolean
     }
     PageEducation: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Education'][]
@@ -10489,9 +10351,9 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       last?: boolean
       empty?: boolean
     }
@@ -10689,10 +10551,10 @@ export interface components {
       hasVisits: boolean
     }
     PageVisitWithVisitors: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitWithVisitors'][]
@@ -10700,9 +10562,9 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       last?: boolean
       empty?: boolean
     }
@@ -10963,10 +10825,10 @@ export interface components {
       otherContacts: components['schemas']['Contact'][]
     }
     PageBedAssignment: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['BedAssignment'][]
@@ -10974,27 +10836,9 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
-      last?: boolean
-      empty?: boolean
-    }
-    PageCaseNote: {
-      /** Format: int64 */
-      totalElements?: number
-      /** Format: int32 */
-      totalPages?: number
-      /** Format: int32 */
-      size?: number
-      content?: components['schemas']['CaseNote'][]
-      /** Format: int32 */
-      number?: number
-      sort?: components['schemas']['SortObject']
-      first?: boolean
-      /** Format: int32 */
-      numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       last?: boolean
       empty?: boolean
     }
@@ -11039,10 +10883,10 @@ export interface components {
       currency: string
     }
     PageAlert: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Alert'][]
@@ -11050,9 +10894,9 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       last?: boolean
       empty?: boolean
     }
@@ -11117,10 +10961,10 @@ export interface components {
       hearingSequence: number
     }
     PagePrisonerBookingSummary: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['PrisonerBookingSummary'][]
@@ -11128,9 +10972,9 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       last?: boolean
       empty?: boolean
     }
@@ -17067,38 +16911,6 @@ export interface operations {
     }
   }
   /**
-   * List of all case note types (with sub-types) accessible to current user (and based on working caseload).
-   * @description List of all case note types (with sub-types) accessible to current user (and based on working caseload).
-   */
-  getMyCaseNoteTypes: {
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json': components['schemas']['ReferenceCode'][]
-        }
-      }
-      /** @description Invalid request. */
-      400: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Requested resource not found. */
-      404: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Unrecoverable error occurred whilst processing request. */
-      500: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
-  /**
    * List of caseloads accessible to current user.
    * @description List of caseloads accessible to current user.<p>This endpoint uses the REPLICA database.</p>
    */
@@ -17755,82 +17567,6 @@ export interface operations {
       path: {
         /** @description The domain identifier/name. */
         domain: string
-      }
-    }
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json': components['schemas']['ReferenceCode'][]
-        }
-      }
-      /** @description Invalid request. */
-      400: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Requested resource not found. */
-      404: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Unrecoverable error occurred whilst processing request. */
-      500: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
-  /**
-   * List of all used case note types (with sub-types).
-   * @description List of all used case note types (with sub-types).<p>This endpoint uses the REPLICA database.</p>
-   */
-  getCaseNoteTypes: {
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json': components['schemas']['ReferenceCode'][]
-        }
-      }
-      /** @description Invalid request. */
-      400: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Requested resource not found. */
-      404: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Unrecoverable error occurred whilst processing request. */
-      500: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
-  /**
-   * List of case note source codes.
-   * @description List of case note source codes.<p>This endpoint uses the REPLICA database.</p>
-   */
-  getCaseNoteSources: {
-    parameters: {
-      header: {
-        /** @description Requested offset of first record in returned collection of caseNoteSource records. */
-        'Page-Offset'?: number
-        /** @description Requested limit to number of caseNoteSource records returned. */
-        'Page-Limit'?: number
-        /** @description Comma separated list of one or more of the following fields - <b>code, description</b> */
-        'Sort-Fields'?: string
-        /** @description Sort order (ASC or DESC) - defaults to ASC. */
-        'Sort-Order'?: 'ASC' | 'DESC'
       }
     }
     responses: {
@@ -18654,6 +18390,9 @@ export interface operations {
    * For example Bristol has wings, spurs and landings, but this endpoint will only return wings and landings as spurs are not mapped in NOMIS.
    * Another example is Moorland where 5-1-B-014 in NOMIS is Wing 5, Landing 1, Cell B and Cell 014, whereas in reality it should be Houseblock 5, Spur 1, Wing B and Cell 014 instead.
    * This endpoint will therefore also return different information from Whereabouts API as that service re-maps the NOMIS layout to include spurs etc.</p>
+   * <p>If the current location is temporary (reception, court, tap, cell swap or early conditional licence) then the previous permanent location is also returned, provided
+   * that the location is at the same prison and they haven't moved to a different prison in the meantime.</p>
+   * <p>Requires a relationship (via caseload) with the prisoner or VIEW_PRISONER_DATA role.</p>
    */
   getHousingLocation: {
     parameters: {
@@ -18821,84 +18560,6 @@ export interface operations {
       500: {
         content: {
           'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
-  /**
-   * Offender case note detail.
-   * @description Retrieve an single offender case note
-   */
-  getOffenderCaseNote: {
-    parameters: {
-      path: {
-        /** @description Noms ID or Prisoner number (also called offenderNo) */
-        offenderNo: string
-        /** @description The case note id */
-        caseNoteId: number
-      }
-    }
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json': components['schemas']['CaseNote']
-        }
-      }
-    }
-  }
-  /**
-   * Offender case notes
-   * @description Retrieve an offenders case notes for latest booking<p>This endpoint uses the REPLICA database.</p>
-   */
-  getOffenderCaseNotes: {
-    parameters: {
-      query: {
-        /**
-         * @description start contact date to search from
-         * @example 2021-02-03
-         */
-        from?: string
-        /**
-         * @description end contact date to search up to (including this date)
-         * @example 2021-02-04
-         */
-        to?: string
-        /**
-         * @description Filter by case note type
-         * @example GEN
-         */
-        type?: string
-        /**
-         * @description Filter by case note sub-type
-         * @example OBS
-         */
-        subType?: string
-        /**
-         * @description Filter by the ID of the prison
-         * @example LEI
-         */
-        prisonId?: string
-        /** @description Zero-based page index (0..N) */
-        page?: number
-        /** @description The size of the page to be returned */
-        size?: number
-        /** @description Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported. */
-        sort?: string[]
-      }
-      path: {
-        /**
-         * @description Noms ID or Prisoner number (also called offenderNo)
-         * @example A1234AA
-         */
-        offenderNo: string
-      }
-    }
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json': components['schemas']['CaseNote']
         }
       }
     }
@@ -22408,7 +22069,7 @@ export interface operations {
   }
   /**
    * Gets cell history for an offender booking
-   * @description Default sort order is by assignment date descending<p>This endpoint uses the REPLICA database.</p>
+   * @description Default sort order is by assignment date descending.  Requires a relationship (via caseload) with the prisoner or VIEW_PRISONER_DATA role.<p>This endpoint uses the REPLICA database.</p>
    */
   getBedAssignmentsHistory_1: {
     parameters: {
@@ -22428,80 +22089,6 @@ export interface operations {
       200: {
         content: {
           'application/json': components['schemas']['PageBedAssignment']
-        }
-      }
-      /** @description Invalid request. */
-      400: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Requested resource not found. */
-      404: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Unrecoverable error occurred whilst processing request. */
-      500: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
-  /**
-   * Offender case notes.
-   * @description Offender case notes.<p>This endpoint uses the REPLICA database.</p>
-   */
-  getOffenderCaseNotes_1: {
-    parameters: {
-      query: {
-        /**
-         * @description start contact date to search from
-         * @example 2021-02-03
-         */
-        from?: string
-        /**
-         * @description end contact date to search up to (including this date)
-         * @example 2021-02-04
-         */
-        to?: string
-        /**
-         * @description Filter by case note type
-         * @example GEN
-         */
-        type?: string
-        /**
-         * @description Filter by case note sub-type
-         * @example OBS
-         */
-        subType?: string
-        /**
-         * @description Filter by the ID of the prison
-         * @example LEI
-         */
-        prisonId?: string
-        /** @description Zero-based page index (0..N) */
-        page?: number
-        /** @description The size of the page to be returned */
-        size?: number
-        /** @description Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported. */
-        sort?: string[]
-      }
-      path: {
-        /**
-         * @description The booking id of offender
-         * @example 23412312
-         */
-        bookingId: number
-      }
-    }
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json': components['schemas']['PageCaseNote']
         }
       }
       /** @description Invalid request. */
@@ -22568,28 +22155,6 @@ export interface operations {
       500: {
         content: {
           'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
-  /**
-   * Offender case note detail.
-   * @description Offender case note detail.
-   */
-  getOffenderCaseNote_1: {
-    parameters: {
-      path: {
-        /** @description The booking id of offender */
-        bookingId: number
-        /** @description The case note id */
-        caseNoteId: number
-      }
-    }
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json': components['schemas']['CaseNote']
         }
       }
     }

--- a/server/@types/prisoner-offender-search-api.d.ts
+++ b/server/@types/prisoner-offender-search-api.d.ts
@@ -875,10 +875,10 @@ export interface components {
       supportingPrisonIds?: string[]
     }
     PagePrisoner: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Prisoner'][]
@@ -886,27 +886,27 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
-      last?: boolean
       empty?: boolean
     }
     PageableObject: {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject']
-      paged?: boolean
-      unpaged?: boolean
       /** Format: int32 */
       pageSize?: number
+      paged?: boolean
+      unpaged?: boolean
       /** Format: int32 */
       pageNumber?: number
     }
     SortObject: {
       empty?: boolean
-      unsorted?: boolean
       sorted?: boolean
+      unsorted?: boolean
     }
     /** @description Search Criteria for Release Date Search */
     ReleaseDateSearch: {
@@ -1099,10 +1099,10 @@ export interface components {
       pagination?: components['schemas']['PaginationRequest']
     }
     PrisonerDetailResponse: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Prisoner'][]
@@ -1110,10 +1110,10 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
-      last?: boolean
       empty?: boolean
     }
     ErrorResponse: {
@@ -1347,10 +1347,10 @@ export interface components {
       pagination?: components['schemas']['PaginationRequest']
     }
     PhysicalDetailResponse: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Prisoner'][]
@@ -1358,10 +1358,10 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
-      last?: boolean
       empty?: boolean
     }
     MatchRequest: {
@@ -1460,10 +1460,10 @@ export interface components {
       type?: 'DEFAULT' | 'ESTABLISHMENT'
     }
     KeywordResponse: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Prisoner'][]
@@ -1471,10 +1471,10 @@ export interface components {
       number?: number
       sort?: components['schemas']['SortObject']
       first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
-      last?: boolean
       empty?: boolean
     }
     /** @description Search Criteria for Global Prisoner Search */

--- a/server/@types/whereabouts-api.d.ts
+++ b/server/@types/whereabouts-api.d.ts
@@ -955,9 +955,9 @@ export interface components {
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
       pageSize?: number
-      unpaged?: boolean
       /** Format: int32 */
       pageNumber?: number
+      unpaged?: boolean
       paged?: boolean
     }
     SortObject: {

--- a/server/data/orchestrationApiTypes.ts
+++ b/server/data/orchestrationApiTypes.ts
@@ -4,17 +4,9 @@ export type SupportType = components['schemas']['SupportTypeDto']
 
 export type VisitorSupport = components['schemas']['VisitorSupportDto']
 
-// Temp fixes for enums incorrectly defined as strings in orchestration API - VB-2081
-// export type PageVisitDto = components['schemas']['PageVisitDto']
-// export type Visit = components['schemas']['VisitDto']
-// export type VisitHistoryDetails = components['schemas']['VisitHistoryDetailsDto']
-export type Visit = Omit<components['schemas']['VisitDto'], 'visitRestriction' | 'visitStatus' | 'visitType'> & {
-  visitRestriction: 'OPEN' | 'CLOSED' | 'UNKNOWN'
-  visitStatus: 'RESERVED' | 'CHANGING' | 'BOOKED' | 'CANCELLED'
-  visitType: 'SOCIAL'
-}
-export type PageVisitDto = Omit<components['schemas']['PageVisitDto'], 'content'> & { content: Visit[] }
-export type VisitHistoryDetails = Omit<components['schemas']['VisitHistoryDetailsDto'], 'visit'> & { visit: Visit }
+export type PageVisitDto = components['schemas']['PageVisitDto']
+export type Visit = components['schemas']['VisitDto']
+export type VisitHistoryDetails = components['schemas']['VisitHistoryDetailsDto']
 
 export type Visitor = components['schemas']['VisitorDto']
 


### PR DESCRIPTION
Orchestration service now correctly returns several properties as `enum` rather than `string` so types updated to reflect this and workaround removed.