### PR TITLE
VB-2170 Handle unknown users in migrated data

### DIFF
--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -192,8 +192,8 @@ describe('/visit/:reference', () => {
     })
 
     it('should handle special cases for migrated data when showing actioned by user details', () => {
-      visitHistoryDetails.createdBy = 'NOT_KNOWN' // test cases for old / migrated data
-      visitHistoryDetails.updatedBy = 'NOT_KNOWN_NOMIS'
+      visitHistoryDetails.createdBy = 'NOT_KNOWN' // test case for old / migrated data
+      visitHistoryDetails.updatedBy = 'NOT_KNOWN_NOMIS' // migrated from Nomis, but user not available
       visitHistoryDetails.cancelledBy = 'User Three'
       visitHistoryDetails.cancelledDateAndTime = '2022-01-01T11:30:00'
 
@@ -204,7 +204,9 @@ describe('/visit/:reference', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
           expect($('[data-test="visit-booked"]').text().replace(/\s+/g, ' ')).toBe('Saturday 1 January 2022 at 9am')
-          expect($('[data-test="visit-updated"]').text().replace(/\s+/g, ' ')).toBe('Saturday 1 January 2022 at 10am')
+          expect($('[data-test="visit-updated"]').text().replace(/\s+/g, ' ')).toBe(
+            'Saturday 1 January 2022 at 10am in NOMIS',
+          )
           expect($('[data-test="visit-cancelled"]').text().replace(/\s+/g, ' ')).toBe(
             'Saturday 1 January 2022 at 11:30am by User Three',
           )

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -6,8 +6,12 @@
 {%-from "moj/components/banner/macro.njk" import mojBanner %}
 
 {% macro actionedByUser(user) %}
-  {% if user and user != 'NOT_KNOWN' and user != 'NOT_KNOWN_NOMIS' %}
-    by {{ user -}}
+  {% if user and user != 'NOT_KNOWN' %}
+    {% if user == 'NOT_KNOWN_NOMIS' %}
+      in NOMIS
+    {%- else %}
+      by {{ user -}}
+    {% endif %}
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
On the booking details summary page, handle special values `NOT_KNOWN` and `NOT_KNOWN_NOMIS` when displaying the user who booked / updated / cancelled the booking.

* `NOT_KNOWN` - don't show a user
* `NOT_KNOWN_NOMIS` - show user as 'NOMIS'

(Added a macro to the template to avoid repetition of testing same conditions; and included extra test coverage for these two special values.)