### PR TITLE
VB-2167 Add user info to App Insights

### DIFF
--- a/server/utils/azureAppInsights.test.ts
+++ b/server/utils/azureAppInsights.test.ts
@@ -1,0 +1,82 @@
+import { DataTelemetry, EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
+import { addUserDataToRequests, ContextObject } from './azureAppInsights'
+
+const user = {
+  activeCaseLoadId: 'LII',
+  username: 'test-user',
+}
+
+const createEnvelope = (properties: Record<string, string | boolean>, baseType = 'RequestData') =>
+  ({
+    data: {
+      baseType,
+      baseData: { properties },
+    } as DataTelemetry,
+  } as EnvelopeTelemetry)
+
+const createContext = (username: string, activeCaseLoadId: string) =>
+  ({
+    'http.ServerRequest': {
+      res: {
+        locals: {
+          user: {
+            username,
+            activeCaseLoadId,
+          },
+        },
+      },
+    },
+  } as ContextObject)
+
+const context = createContext(user.username, user.activeCaseLoadId)
+
+describe('azure-appinsights', () => {
+  describe('addUserDataToRequests', () => {
+    it('adds user data to properties when present', () => {
+      const envelope = createEnvelope({ other: 'things' })
+
+      addUserDataToRequests(envelope, context)
+
+      expect(envelope.data.baseData.properties).toStrictEqual({
+        ...user,
+        other: 'things',
+      })
+    })
+
+    it('handles absent user data', () => {
+      const envelope = createEnvelope({ other: 'things' })
+
+      addUserDataToRequests(envelope, createContext(undefined, user.activeCaseLoadId))
+
+      expect(envelope.data.baseData.properties).toStrictEqual({ other: 'things' })
+    })
+
+    it('returns true when not RequestData type', () => {
+      const envelope = createEnvelope({}, 'NOT_REQUEST_DATA')
+
+      const response = addUserDataToRequests(envelope, context)
+
+      expect(response).toStrictEqual(true)
+    })
+
+    it('handles when no properties have been set', () => {
+      const envelope = createEnvelope(undefined)
+
+      addUserDataToRequests(envelope, context)
+
+      expect(envelope.data.baseData.properties).toStrictEqual(user)
+    })
+
+    it('handles missing user details', () => {
+      const envelope = createEnvelope({ other: 'things' })
+
+      addUserDataToRequests(envelope, {
+        'http.ServerRequest': {},
+      } as ContextObject)
+
+      expect(envelope.data.baseData.properties).toEqual({
+        other: 'things',
+      })
+    })
+  })
+})

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,5 +1,11 @@
-import { setup, defaultClient, TelemetryClient, DistributedTracingModes } from 'applicationinsights'
+import { setup, defaultClient, TelemetryClient, DistributedTracingModes, Contracts } from 'applicationinsights'
+import { EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
 import applicationVersion from '../applicationVersion'
+
+export type ContextObject = {
+  /* eslint-disable  @typescript-eslint/no-explicit-any */
+  [name: string]: any
+}
 
 function defaultName(): string {
   const {
@@ -26,7 +32,25 @@ export function buildAppInsightsClient(name = defaultName()): TelemetryClient {
   if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
     defaultClient.context.tags['ai.cloud.role'] = name
     defaultClient.context.tags['ai.application.ver'] = version()
+    defaultClient.addTelemetryProcessor(addUserDataToRequests)
     return defaultClient
   }
   return null
+}
+
+export function addUserDataToRequests(envelope: EnvelopeTelemetry, contextObjects: ContextObject) {
+  const isRequest = envelope.data.baseType === Contracts.TelemetryTypeString.Request
+  if (isRequest) {
+    const { username, activeCaseLoadId } = contextObjects?.['http.ServerRequest']?.res?.locals?.user || {}
+    if (username) {
+      const { properties } = envelope.data.baseData
+      // eslint-disable-next-line no-param-reassign
+      envelope.data.baseData.properties = {
+        username,
+        activeCaseLoadId,
+        ...properties,
+      }
+    }
+  }
+  return true
 }


### PR DESCRIPTION
Adds `username` and `activeCaseLoadId` as custom dimensions to requests in App Insights.

Based on https://github.com/ministryofjustice/use-of-force/pull/599