### PR TITLE
VB-2198 update govuk frontend version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or, to start just Redis if using HMPPS Auth dev:
 
 `docker-compose up redis-bapv`
 
-Install dependencies using `npm install`, ensuring you are using >= `Node v16.x`
+Install dependencies using `npm install`, ensuring you are using >= `Node v18.x`
 
 Using your personal client credentials, create a `.env` local settings file
 ```bash

--- a/assets/js/voOverride.js
+++ b/assets/js/voOverride.js
@@ -3,15 +3,13 @@ const voOverride = document.querySelector('#vo-override')
 if (voOverride) {
   function setBookButtonState() {
     const bookButton = document.querySelector('.govuk-button')
-    
+
     if (voOverride.checked) {
       bookButton.removeAttribute('disabled')
       bookButton.removeAttribute('aria-disabled')
-      bookButton.classList.remove('govuk-button--disabled')
     } else {
       bookButton.setAttribute('disabled', '')
       bookButton.setAttribute('aria-disabled', 'true')
-      bookButton.classList.add('govuk-button--disabled')
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "express-validator": "^6.15.0",
-        "govuk-frontend": "^4.5.0",
+        "govuk-frontend": "^4.6.0",
         "helmet": "^6.1.5",
         "http-errors": "^2.0.0",
         "jquery": "^3.6.4",
@@ -8107,9 +8107,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
-      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
+      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "express-validator": "^6.15.0",
-    "govuk-frontend": "^4.5.0",
+    "govuk-frontend": "^4.6.0",
     "helmet": "^6.1.5",
     "http-errors": "^2.0.0",
     "jquery": "^3.6.4",

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -1,6 +1,5 @@
 import type { Request, Response } from 'express'
 import { body, ValidationChain, validationResult } from 'express-validator'
-import { v4 as uuidv4 } from 'uuid'
 import { VisitSlot } from '../../@types/bapv'
 import AuditService from '../../services/auditService'
 import VisitSessionsService from '../../services/visitSessionsService'
@@ -77,7 +76,6 @@ export default class DateAndTime {
     req.session.slotsList = slotsList
 
     res.render('pages/bookAVisit/dateAndTime', {
-      accordionId: uuidv4(),
       errors: req.flash('errors'),
       visitRestriction: visitSessionData.visitRestriction,
       prisonerName: visitSessionData.prisoner.name,

--- a/server/views/pages/bookAVisit/dateAndTime.njk
+++ b/server/views/pages/bookAVisit/dateAndTime.njk
@@ -192,7 +192,8 @@
       {% endfor -%}
 
       {{- govukAccordion({
-        id: "slots-month-" + (month | replace(" ", "")) + "-" + accordionId,
+        id: "slots-month-" + (month | replace(" ", "")),
+        rememberExpanded: false,
         headingLevel: 3,
         items: accordion
       }) }}

--- a/server/views/pages/bookAVisit/dateAndTime.test.ts
+++ b/server/views/pages/bookAVisit/dateAndTime.test.ts
@@ -30,7 +30,6 @@ describe('Views - Date and time of visit', () => {
 
   it('should display date and time picker for two months with morning and afternoon slots', () => {
     viewContext = {
-      accordionId: 'thisAccordion',
       prisonerName: 'John Smith',
       visitRestriction: 'OPEN',
       slotsList: <VisitSlotList>{
@@ -202,7 +201,6 @@ describe('Views - Date and time of visit', () => {
   describe('slot labelling', () => {
     beforeEach(() => {
       viewContext = {
-        accordionId: 'thisAccordion',
         prisonerName: 'John Smith',
         visitRestriction: 'OPEN',
         slotsList: <VisitSlotList>{

--- a/server/views/pages/bookAVisit/dateAndTime.test.ts
+++ b/server/views/pages/bookAVisit/dateAndTime.test.ts
@@ -155,8 +155,8 @@ describe('Views - Date and time of visit', () => {
     expect($('[data-test="closed-visit-reason"]').length).toBe(0)
 
     expect($('[data-test="month"]').eq(0).text()).toBe('February 2022')
-    expect($('#slots-month-February2022-thisAccordion-heading-1').text().trim()).toBe('Monday 14 February')
-    expect($('#slots-month-February2022-thisAccordion-content-1 h3').eq(0).text()).toBe('Morning')
+    expect($('#slots-month-February2022-heading-1').text().trim()).toBe('Monday 14 February')
+    expect($('#slots-month-February2022-content-1 h3').eq(0).text()).toBe('Morning')
     expect($('label[for="1"]').text()).toContain('10am to 11am')
     expect($('label[for="1"]').text()).toContain('15 tables available')
     expect($('label[for="2"]').text()).toContain('11:59am to 12:59pm')
@@ -164,16 +164,16 @@ describe('Views - Date and time of visit', () => {
     expect($('label[for="3"]').text()).toContain('12pm to 1:05pm')
     expect($('label[for="3"]').text()).toContain('Prisoner has a visit')
     expect($('#3').attr('disabled')).toBe('disabled')
-    expect($('#slots-month-February2022-thisAccordion-content-1 .bapv-afternoon-slots > h3').text()).toBe('Afternoon')
-    expect($('#slots-month-February2022-thisAccordion-heading-2').text().trim()).toBe('Tuesday 15 February')
+    expect($('#slots-month-February2022-content-1 .bapv-afternoon-slots > h3').text()).toBe('Afternoon')
+    expect($('#slots-month-February2022-heading-2').text().trim()).toBe('Tuesday 15 February')
     expect($('#4').prop('checked')).toBe(true)
     expect($('.govuk-accordion__section--expanded').length).toBe(1)
     expect($('.govuk-accordion__section--expanded #4').length).toBe(1)
 
     expect($('[data-test="month"]').eq(1).text()).toBe('March 2022')
-    expect($('#slots-month-March2022-thisAccordion-heading-1').text().trim()).toBe('Tuesday 1 March')
-    expect($('#slots-month-March2022-thisAccordion-content-1 .bapv-morning-slots > h3').text()).toBe('Morning')
-    expect($('#slots-month-March2022-thisAccordion-content-1 .bapv-afternoon-slots > h3').eq(1).length).toBe(0) // no afternoon slots
+    expect($('#slots-month-March2022-heading-1').text().trim()).toBe('Tuesday 1 March')
+    expect($('#slots-month-March2022-content-1 .bapv-morning-slots > h3').text()).toBe('Morning')
+    expect($('#slots-month-March2022-content-1 .bapv-afternoon-slots > h3').eq(1).length).toBe(0) // no afternoon slots
     expect($('label[for="5"]').text()).toContain('9:30am to 10:30am')
     expect($('label[for="5"]').text()).toContain('Fully booked (30 of 30 tables booked)')
     // correctly display overbooking


### PR DESCRIPTION
New version of [GOV.UK](http://gov.uk/) Frontend available: [Release GOV.UK Frontend v4.6.0 · alphagov/govuk-frontend](https://github.com/alphagov/govuk-frontend/releases/tag/v4.6.0)

- Updated library version.
- Book a visit: accordion internally improved, new property `rememberExpanded`