### PR TITLE
VB-1834: Move getSupportedPrisonIds() to orchestration API client

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         // Orchestration service
         stubVisitHistory: orchestrationService.stubVisitHistory,
         stubPrisonerProfile: orchestrationService.stubPrisonerProfile,
+        stubSupportedPrisonIds: orchestrationService.stubSupportedPrisonIds,
 
         // Prisoner contact registry
         stubPrisonerSocialContacts: prisonerContactRegistry.stubPrisonerSocialContacts,
@@ -57,7 +58,6 @@ export default defineConfig({
         stubBookVisit: visitScheduler.stubBookVisit,
         stubCancelVisit: visitScheduler.stubCancelVisit,
         stubChangeReservedSlot: visitScheduler.stubChangeReservedSlot,
-        stubSupportedPrisonIds: visitScheduler.stubSupportedPrisonIds,
         stubUpcomingVisits: visitScheduler.stubUpcomingVisits,
         stubPastVisits: visitScheduler.stubPastVisits,
         stubReserveVisit: visitScheduler.stubReserveVisit,

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -1,6 +1,7 @@
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 import { PrisonerProfile, VisitHistoryDetails } from '../../server/data/orchestrationApiTypes'
+import TestData from '../../server/routes/testutils/testData'
 
 export default {
   stubVisitHistory: (visitHistoryDetails: VisitHistoryDetails): SuperAgentRequest => {
@@ -34,6 +35,19 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: profile,
+      },
+    })
+  },
+  stubSupportedPrisonIds: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        url: '/orchestration/config/prisons/supported',
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: TestData.supportedPrisonIds(),
       },
     })
   },

--- a/integration_tests/mockApis/visitScheduler.ts
+++ b/integration_tests/mockApis/visitScheduler.ts
@@ -83,19 +83,6 @@ export default {
       },
     })
   },
-  stubSupportedPrisonIds: (): SuperAgentRequest => {
-    return stubFor({
-      request: {
-        method: 'GET',
-        url: '/visitScheduler/config/prisons/supported',
-      },
-      response: {
-        status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: TestData.supportedPrisonIds(),
-      },
-    })
-  },
   stubUpcomingVisits: ({
     offenderNo,
     upcomingVisits,

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -52,4 +52,19 @@ describe('orchestrationApiClient', () => {
       expect(output).toEqual(prisonerProfile)
     })
   })
+
+  describe('getSupportedPrisonIds', () => {
+    it('should return an array of supported prison IDs', async () => {
+      const results = ['HEI', 'BLI']
+
+      fakeOrchestrationApi
+        .get('/config/prisons/supported')
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, results)
+
+      const output = await orchestrationApiClient.getSupportedPrisonIds()
+
+      expect(output).toEqual(results)
+    })
+  })
 })

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -9,11 +9,22 @@ export default class OrchestrationApiClient {
     this.restClient = new RestClient('orchestrationApiClient', config.apis.orchestration as ApiConfig, token)
   }
 
+  // orchestration-visits-controller
+
   async getVisitHistory(reference: string): Promise<VisitHistoryDetails> {
     return this.restClient.get({ path: `/visits/${reference}/history` })
   }
 
+  // prisoner-profile-controller
+
   async getPrisonerProfile(prisonId: string, prisonerId: string): Promise<PrisonerProfile> {
     return this.restClient.get({ path: `/prisoner/${prisonId}/${prisonerId}/profile` })
+  }
+
+  // orchestration-prisons-config-controller
+  async getSupportedPrisonIds(): Promise<string[]> {
+    return this.restClient.get({
+      path: '/config/prisons/supported',
+    })
   }
 }

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -33,21 +33,6 @@ describe('visitSchedulerApiClient', () => {
     nock.cleanAll()
   })
 
