### PR TITLE
VB-2061 Prisoner profile page Visits tab - update no visits message

### DIFF
--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -171,6 +171,20 @@ describe('GET /prisoner/A1234BC', () => {
       })
   })
 
+  it('should display message in the Visits tab when there are no upcoming or past visits', () => {
+    return request(app)
+      .get('/prisoner/A1234BC')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('h1').text().trim()).toBe('Smith, John')
+        expect($('#visits').text()).toContain(
+          'There are no upcoming visits or visits within the last 3 months for this prisoner.',
+        )
+      })
+  })
+
   it('should render the prisoner profile page for offender number A1234BC without active alerts if there are none', () => {
     prisonerProfile.flaggedAlerts = []
     prisonerProfile.activeAlerts = []

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -196,7 +196,7 @@
         {% endfor %}
 
       {% else %}
-        <p>There are no visits for this prisoner.</p>
+        <p>There are no upcoming visits or visits within the last 3 months for this prisoner.</p>
       {% endif %}
 
       {{ govukButton({


### PR DESCRIPTION
* Update the message in the Visits tab on prisoner profile page that is displayed when the prisoner has no upcoming or recent past visits
* Add a test to cover this scenario