### PR TITLE
VB-2061 Prisoner profile page visits tab – group visits by month

### DIFF
--- a/assets/sass/components/_prisoner-profile.scss
+++ b/assets/sass/components/_prisoner-profile.scss
@@ -43,3 +43,27 @@
     background-color: govuk-colour("purple");
   }
 }
+
+.prisoner-profile-visits {
+  & td:first-child {
+    width: 15%;
+  }
+
+  & td:nth-child(2) {
+    width: 12%;
+  }
+
+  & td:nth-child(6) {
+    width: 10%;
+  }
+}
+
+.prisoner-profile-visits:not(:first-of-type) {
+  & thead {
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+
+  & th {
+    @include govuk-visually-hidden($important: true);
+  }
+}

--- a/assets/sass/components/_prisoner-profile.scss
+++ b/assets/sass/components/_prisoner-profile.scss
@@ -45,7 +45,7 @@
 }
 
 .prisoner-profile-visits {
-  & td:first-child {
+  & td:nth-child(1) {
     width: 15%;
   }
 
@@ -53,8 +53,20 @@
     width: 12%;
   }
 
+  & td:nth-child(3) {
+    width: 20%;
+  }
+
+  & td:nth-child(4) {
+    width: 20%;
+  }
+
   & td:nth-child(6) {
     width: 10%;
+  }
+
+  & tbody tr:last-child {
+    border-bottom: 1px solid $govuk-border-colour;
   }
 }
 

--- a/integration_tests/integration/prisonerProfile.cy.ts
+++ b/integration_tests/integration/prisonerProfile.cy.ts
@@ -40,8 +40,8 @@ context('Prisoner profile page', () => {
         active: true,
       },
     ]
-
-    const profile = TestData.prisonerProfile({ alerts })
+    const visit = TestData.visit()
+    const profile = TestData.prisonerProfile({ alerts, visits: [visit] })
 
     const { prisonerId } = profile
     const prisonId = 'HEI'
@@ -86,6 +86,7 @@ context('Prisoner profile page', () => {
 
     // Visits history tab
     prisonerProfilePage.selectVisitsTab()
+    prisonerProfilePage.visitTabCaption().contains('January 2022 (1 past visit)')
     prisonerProfilePage
       .visitTabReference()
       .eq(0)
@@ -97,8 +98,8 @@ context('Prisoner profile page', () => {
       .visitTabDateAndTime()
       .eq(0)
       .contains(format(new Date(profile.visits[0].startTimestamp), prettyDateFormat))
-      .contains('10:00am - 11:00am')
-    prisonerProfilePage.visitTabVisitors().eq(0).contains('Mary Smith')
+      .contains('10am - 11am')
+    prisonerProfilePage.visitTabVisitors().eq(0).contains('Jeanette Smith')
     prisonerProfilePage.visitTabVisitStatus().eq(0).contains('Booked')
   })
 })

--- a/integration_tests/integration/prisonerProfile.cy.ts
+++ b/integration_tests/integration/prisonerProfile.cy.ts
@@ -41,11 +41,14 @@ context('Prisoner profile page', () => {
       },
     ]
     const visit = TestData.visit()
+    const contacts = [TestData.contact(), TestData.contact({ personId: 4322, firstName: 'Bob' })]
     const profile = TestData.prisonerProfile({ alerts, visits: [visit] })
 
     const { prisonerId } = profile
     const prisonId = 'HEI'
+
     // Prisoner profile page
+    cy.task('stubPrisonerSocialContacts', { offenderNo: prisonerId, contacts })
     cy.task('stubPrisonerProfile', { prisonId, prisonerId, profile })
 
     // Go to prisoner profile page
@@ -84,7 +87,7 @@ context('Prisoner profile page', () => {
       .contains(format(new Date('01-02-2022'), prettyDateFormat))
     prisonerProfilePage.alertsTabExpires().eq(0).contains('Not entered')
 
-    // Visits history tab
+    // Visits tab
     prisonerProfilePage.selectVisitsTab()
     prisonerProfilePage.visitTabCaption().contains('January 2022 (1 past visit)')
     prisonerProfilePage
@@ -99,7 +102,13 @@ context('Prisoner profile page', () => {
       .eq(0)
       .contains(format(new Date(profile.visits[0].startTimestamp), prettyDateFormat))
       .contains('10am - 11am')
-    prisonerProfilePage.visitTabVisitors().eq(0).contains('Jeanette Smith')
+    prisonerProfilePage
+      .visitTabVisitors()
+      .eq(0)
+      .within(() => {
+        cy.contains('Jeanette Smith')
+        cy.contains('Bob Smith')
+      })
     prisonerProfilePage.visitTabVisitStatus().eq(0).contains('Booked')
   })
 })

