### PR TITLE
VB-1999 Add descriptor to visits timetable page for prisoner category

### DIFF
--- a/integration_tests/integration/visitTimetable.cy.ts
+++ b/integration_tests/integration/visitTimetable.cy.ts
@@ -31,6 +31,11 @@ context('View visit schedule timetable', () => {
         sessionTemplateFrequency: 'BI_WEEKLY',
       }),
       TestData.sessionSchedule(),
+      TestData.sessionSchedule({
+        prisonerCategoryGroupNames: ['Category A (High Risk) prisoners'],
+        sessionTemplateEndDate: '2023-04-01',
+        sessionTemplateFrequency: 'ONE_OFF',
+      }),
     ]
     cy.task('stubSessionSchedule', { prisonId, date: format(today, shortDateFormat), sessionSchedule })
 
@@ -71,6 +76,13 @@ context('View visit schedule timetable', () => {
     visitTimetablePage.scheduleAttendees(2).contains('All prisoners')
     visitTimetablePage.scheduleFrequency(2).contains('Weekly')
     visitTimetablePage.scheduleEndDate(2).contains('Not entered')
+
+    visitTimetablePage.scheduleTime(3).contains('1:45pm to 3:45pm')
+    visitTimetablePage.scheduleType(3).contains('Open')
+    visitTimetablePage.scheduleCapacity(3).contains('40 tables')
+    visitTimetablePage.scheduleAttendees(3).contains('Category A (High Risk) prisoners')
+    visitTimetablePage.scheduleFrequency(3).contains('One off')
+    visitTimetablePage.scheduleEndDate(3).contains('1 April 2023')
 
     visitTimetablePage
       .requestChangeLink()

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -457,10 +457,10 @@ export interface components {
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
       pageSize?: number
+      unpaged?: boolean
       /** Format: int32 */
       pageNumber?: number
       paged?: boolean
-      unpaged?: boolean
     }
     SortObject: {
       empty?: boolean

--- a/server/@types/prison-api.d.ts
+++ b/server/@types/prison-api.d.ts
@@ -7458,10 +7458,10 @@ export interface components {
       establishmentName: string
     }
     PagePrisonerInformation: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['PrisonerInformation'][]
@@ -9537,10 +9537,10 @@ export interface components {
       additionalAnswers?: string[]
     }
     PageOffenceDto: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['OffenceDto'][]
@@ -10229,10 +10229,10 @@ export interface components {
       numberAllocated: number
     }
     PageOffenderNumber: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['OffenderNumber'][]
@@ -10336,10 +10336,10 @@ export interface components {
       addresses: components['schemas']['AddressDto'][]
     }
     PageEmployment: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Employment'][]
@@ -10354,10 +10354,10 @@ export interface components {
       empty?: boolean
     }
     PageEducation: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Education'][]
@@ -10544,15 +10544,15 @@ export interface components {
        */
       establishmentCode?: string
       /**
-       * @description Case Note Type and Sub Type
-       * @example POS IEP_ENC
-       */
-      noteType: string
-      /**
        * @description Name of staff member who created case note (lastname, firstname)
        * @example Smith, John
        */
       staffName: string
+      /**
+       * @description Case Note Type and Sub Type
+       * @example POS IEP_ENC
+       */
+      noteType: string
     }
     /** @description Visit summary */
     VisitSummary: {
@@ -10565,10 +10565,10 @@ export interface components {
       hasVisits: boolean
     }
     PageVisitWithVisitors: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitWithVisitors'][]
@@ -10839,10 +10839,10 @@ export interface components {
       otherContacts: components['schemas']['Contact'][]
     }
     PageBedAssignment: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['BedAssignment'][]
@@ -10897,10 +10897,10 @@ export interface components {
       currency: string
     }
     PageAlert: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['Alert'][]
@@ -10975,10 +10975,10 @@ export interface components {
       hearingSequence: number
     }
     PagePrisonerBookingSummary: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['PrisonerBookingSummary'][]

--- a/server/@types/prisoner-offender-search-api.d.ts
+++ b/server/@types/prisoner-offender-search-api.d.ts
@@ -896,17 +896,17 @@ export interface components {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject']
-      paged?: boolean
-      unpaged?: boolean
       /** Format: int32 */
       pageSize?: number
       /** Format: int32 */
       pageNumber?: number
+      paged?: boolean
+      unpaged?: boolean
     }
     SortObject: {
       empty?: boolean
-      unsorted?: boolean
       sorted?: boolean
+      unsorted?: boolean
     }
     /** @description Search Criteria for Release Date Search */
     ReleaseDateSearch: {

--- a/server/@types/whereabouts-api.d.ts
+++ b/server/@types/whereabouts-api.d.ts
@@ -945,8 +945,8 @@ export interface components {
       first?: boolean
       /** Format: int32 */
       numberOfElements?: number
-      pageable?: components['schemas']['PageableObject']
       last?: boolean
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     PageableObject: {
@@ -955,10 +955,10 @@ export interface components {
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
       pageSize?: number
-      unpaged?: boolean
-      paged?: boolean
       /** Format: int32 */
       pageNumber?: number
+      unpaged?: boolean
+      paged?: boolean
     }
     SortObject: {
       empty?: boolean

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -252,6 +252,7 @@ export default class TestData {
     enhanced = false,
     capacity = { closed: 0, open: 40 },
     prisonerLocationGroupNames = [],
+    prisonerCategoryGroupNames = [],
     sessionTemplateFrequency = 'WEEKLY',
     sessionTemplateEndDate = '',
   }: Partial<SessionSchedule> = {}): SessionSchedule => ({
@@ -261,6 +262,7 @@ export default class TestData {
     enhanced,
     capacity,
     prisonerLocationGroupNames,
+    prisonerCategoryGroupNames,
     sessionTemplateFrequency,
     sessionTemplateEndDate,
   })

--- a/server/routes/timetable.test.ts
+++ b/server/routes/timetable.test.ts
@@ -138,6 +138,7 @@ describe('View visits timetable', () => {
       TestData.sessionSchedule({ capacity: { open: 11, closed: 22 } }), // Row 3 + 4
       TestData.sessionSchedule({ enhanced: true, startTime: '15:00', prisonerLocationGroupNames: ['Group 1'] }), // Row 5
       TestData.sessionSchedule({ enhanced: true, sessionTemplateEndDate: '2025-12-31' }), // Row 6
+      TestData.sessionSchedule({ prisonerCategoryGroupNames: ['Category A (High Risk) prisoners'] }), // Row 7
     ]
     visitSessionsService.getSessionSchedule.mockResolvedValue(sessionSchedule)
 
@@ -152,7 +153,7 @@ describe('View visits timetable', () => {
         expect($('[data-test="schedule-time-0"]').text()).toBe('1:45pm to 3:45pm')
         expect($('[data-test="schedule-type-0"]').text()).toBe('Open')
         expect($('[data-test="schedule-capacity-0"]').text()).toBe('40 tables')
-        expect($('[data-test="schedule-attendees-0"]').text()).toBe('All prisoners')
+        expect($('[data-test="schedule-attendees-0"]').text().trim()).toBe('All prisoners')
         expect($('[data-test="schedule-frequency-0"]').text()).toBe('Weekly')
         expect($('[data-test="schedule-end-date-0"]').text()).toBe('Not entered')
         // Row 1
@@ -167,11 +168,13 @@ describe('View visits timetable', () => {
         expect($('[data-test="schedule-capacity-4"]').text()).toBe('22 tables')
         // Row 5
         expect($('[data-test="schedule-time-5"]').text()).toBe('3pm to 3:45pm')
-        expect($('[data-test="schedule-attendees-5"] > span').text()).toBe('Enhanced prisoners in:')
+        expect($('[data-test="schedule-attendees-5"] > span').text().trim()).toBe('Enhanced prisoners in:')
         expect($('[data-test="schedule-attendees-5"] li').eq(0).text()).toBe('Group 1')
         // Row 6
-        expect($('[data-test="schedule-attendees-6"]').text()).toBe('Enhanced prisoners only')
+        expect($('[data-test="schedule-attendees-6"]').text().trim()).toBe('Enhanced prisoners')
         expect($('[data-test="schedule-end-date-6"]').text()).toBe('31 December 2025')
+        // Row 7
+        expect($('[data-test="schedule-attendees-7"]').text().trim()).toBe('Category A (High Risk) prisoners')
       })
   })
 })

--- a/server/views/pages/timetable.njk
+++ b/server/views/pages/timetable.njk
@@ -8,18 +8,28 @@
 
 {% set backLinkHref = "/" %}
 
-{% macro attendees(enhanced, prisonerLocationGroupNames) %}
+{% macro attendees(enhanced, prisonerCategoryGroupNames, prisonerLocationGroupNames) %}
   {% if prisonerLocationGroupNames | length %}
-    {% if enhanced %}
-      <span>Enhanced prisoners in:</span>
-    {% endif %}
+    <span>
+      {{ "Enhanced prisoners" if enhanced -}}
+      {% if prisonerCategoryGroupNames | length %}
+        {% if enhanced %},<br>{% endif %}
+        {{ prisonerCategoryGroupNames | join(",<br>") | safe }}
+      {% endif %}
+      {{- " in:" if enhanced or prisonerCategoryGroupNames | length }}
+    </span>
     <ul class="govuk-list govuk-!-margin-bottom-0{{ " govuk-!-margin-top-2" if enhanced }}">
       {% for name in prisonerLocationGroupNames %}
         <li class="{{ "govuk-!-margin-bottom-0" if loop.last }}">{{ name }}</li>
       {% endfor %}
     </ul>
   {% else %}
-    {{- "Enhanced prisoners only" if enhanced else "All prisoners" -}}
+    {{ "Enhanced prisoners" if enhanced }}
+    {% if prisonerCategoryGroupNames | length %}
+      {% if enhanced %}<br>{% endif %}
+      {{ prisonerCategoryGroupNames | join("<br>") | safe }}
+    {% endif %}
+    {{ "All prisoners" if not enhanced and not prisonerCategoryGroupNames | length }}
   {% endif %}
 {% endmacro %}
 
@@ -41,7 +51,7 @@
         attributes: { "data-test" : "schedule-capacity-" + rowNumber } 
       },
       {
-        text: attendees(schedule.enhanced, schedule.prisonerLocationGroupNames),
+        text: attendees(schedule.enhanced, schedule.prisonerCategoryGroupNames, schedule.prisonerLocationGroupNames),
         attributes: { "data-test" : "schedule-attendees-" + rowNumber } 
       },
       {


### PR DESCRIPTION
Update the visits timetable page so that the 'Attendees' column includes prisoner category groups as well as enhanced IEP status and location groups.