-  describe('getSupportedPrisonIds', () => {
-    it('should return an array of supported prison IDs', async () => {
-      const results = ['HEI', 'BLI']
-
-      fakeVisitSchedulerApi
-        .get('/config/prisons/supported')
-        .matchHeader('authorization', `Bearer ${token}`)
-        .reply(200, results)
-
-      const output = await visitSchedulerApiClient.getSupportedPrisonIds()
-
-      expect(output).toEqual(results)
-    })
-  })
-
   describe('getAvailableSupportOptions', () => {
     it('should return an array of available support types', async () => {
       const results = TestData.supportTypes()

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -28,12 +28,6 @@ export default class VisitSchedulerApiClient {
 
   private size = '1000'
 
-  async getSupportedPrisonIds(): Promise<string[]> {
-    return this.restClient.get({
-      path: '/config/prisons/supported',
-    })
-  }
-
   async getAvailableSupportOptions(): Promise<SupportType[]> {
     return this.restClient.get({
       path: '/visit-support',

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -27,7 +27,7 @@ export const services = () => {
   const notificationsService = new NotificationsService(notificationsApiClientBuilder)
 
   const supportedPrisonsService = new SupportedPrisonsService(
-    visitSchedulerApiClientBuilder,
+    orchestrationApiClientBuilder,
     prisonRegisterApiClientBuilder,
     hmppsAuthClient,
   )

--- a/server/services/supportedPrisonsService.test.ts
+++ b/server/services/supportedPrisonsService.test.ts
@@ -3,31 +3,31 @@ import TestData from '../routes/testutils/testData'
 import { PrisonDto } from '../data/prisonRegisterApiTypes'
 import {
   createMockHmppsAuthClient,
+  createMockOrchestrationApiClient,
   createMockPrisonRegisterApiClient,
-  createMockVisitSchedulerApiClient,
 } from '../data/testutils/mocks'
 
 const token = 'some token'
 
 describe('Supported prisons service', () => {
   const hmppsAuthClient = createMockHmppsAuthClient()
+  const orchestrationApiClient = createMockOrchestrationApiClient()
   const prisonRegisterApiClient = createMockPrisonRegisterApiClient()
-  const visitSchedulerApiClient = createMockVisitSchedulerApiClient()
 
   let supportedPrisonsService: SupportedPrisonsService
 
+  const OrchestrationApiClientFactory = jest.fn()
   const PrisonRegisterApiClientFactory = jest.fn()
-  const VisitSchedulerApiClientFactory = jest.fn()
 
   const allPrisons = TestData.prisons()
   const supportedPrisons = TestData.supportedPrisons()
   const supportedPrisonIds = TestData.supportedPrisonIds()
 
   beforeEach(() => {
+    OrchestrationApiClientFactory.mockReturnValue(orchestrationApiClient)
     PrisonRegisterApiClientFactory.mockReturnValue(prisonRegisterApiClient)
-    VisitSchedulerApiClientFactory.mockReturnValue(visitSchedulerApiClient)
     supportedPrisonsService = new SupportedPrisonsService(
-      VisitSchedulerApiClientFactory,
+      OrchestrationApiClientFactory,
       PrisonRegisterApiClientFactory,
       hmppsAuthClient,
     )
@@ -42,7 +42,7 @@ describe('Supported prisons service', () => {
 
   describe('getSupportedPrisons', () => {
     it('should return an object with key/values of supported prison IDs and names', async () => {
-      visitSchedulerApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
+      orchestrationApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
 
       const results = await supportedPrisonsService.getSupportedPrisons('user')
 
@@ -50,7 +50,7 @@ describe('Supported prisons service', () => {
     })
 
     it('should ignore an unknown prison ID', async () => {
-      visitSchedulerApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds.concat(['XYZ']))
+      orchestrationApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds.concat(['XYZ']))
 
       const results = await supportedPrisonsService.getSupportedPrisons('user')
 
@@ -60,18 +60,18 @@ describe('Supported prisons service', () => {
 
   describe('getSupportedPrisonIds', () => {
     it('should return an array of supported prison IDs', async () => {
-      visitSchedulerApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
+      orchestrationApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
 
       const results = await supportedPrisonsService.getSupportedPrisonIds('user')
 
-      expect(visitSchedulerApiClient.getSupportedPrisonIds).toHaveBeenCalledTimes(1)
+      expect(orchestrationApiClient.getSupportedPrisonIds).toHaveBeenCalledTimes(1)
       expect(results).toStrictEqual(supportedPrisonIds)
     })
   })
 
   describe('API response caching', () => {
     beforeEach(() => {
-      visitSchedulerApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
+      orchestrationApiClient.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
     })
 
     it('should call API to get all prisons once then use internal cache for subsequent calls', async () => {

--- a/server/services/supportedPrisonsService.ts
+++ b/server/services/supportedPrisonsService.ts
@@ -1,11 +1,11 @@
 import { Prison } from '../@types/bapv'
-import { HmppsAuthClient, PrisonRegisterApiClient, RestClientBuilder, VisitSchedulerApiClient } from '../data'
+import { HmppsAuthClient, OrchestrationApiClient, PrisonRegisterApiClient, RestClientBuilder } from '../data'
 
 const A_DAY_IN_MS = 24 * 60 * 60 * 1000
 
 export default class SupportedPrisonsService {
   constructor(
-    private readonly visitSchedulerApiClientFactory: RestClientBuilder<VisitSchedulerApiClient>,
+    private readonly orchestrationApiClientFactory: RestClientBuilder<OrchestrationApiClient>,
     private readonly prisonRegisterApiClientFactory: RestClientBuilder<PrisonRegisterApiClient>,
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
@@ -32,8 +32,8 @@ export default class SupportedPrisonsService {
 
   async getSupportedPrisonIds(username: string): Promise<string[]> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
-    const visitSchedulerApiClient = this.visitSchedulerApiClientFactory(token)
-    return visitSchedulerApiClient.getSupportedPrisonIds()
+    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
+    return orchestrationApiClient.getSupportedPrisonIds()
   }
 
   private async refreshAllPrisons(username: string): Promise<void> {


### PR DESCRIPTION
Part of refactoring from using visit scheduler to orchestration service.

* Move `getSupportedPrisonIds()` to `orchestrationApiClient`