--- a/integration_tests/integration/prisonerProfile.cy.ts
+++ b/integration_tests/integration/prisonerProfile.cy.ts
@@ -89,7 +89,7 @@ context('Prisoner profile page', () => {
 
     // Visits tab
     prisonerProfilePage.selectVisitsTab()
-    prisonerProfilePage.visitTabCaption().contains('January 2022 (1 past visit)')
+    prisonerProfilePage.visitTabCaption(1).contains('January 2022 (1 past visit)')
     prisonerProfilePage
       .visitTabReference()
       .eq(0)

--- a/integration_tests/pages/prisonerProfile.ts
+++ b/integration_tests/pages/prisonerProfile.ts
@@ -66,4 +66,6 @@ export default class PrisonerProfilePage extends Page {
   visitTabVisitors = (): PageElement => cy.get('[data-test="tab-visits-visitors"]')
 
   visitTabVisitStatus = (): PageElement => cy.get('[data-test="tab-visits-status"]')
+
+  visitTabCaption = (): PageElement => cy.get('.govuk-table__caption--m')
 }

--- a/integration_tests/pages/prisonerProfile.ts
+++ b/integration_tests/pages/prisonerProfile.ts
@@ -55,6 +55,8 @@ export default class PrisonerProfilePage extends Page {
 
   alertsTabExpires = (): PageElement => cy.get('[data-test="tab-alerts-expires"]')
 
+  visitTabCaption = (index: number): PageElement => cy.get(`#visits caption:nth-of-type(${index})`)
+
   visitTabReference = (): PageElement => cy.get('[data-test="tab-visits-reference"]')
 
   visitTabType = (): PageElement => cy.get('[data-test="tab-visits-type"]')
@@ -66,6 +68,4 @@ export default class PrisonerProfilePage extends Page {
   visitTabVisitors = (): PageElement => cy.get('[data-test="tab-visits-visitors"]')
 
   visitTabVisitStatus = (): PageElement => cy.get('[data-test="tab-visits-status"]')
-
-  visitTabCaption = (): PageElement => cy.get('.govuk-table__caption--m')
 }

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -49,84 +49,6 @@ export type PrisonerAlertItem = [
   },
 ]
 
-export type UpcomingVisitItem = [
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    text: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    text: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-]
-
-export type PastVisitItem = [
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    text: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    text: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-]
-
 export type VisitorListItem = {
   personId: number
   name: string
@@ -142,7 +64,7 @@ export type PrisonerProfilePage = {
   activeAlerts: PrisonerAlertItem[]
   activeAlertCount: number
   flaggedAlerts: Alert[]
-  visits: VisitItem[]
+  visitsByMonth: Map<string, { upcomingCount: number; pastCount: number; visits: Visit[] }>
   prisonerDetails: PrisonerDetails
 }
 
@@ -254,42 +176,3 @@ export type PrisonerDetails = {
   incentiveLevel: string
   visitBalances: VisitBalances
 }
-
-export type VisitItem = [
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    text: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    html: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-  {
-    text: string
-    attributes?: {
-      'data-test': string
-    }
-  },
-]

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -66,6 +66,7 @@ export type PrisonerProfilePage = {
   flaggedAlerts: Alert[]
   visitsByMonth: Map<string, { upcomingCount: number; pastCount: number; visits: Visit[] }>
   prisonerDetails: PrisonerDetails
+  contactNames: Record<number, string>
 }
 
 export type BAPVVisitBalances = VisitBalances & {

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -39,17 +39,17 @@ describe('orchestrationApiClient', () => {
 
   describe('getPrisonerProfile', () => {
     it('should return prisoner profile page for selected prisoner', async () => {
-      const fullPrisoner = TestData.prisonerProfile()
+      const prisonerProfile = TestData.prisonerProfile()
       const prisonId = 'HEI'
 
       fakeOrchestrationApi
-        .get(`/prisoner/${prisonId}/${fullPrisoner.prisonerId}/profile`)
+        .get(`/prisoner/${prisonId}/${prisonerProfile.prisonerId}/profile`)
         .matchHeader('authorization', `Bearer ${token}`)
-        .reply(200, fullPrisoner)
+        .reply(200, prisonerProfile)
 
-      const output = await orchestrationApiClient.getPrisonerProfile(prisonId, fullPrisoner.prisonerId)
+      const output = await orchestrationApiClient.getPrisonerProfile(prisonId, prisonerProfile.prisonerId)
 
-      expect(output).toEqual(fullPrisoner)
+      expect(output).toEqual(prisonerProfile)
     })
   })
 })

--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -83,29 +83,7 @@ describe('GET /prisoner/A1234BC', () => {
           alertCodeDescription: 'Protective Isolation Unit',
         },
       ],
-      visits: [
-        [
-          {
-            html: "<a href='/visit/ab-cd-ef-gh'>ab-cd-ef-gh</a>",
-            attributes: {
-              'data-test': 'tab-visits-reference',
-            },
-          },
-          {
-            html: '<span>Social<br>(Open)</span>',
-            attributes: {
-              'data-test': 'tab-visits-type',
-            },
-          },
-          { text: 'Hewell (HMP)', attributes: { 'data-test': 'tab-visits-location' } },
-          {
-            html: '<p>17 August 2022<br>10:00am - 11:00am</p>',
-            attributes: { 'data-test': 'tab-visits-date-and-time' },
-          },
-          { html: '<p>Mary Smith</p>', attributes: { 'data-test': 'tab-visits-visitors' } },
-          { text: 'Booked', attributes: { 'data-test': 'tab-visits-status' } },
-        ],
-      ],
+      visitsByMonth: new Map(),
       prisonerDetails: {
         offenderNo: 'A1234BC',
         name: 'Smith, John',
@@ -318,7 +296,6 @@ describe('GET /prisoner/A1234BC', () => {
 
 describe('POST /prisoner/A1234BC', () => {
   let prisonerProfile: PrisonerProfilePage
-
   beforeEach(() => {
     prisonerProfile = {
       activeAlerts: [
@@ -347,29 +324,7 @@ describe('POST /prisoner/A1234BC', () => {
           alertCodeDescription: 'Protective Isolation Unit',
         },
       ],
-      visits: [
-        [
-          {
-            html: "<a href='/visit/ab-cd-ef-gh'>ab-cd-ef-gh</a>",
-            attributes: {
-              'data-test': 'tab-visits-reference',
-            },
-          },
-          {
-            html: '<span>Social<br>(Open)</span>',
-            attributes: {
-              'data-test': 'tab-visits-type',
-            },
-          },
-          { text: 'Hewell (HMP)', attributes: { 'data-test': 'tab-visits-location' } },
-          {
-            html: '<p>17 August 2022<br>10:00am - 11:00am</p>',
-            attributes: { 'data-test': 'tab-visits-date-and-time' },
-          },
-          { html: '<p>Mary Smith</p>', attributes: { 'data-test': 'tab-visits-visitors' } },
-          { text: 'Booked', attributes: { 'data-test': 'tab-visits-status' } },
-        ],
-      ],
+      visitsByMonth: new Map(),
       prisonerDetails: {
         offenderNo: 'A1234BC',
         name: 'Smith, John',

--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -100,6 +100,7 @@ describe('GET /prisoner/A1234BC', () => {
           latestPrivIepAdjustDate: '1 December 2021',
         },
       },
+      contactNames: {},
     }
 
     prisonerProfileService.getProfile.mockResolvedValue(prisonerProfile)
@@ -341,6 +342,7 @@ describe('POST /prisoner/A1234BC', () => {
           latestPrivIepAdjustDate: '1 December 2021',
         },
       },
+      contactNames: {},
     }
 
     prisonerProfileService.getProfile.mockResolvedValue(prisonerProfile)

--- a/server/routes/prisoner.ts
+++ b/server/routes/prisoner.ts
@@ -11,6 +11,7 @@ export default function routes({
   auditService,
   prisonerProfileService,
   prisonerSearchService,
+  supportedPrisonsService,
   visitSessionsService,
 }: Services): Router {
   const router = Router()
@@ -25,6 +26,8 @@ export default function routes({
     const queryParamsForBackLink = search !== '' ? new URLSearchParams({ search }).toString() : ''
 
     const prisonerProfile = await prisonerProfileService.getProfile(prisonId, prisonerId, res.locals.user.username)
+    const supportedPrisons = await supportedPrisonsService.getSupportedPrisons(res.locals.user.username)
+
     await auditService.viewPrisoner({
       prisonerId,
       prisonId,
@@ -35,6 +38,7 @@ export default function routes({
     return res.render('pages/prisoner/profile', {
       errors: req.flash('errors'),
       ...prisonerProfile,
+      supportedPrisons,
       queryParamsForBackLink,
     })
   })

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -21,67 +21,6 @@ import { Address, Contact, Restriction } from '../../data/prisonerContactRegistr
 import { ScheduledEvent } from '../../data/whereaboutsApiTypes'
 
 export default class TestData {
-  static prisonerProfile = ({
-    prisonerId = 'A1234BC',
-    firstName = 'JOHN',
-    lastName = 'SMITH',
-    dateOfBirth = '1975-04-02',
-    cellLocation = '1-1-C-028',
-    prisonName = 'Hewell (HMP)',
-    category = 'Cat C',
-    convictedStatus = 'Convicted',
-    incentiveLevel = 'Standard',
-    alerts = [],
-    visitBalances = {
-      remainingVo: 1,
-      remainingPvo: 2,
-      latestIepAdjustDate: '2021-04-21',
-      latestPrivIepAdjustDate: '2021-12-01',
-    },
-    visits = [
-      {
-        applicationReference: 'aaa-bbb-ccc',
-        reference: 'ab-cd-ef-gh',
-        prisonerId: 'A1234BC',
-        prisonId: 'HEI',
-        visitRoom: 'A1 L3',
-        visitType: 'SOCIAL',
-        visitStatus: 'BOOKED',
-        visitRestriction: 'OPEN',
-        startTimestamp: '2022-08-17T10:00:00',
-        endTimestamp: '2022-08-17T11:00:00',
-        visitNotes: [],
-        visitContact: {
-          name: 'Mary Smith',
-          telephone: '01234 555444',
-        },
-        visitors: [
-          {
-            nomisPersonId: 1234,
-          },
-        ],
-        visitorSupport: [],
-        createdBy: 'user1',
-        createdTimestamp: '',
-        modifiedTimestamp: '',
-      },
-    ],
-  }: Partial<PrisonerProfile> = {}): PrisonerProfile =>
-    ({
-      prisonerId,
-      firstName,
-      lastName,
-      dateOfBirth,
-      cellLocation,
-      prisonName,
-      category,
-      convictedStatus,
-      incentiveLevel,
-      alerts,
-      visitBalances,
-      visits,
-    } as PrisonerProfile)
-
   static address = ({
     flat = '23B',
     premise = 'Premises',
@@ -291,6 +230,40 @@ export default class TestData {
       },
     ] as Prison[],
   } = {}): Prison[] => prisons
+
+  static prisonerProfile = ({
+    prisonerId = 'A1234BC',
+    firstName = 'JOHN',
+    lastName = 'SMITH',
+    dateOfBirth = '1975-04-02',
+    cellLocation = '1-1-C-028',
+    prisonName = 'Hewell (HMP)',
+    category = 'Cat C',
+    convictedStatus = 'Convicted',
+    incentiveLevel = 'Standard',
+    alerts = [],
+    visitBalances = {
+      remainingVo: 1,
+      remainingPvo: 2,
+      latestIepAdjustDate: '2021-04-21',
+      latestPrivIepAdjustDate: '2021-12-01',
+    },
+    visits = [],
+  }: Partial<PrisonerProfile> = {}): PrisonerProfile =>
+    ({
+      prisonerId,
+      firstName,
+      lastName,
+      dateOfBirth,
+      cellLocation,
+      prisonName,
+      category,
+      convictedStatus,
+      incentiveLevel,
+      alerts,
+      visitBalances,
+      visits,
+    } as PrisonerProfile)
 
   // Visitor restrictions
   static restriction = ({

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -35,6 +35,7 @@ export const services = () => {
   const prisonerProfileService = new PrisonerProfileService(
     orchestrationApiClientBuilder,
     prisonApiClientBuilder,
+    prisonerContactRegistryApiClientBuilder,
     hmppsAuthClient,
   )
 

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -35,10 +35,6 @@ export const services = () => {
   const prisonerProfileService = new PrisonerProfileService(
     orchestrationApiClientBuilder,
     prisonApiClientBuilder,
-    visitSchedulerApiClientBuilder,
-    prisonerContactRegistryApiClientBuilder,
-    prisonerSearchClientBuilder,
-    supportedPrisonsService,
     hmppsAuthClient,
   )
 

--- a/server/services/prisonerProfileService.test.ts
+++ b/server/services/prisonerProfileService.test.ts
@@ -1,4 +1,4 @@
-import { NotFound } from 'http-errors'
+import { addMonths, format, subMonths } from 'date-fns'
 import PrisonerProfileService from './prisonerProfileService'
 import { PagePrisonerBookingSummary, VisitBalances, OffenderRestrictions } from '../data/prisonApiTypes'
 import { PrisonerAlertItem, PrisonerProfilePage } from '../@types/bapv'
@@ -46,10 +46,6 @@ describe('Prisoner profile service', () => {
     prisonerProfileService = new PrisonerProfileService(
       OrchestrationApiClientFactory,
       PrisonApiClientFactory,
-      VisitSchedulerApiClientFactory,
-      PrisonerContactRegistryApiClientFactory,
-      PrisonerSearchClientFactory,
-      supportedPrisonsService,
       hmppsAuthClient,
     )
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
@@ -66,45 +62,22 @@ describe('Prisoner profile service', () => {
       supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
     })
 
-    it('Retrieves and processes data for prisoner profile with visit balances', async () => {
-      const fullPrisoner = TestData.prisonerProfile()
+    it('should retrieve and process data for prisoner profile (with visit balances)', async () => {
+      const prisonerProfile = TestData.prisonerProfile()
 
-      orchestrationApiClient.getPrisonerProfile.mockResolvedValue(fullPrisoner)
+      orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)
 
       const results = await prisonerProfileService.getProfile(prisonId, prisonerId, 'user')
 
       expect(OrchestrationApiClientFactory).toHaveBeenCalledWith(token)
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith('user')
       expect(orchestrationApiClient.getPrisonerProfile).toHaveBeenCalledTimes(1)
-      expect(supportedPrisonsService.getSupportedPrisons).toHaveBeenCalledTimes(1)
 
       expect(results).toEqual(<PrisonerProfilePage>{
         activeAlerts: [],
         activeAlertCount: 0,
         flaggedAlerts: [],
-        visits: [
-          [
-            {
-              html: "<a href='/visit/ab-cd-ef-gh'>ab-cd-ef-gh</a>",
-              attributes: {
-                'data-test': 'tab-visits-reference',
-              },
-            },
-            {
-              html: '<span>Social<br>(Open)</span>',
-              attributes: {
-                'data-test': 'tab-visits-type',
-              },
-            },
-            { text: 'Hewell (HMP)', attributes: { 'data-test': 'tab-visits-location' } },
-            {
-              html: '<p>17 August 2022<br>10:00am - 11:00am</p>',
-              attributes: { 'data-test': 'tab-visits-date-and-time' },
-            },
-            { html: '<p>Mary Smith</p>', attributes: { 'data-test': 'tab-visits-visitors' } },
-            { text: 'Booked', attributes: { 'data-test': 'tab-visits-status' } },
-          ],
-        ],
+        visitsByMonth: new Map(),
         prisonerDetails: {
           offenderNo: 'A1234BC',
           name: 'Smith, John',
@@ -123,25 +96,25 @@ describe('Prisoner profile service', () => {
         },
       })
     })
+
     // Skipped - previously used endpoints were skipped if prisoner was on remand, this logic may wish be to included in the new endpoint
-    it.skip('Does not return visit balances for those on REMAND', async () => {
-      const fullPrisoner = TestData.prisonerProfile({
+    it.skip('should not return visit balances for those on REMAND', async () => {
+      const prisonerProfile = TestData.prisonerProfile({
         convictedStatus: 'Remand',
       })
 
-      orchestrationApiClient.getPrisonerProfile.mockResolvedValue(fullPrisoner)
+      orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)
 
       const results = await prisonerProfileService.getProfile(prisonId, prisonerId, 'user')
 
       expect(OrchestrationApiClientFactory).toHaveBeenCalledWith(token)
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith('user')
       expect(orchestrationApiClient.getPrisonerProfile).toHaveBeenCalledTimes(1)
-      expect(supportedPrisonsService.getSupportedPrisons).toHaveBeenCalledTimes(1)
       expect(results).toEqual(<PrisonerProfilePage>{
         activeAlerts: [],
         activeAlertCount: 0,
         flaggedAlerts: [],
-        visits: [],
+        visitsByMonth: new Map(),
         prisonerDetails: {
           offenderNo: 'A1234BC',
           name: 'Smith, John',
@@ -154,6 +127,32 @@ describe('Prisoner profile service', () => {
           visitBalances: {},
         },
       })
+    })
+
+    it('should group upcoming and past visits by month, with totals for BOOKED only', async () => {
+      const today = new Date()
+      const nextMonth = new Date(addMonths(today, 1))
+      const previousMonth = new Date(subMonths(today, 1))
+      const nextMonthKey = format(nextMonth, 'MMMM yyyy')
+      const previousMonthKey = format(previousMonth, 'MMMM yyyy')
+
+      const visit1 = TestData.visit({ startTimestamp: nextMonth.toISOString() })
+      const visit2 = TestData.visit({ startTimestamp: previousMonth.toISOString() })
+      const visit3 = TestData.visit({ visitStatus: 'CANCELLED', startTimestamp: previousMonth.toISOString() })
+
+      const prisonerProfile = TestData.prisonerProfile({
+        visits: [visit1, visit2, visit3],
+      })
+
+      orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)
+      const results = await prisonerProfileService.getProfile(prisonId, prisonerId, 'user')
+
+      expect(results.visitsByMonth).toEqual(
+        new Map([
+          [nextMonthKey, { upcomingCount: 1, pastCount: 0, visits: [visit1] }],
+          [previousMonthKey, { upcomingCount: 0, pastCount: 1, visits: [visit2, visit3] }],
+        ]),
+      )
     })
 
     it('Filters active alerts that should be flagged', async () => {
@@ -348,58 +347,23 @@ describe('Prisoner profile service', () => {
         ],
       ]
 
-      const fullPrisoner = TestData.prisonerProfile({
+      const prisonerProfile = TestData.prisonerProfile({
         alerts: [inactiveAlert, nonRelevantAlert, ...alertsToFlag],
-        visits: [],
       })
 
-      fullPrisoner.alerts = [inactiveAlert, nonRelevantAlert, ...alertsToFlag]
+      prisonerProfile.alerts = [inactiveAlert, nonRelevantAlert, ...alertsToFlag]
 
-      orchestrationApiClient.getPrisonerProfile.mockResolvedValue(fullPrisoner)
+      orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)
 
       const results = await prisonerProfileService.getProfile(prisonId, prisonerId, 'user')
 
       expect(OrchestrationApiClientFactory).toHaveBeenCalledWith(token)
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith('user')
       expect(orchestrationApiClient.getPrisonerProfile).toHaveBeenCalledTimes(1)
-      expect(supportedPrisonsService.getSupportedPrisons).toHaveBeenCalledTimes(1)
 
-      expect(results).toEqual(<PrisonerProfilePage>{
-        activeAlerts: alertsForDisplay,
-        activeAlertCount: 4,
-        flaggedAlerts: alertsToFlag,
-        visits: [],
-        prisonerDetails: {
-          offenderNo: 'A1234BC',
-          name: 'Smith, John',
-          dob: '2 April 1975',
-          convictedStatus: 'Convicted',
-          category: 'Cat C',
-          location: '1-1-C-028',
-          prisonName: 'Hewell (HMP)',
-          incentiveLevel: 'Standard',
-          visitBalances: {
-            remainingVo: 1,
-            remainingPvo: 2,
-            latestIepAdjustDate: '21 April 2021',
-            latestPrivIepAdjustDate: '1 December 2021',
-          },
-        },
-      })
-    })
-
-    it.skip('Throws 404 if no bookings found for criteria', async () => {
-      // e.g. offenderNo doesn't exist - or not at specified prisonId
-      const bookings = <PagePrisonerBookingSummary>{
-        content: [],
-        numberOfElements: 0,
-      }
-
-      prisonApiClient.getBookings.mockResolvedValue(bookings)
-
-      await expect(async () => {
-        await prisonerProfileService.getProfile(prisonerId, prisonId, 'user')
-      }).rejects.toBeInstanceOf(NotFound)
+      expect(results.activeAlerts).toStrictEqual(alertsForDisplay)
+      expect(results.activeAlertCount).toBe(4)
+      expect(results.flaggedAlerts).toStrictEqual(alertsToFlag)
     })
   })
 

--- a/server/services/prisonerProfileService.test.ts
+++ b/server/services/prisonerProfileService.test.ts
@@ -46,6 +46,7 @@ describe('Prisoner profile service', () => {
     prisonerProfileService = new PrisonerProfileService(
       OrchestrationApiClientFactory,
       PrisonApiClientFactory,
+      PrisonerContactRegistryApiClientFactory,
       hmppsAuthClient,
     )
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
@@ -64,8 +65,10 @@ describe('Prisoner profile service', () => {
 
     it('should retrieve and process data for prisoner profile (with visit balances)', async () => {
       const prisonerProfile = TestData.prisonerProfile()
-
       orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)
+
+      const contacts = [TestData.contact(), TestData.contact({ personId: 4322, firstName: 'Bob' })]
+      prisonerContactRegistryApiClient.getPrisonerSocialContacts.mockResolvedValue(contacts)
 
       const results = await prisonerProfileService.getProfile(prisonId, prisonerId, 'user')
 
@@ -94,6 +97,7 @@ describe('Prisoner profile service', () => {
             latestPrivIepAdjustDate: '1 December 2021',
           },
         },
+        contactNames: { 4321: 'Jeanette Smith', 4322: 'Bob Smith' },
       })
     })
 
@@ -145,6 +149,8 @@ describe('Prisoner profile service', () => {
       })
 
       orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)
+      prisonerContactRegistryApiClient.getPrisonerSocialContacts.mockResolvedValue([])
+
       const results = await prisonerProfileService.getProfile(prisonId, prisonerId, 'user')
 
       expect(results.visitsByMonth).toEqual(
@@ -354,6 +360,7 @@ describe('Prisoner profile service', () => {
       prisonerProfile.alerts = [inactiveAlert, nonRelevantAlert, ...alertsToFlag]
 
       orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)
+      prisonerContactRegistryApiClient.getPrisonerSocialContacts.mockResolvedValue([])
 
       const results = await prisonerProfileService.getProfile(prisonId, prisonerId, 'user')
 

--- a/server/services/prisonerProfileService.ts
+++ b/server/services/prisonerProfileService.ts
@@ -24,7 +24,7 @@ export default class PrisonerProfileService {
   async getProfile(prisonId: string, prisonerId: string, username: string): Promise<PrisonerProfilePage> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
-    const fullPrisoner = await orchestrationApiClient.getPrisonerProfile(prisonId, prisonerId)
+    const prisonerProfile = await orchestrationApiClient.getPrisonerProfile(prisonId, prisonerId)
 
     // To remove when VB-2060 done - build list of contact IDs => contact name
     const prisonerContactRegistryApiClient = this.prisonerContactRegistryApiClientFactory(token)
@@ -34,7 +34,7 @@ export default class PrisonerProfileService {
       contactNames[contact.personId] = `${contact.firstName} ${contact.lastName}`
     })
 
-    const alerts = fullPrisoner.alerts || []
+    const alerts = prisonerProfile.alerts || []
     const activeAlerts: Alert[] = alerts.filter(alert => alert.active)
     const activeAlertCount = activeAlerts.length
     const flaggedAlerts: Alert[] = activeAlerts.filter(alert => this.alertCodesToFlag.includes(alert.alertCode))
@@ -81,7 +81,7 @@ export default class PrisonerProfileService {
     const visitsByMonth: PrisonerProfilePage['visitsByMonth'] = new Map()
     const now = new Date()
 
-    fullPrisoner.visits.forEach(visit => {
+    prisonerProfile.visits.forEach(visit => {
       const visitStartTime = new Date(visit.startTimestamp)
       const visitMonth = format(visitStartTime, 'MMMM yyyy') // e.g. 'May 2023'
 
@@ -102,15 +102,15 @@ export default class PrisonerProfileService {
     })
 
     const prisonerDetails: PrisonerDetails = {
-      offenderNo: fullPrisoner.prisonerId,
-      name: properCaseFullName(`${fullPrisoner.lastName}, ${fullPrisoner.firstName}`),
-      dob: prisonerDatePretty({ dateToFormat: fullPrisoner.dateOfBirth }),
-      convictedStatus: fullPrisoner.convictedStatus,
-      category: fullPrisoner.category,
-      location: fullPrisoner.cellLocation,
-      prisonName: fullPrisoner.prisonName,
-      incentiveLevel: fullPrisoner.incentiveLevel,
-      visitBalances: fullPrisoner.visitBalances,
+      offenderNo: prisonerProfile.prisonerId,
+      name: properCaseFullName(`${prisonerProfile.lastName}, ${prisonerProfile.firstName}`),
+      dob: prisonerDatePretty({ dateToFormat: prisonerProfile.dateOfBirth }),
+      convictedStatus: prisonerProfile.convictedStatus,
+      category: prisonerProfile.category,
+      location: prisonerProfile.cellLocation,
+      prisonName: prisonerProfile.prisonName,
+      incentiveLevel: prisonerProfile.incentiveLevel,
+      visitBalances: prisonerProfile.visitBalances,
     }
 
     if (prisonerDetails.visitBalances?.latestIepAdjustDate) {

--- a/server/services/testutils/mocks.ts
+++ b/server/services/testutils/mocks.ts
@@ -17,7 +17,7 @@ export const createMockAuditService = () => new AuditService(null, null, null, n
 export const createMockNotificationsService = () => new NotificationsService(null) as jest.Mocked<NotificationsService>
 
 export const createMockPrisonerProfileService = () =>
-  new PrisonerProfileService(null, null, null) as jest.Mocked<PrisonerProfileService>
+  new PrisonerProfileService(null, null, null, null) as jest.Mocked<PrisonerProfileService>
 
 export const createMockPrisonerSearchService = () =>
   new PrisonerSearchService(null, null) as jest.Mocked<PrisonerSearchService>

--- a/server/services/testutils/mocks.ts
+++ b/server/services/testutils/mocks.ts
@@ -17,7 +17,7 @@ export const createMockAuditService = () => new AuditService(null, null, null, n
 export const createMockNotificationsService = () => new NotificationsService(null) as jest.Mocked<NotificationsService>
 
 export const createMockPrisonerProfileService = () =>
-  new PrisonerProfileService(null, null, null, null, null, null, null) as jest.Mocked<PrisonerProfileService>
+  new PrisonerProfileService(null, null, null) as jest.Mocked<PrisonerProfileService>
 
 export const createMockPrisonerSearchService = () =>
   new PrisonerSearchService(null, null) as jest.Mocked<PrisonerSearchService>

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -117,19 +117,6 @@ const properCaseName = (name: string): string => (isBlank(name) ? '' : name.spli
 export const convertToTitleCase = (sentence: string): string =>
   isBlank(sentence) ? '' : sentence.split(' ').map(properCaseName).join(' ')
 
-export const visitDateAndTime = ({
-  startTimestamp,
-  endTimestamp,
-}: {
-  startTimestamp: string
-  endTimestamp: string
-}): string => {
-  const startTime = format(parseISO(startTimestamp), 'h:mmaaa')
-  const endTime = endTimestamp ? ` - ${format(parseISO(endTimestamp), 'h:mmaaa')}` : ''
-
-  return `${prisonerDateTimePretty(startTimestamp)}<br>${startTime}${endTime}`
-}
-
 export const nextIepAdjustDate = (latestIepAdjustDate: string): string => {
   return format(addDays(parseISO(latestIepAdjustDate), 14), 'd MMMM yyyy')
 }
@@ -183,27 +170,4 @@ export const getWeekOfDatesStartingMonday = (
   const nextWeek = format(addWeeks(weekStartDate, 1), dateFormat)
 
   return { weekOfDates, previousWeek, nextWeek }
-}
-
-export const longPrisonerDateTimePretty = (dateToFormat: string): string => {
-  return format(new Date(dateToFormat), 'EEEE d MMMM yyyy')
-}
-export const longVisitDateAndTime = ({
-  startTimestamp,
-  endTimestamp,
-}: {
-  startTimestamp: string
-  endTimestamp: string
-}): string => {
-  const startTime =
-    format(parseISO(startTimestamp), 'mm') === '00'
-      ? format(parseISO(startTimestamp), 'haaa')
-      : format(parseISO(startTimestamp), 'h:mmaaa')
-
-  const endTime =
-    format(parseISO(endTimestamp), 'mm') === '00'
-      ? format(parseISO(endTimestamp), 'haaa')
-      : format(parseISO(endTimestamp), 'h:mmaaa')
-
-  return `${longPrisonerDateTimePretty(startTimestamp)}<br>${startTime} - ${endTime}`
 }

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -120,6 +120,7 @@
 
         {% for month, data in visitsByMonth %}
 
+          {# Build month headings with visit counts - e.g. "January 2022 (1 upcoming visit, 1 past visit)" #}
           {% set upcomingCount %}{{ data.upcomingCount }} upcoming {{ "visit" | pluralise(data.upcomingCount) }}{% endset %}
           {% set pastCount %}{{ data.pastCount }} past {{ "visit" | pluralise(data.pastCount) }}{% endset %}
           {% set visitTotals %}
@@ -128,6 +129,7 @@
             {{- pastCount if data.pastCount -}}
           {% endset %}
 
+          {# Build rows for this month's visits table #}
           {% set visits = [] %}
           {% for visit in data.visits %}
 

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -114,36 +114,97 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+
     {% set visitsTab %}
-      <h2 class="govuk-heading-m">Visits</h2>
-      {% if visits | length %}
-        {{ govukTable({
-          head: [
-            {
-              text: "Visit reference"
-            },
-            {
-              text: "Visit type"
-            },
-            {
-              text: "Establishment"
-            },
-            {
-              text: "Date and time"
-            },
-            {
-              text: "Visitors"
-            },
-            {
-              text: "Visit status"
-            }
-          ],
-          rows: visits
-        }) }}
+      {% if visitsByMonth | length %}
+
+        {% for month, data in visitsByMonth %}
+
+          {% set upcomingCount %}{{ data.upcomingCount }} upcoming {{ "visit" | pluralise(data.upcomingCount) }}{% endset %}
+          {% set pastCount %}{{ data.pastCount }} past {{ "visit" | pluralise(data.pastCount) }}{% endset %}
+          {% set visitTotals %}
+            {{- upcomingCount if data.upcomingCount -}}
+            {{- ", " if data.upcomingCount and data.pastCount -}}
+            {{- pastCount if data.pastCount -}}
+          {% endset %}
+
+          {% set visits = [] %}
+          {% for visit in data.visits %}
+
+            {% set visitors = [] %}
+            {% for visitor in visit.visitors %}
+              {% set visitors = (visitors.push([visitor.nomisPersonId]), visitors) %}
+            {% endfor %}
+
+            {% set visits = (visits.push([
+              {
+                html: '<a href="/visit/' + visit.reference + '">' +  visit.reference + '</a>',
+                attributes: { "data-test": "tab-visits-reference" }
+              },
+              {
+                html: '<span>' + visit.visitType | capitalize + '<br>(' + visit.visitRestriction | capitalize + ')</span>',
+                attributes: { "data-test": "tab-visits-type" }
+              },
+              {
+                text: supportedPrisons[visit.prisonId],
+                attributes: { "data-test": "tab-visits-location" }
+              },
+              {
+                html: visit.startTimestamp | formatDate + '<br>' +
+                  visit.startTimestamp | formatTime + ' - ' + visit.endTimestamp | formatTime,
+                attributes: { "data-test": "tab-visits-date-and-time" }
+              },
+              {
+                text: visitors,
+                attributes: { "data-test": "tab-visits-visitors" }
+              },
+              {
+                text: visit.visitStatus | capitalize,
+                attributes: { "data-test": "tab-visits-status" }
+              }
+            ]), visits) %}
+          {% endfor %}
+
+          {{ govukTable({
+            caption: month + " (" + visitTotals + ")",
+            captionClasses: "govuk-table__caption--m",
+            head: [
+              {
+                text: "Visit reference"
+              },
+              {
+                text: "Visit type"
+              },
+              {
+                text: "Establishment"
+              },
+              {
+                text: "Date and time"
+              },
+              {
+                text: "Visitors"
+              },
+              {
+                text: "Visit status"
+              }
+            ],
+            rows: visits
+          }) }}
+        {% endfor %}
+
       {% else %}
-    <p>There are no visits for this prisoner.</p>
-    {% endif %}
+        <p>There are no visits for this prisoner.</p>
+      {% endif %}
+
+      {{ govukButton({
+        text: "View full visits history",
+        classes: "govuk-!-margin-top-3 govuk-button--secondary",
+        href: dpsHome + "prisoner/" + prisonerDetails.offenderNo + '/visits-details',
+        attributes: { "data-test": "view-dps-profile" },
+        preventDoubleClick: true
+      })}}
     {% endset %}
+
     {% set alertsTab %}
     <h2 class="govuk-heading-m">Active alerts</h2>
     {% if activeAlerts | length %}

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -168,6 +168,7 @@
           {{ govukTable({
             caption: month + " (" + visitTotals + ")",
             captionClasses: "govuk-table__caption--m",
+            classes: "prisoner-profile-visits",
             head: [
               {
                 text: "Visit reference"

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -133,7 +133,7 @@
 
             {% set visitors = [] %}
             {% for visitor in visit.visitors %}
-              {% set visitors = (visitors.push([visitor.nomisPersonId]), visitors) %}
+              {% set visitors = (visitors.push(contactNames[visitor.nomisPersonId]), visitors) %}
             {% endfor %}
 
             {% set visits = (visits.push([
@@ -155,7 +155,7 @@
                 attributes: { "data-test": "tab-visits-date-and-time" }
               },
               {
-                text: visitors,
+                html: visitors | join('<br>'),
                 attributes: { "data-test": "tab-visits-visitors" }
               },
               {


### PR DESCRIPTION
Change the Visits tab on the Prisoner profile page to show upcoming and past visits grouped by month with totals. E.g.

![Screenshot 2023-05-10 at 11 26 02](https://github.com/ministryofjustice/book-a-prison-visit-staff-ui/assets/1441286/b1d67e2e-4b17-4603-9ee5-3405518e36bb)

Only past visits from recent months (past 3 - controlled by orchestration service) are shown. Full history available by link button at the bottom to listing page within DPS.