### PR TITLE
VB-1834 Move additional support to new service

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -32,9 +32,10 @@ export default defineConfig({
         ...tokenVerification,
 
         // Orchestration service
-        stubVisitHistory: orchestrationService.stubVisitHistory,
+        stubAvailableSupport: orchestrationService.stubAvailableSupport,
         stubPrisonerProfile: orchestrationService.stubPrisonerProfile,
         stubSupportedPrisonIds: orchestrationService.stubSupportedPrisonIds,
+        stubVisitHistory: orchestrationService.stubVisitHistory,
 
         // Prisoner contact registry
         stubPrisonerSocialContacts: prisonerContactRegistry.stubPrisonerSocialContacts,
@@ -54,7 +55,6 @@ export default defineConfig({
         stubPrisons: prisonRegister.stubPrisons,
 
         // Visit scheduler
-        stubAvailableSupport: visitScheduler.stubAvailableSupport,
         stubBookVisit: visitScheduler.stubBookVisit,
         stubCancelVisit: visitScheduler.stubCancelVisit,
         stubChangeReservedSlot: visitScheduler.stubChangeReservedSlot,

--- a/integration_tests/integration/bookAVisit.cy.ts
+++ b/integration_tests/integration/bookAVisit.cy.ts
@@ -96,6 +96,7 @@ context('Book a visit', () => {
 
     const { prisonerId } = profile
     // Prisoner profile page
+    cy.task('stubPrisonerSocialContacts', { offenderNo, contacts })
     cy.task('stubPrisonerProfile', { prisonId, prisonerId, profile })
 
     searchForAPrisonerResultsPage.firstResultLink().contains(prisonerDisplayName).click()
@@ -104,7 +105,6 @@ context('Book a visit', () => {
     // Select visitors
     const offenderRestrictions = [TestData.offenderRestriction()]
     cy.task('stubOffenderRestrictions', { offenderNo, offenderRestrictions })
-    cy.task('stubPrisonerSocialContacts', { offenderNo, contacts })
     prisonerProfilePage.bookAVisitButton().click()
     const selectVisitorsPage = Page.verifyOnPage(SelectVisitorsPage)
     selectVisitorsPage.getPrisonerRestrictionType(1).contains(offenderRestrictions[0].restrictionTypeDescription)

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -51,4 +51,17 @@ export default {
       },
     })
   },
+  stubAvailableSupport: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        url: '/orchestration/visit-support',
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: TestData.supportTypes(),
+      },
+    })
+  },
 }

--- a/integration_tests/mockApis/visitScheduler.ts
+++ b/integration_tests/mockApis/visitScheduler.ts
@@ -7,22 +7,8 @@ import {
   Visit,
   VisitSession,
 } from '../../server/data/orchestrationApiTypes'
-import TestData from '../../server/routes/testutils/testData'
 
 export default {
-  stubAvailableSupport: (): SuperAgentRequest => {
-    return stubFor({
-      request: {
-        method: 'GET',
-        url: '/visitScheduler/visit-support',
-      },
-      response: {
-        status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: TestData.supportTypes(),
-      },
-    })
-  },
   stubBookVisit: (visit: Visit): SuperAgentRequest => {
     return stubFor({
       request: {

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -37,6 +37,18 @@ describe('orchestrationApiClient', () => {
     })
   })
 
+  describe('getAvailableSupportOptions', () => {
+    it('should return an array of available support types', async () => {
+      const results = TestData.supportTypes()
+
+      fakeOrchestrationApi.get('/visit-support').matchHeader('authorization', `Bearer ${token}`).reply(200, results)
+
+      const output = await orchestrationApiClient.getAvailableSupportOptions()
+
+      expect(output).toEqual(results)
+    })
+  })
+
   describe('getPrisonerProfile', () => {
     it('should return prisoner profile page for selected prisoner', async () => {
       const prisonerProfile = TestData.prisonerProfile()

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -1,6 +1,6 @@
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
-import { PrisonerProfile, VisitHistoryDetails } from './orchestrationApiTypes'
+import { PrisonerProfile, SupportType, VisitHistoryDetails } from './orchestrationApiTypes'
 
 export default class OrchestrationApiClient {
   private restClient: RestClient
@@ -13,6 +13,12 @@ export default class OrchestrationApiClient {
 
   async getVisitHistory(reference: string): Promise<VisitHistoryDetails> {
     return this.restClient.get({ path: `/visits/${reference}/history` })
+  }
+
+  async getAvailableSupportOptions(): Promise<SupportType[]> {
+    return this.restClient.get({
+      path: '/visit-support',
+    })
   }
 
   // prisoner-profile-controller

--- a/server/data/visitSchedulerApiClient.test.ts
+++ b/server/data/visitSchedulerApiClient.test.ts
@@ -33,18 +33,6 @@ describe('visitSchedulerApiClient', () => {
     nock.cleanAll()
   })
 
-  describe('getAvailableSupportOptions', () => {
-    it('should return an array of available support types', async () => {
-      const results = TestData.supportTypes()
-
-      fakeVisitSchedulerApi.get('/visit-support').matchHeader('authorization', `Bearer ${token}`).reply(200, results)
-
-      const output = await visitSchedulerApiClient.getAvailableSupportOptions()
-
-      expect(output).toEqual(results)
-    })
-  })
-
   describe('getVisit', () => {
     it('should return a single matching Visit from the Visit Scheduler API for a valid reference', async () => {
       const reference = 'ab-cd-ef-gh'

--- a/server/data/visitSchedulerApiClient.ts
+++ b/server/data/visitSchedulerApiClient.ts
@@ -1,7 +1,6 @@
 import { URLSearchParams } from 'url'
 import RestClient from './restClient'
 import {
-  SupportType,
   Visit,
   VisitSession,
   OutcomeDto,
@@ -27,12 +26,6 @@ export default class VisitSchedulerApiClient {
   private page = '0'
 
   private size = '1000'
-
-  async getAvailableSupportOptions(): Promise<SupportType[]> {
-    return this.restClient.get({
-      path: '/visit-support',
-    })
-  }
 
   async getVisit(reference: string): Promise<Visit> {
     return this.restClient.get({ path: `/visits/${reference}` })

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -11,6 +11,7 @@ import MainContact from './visitJourney/mainContact'
 import type { Services } from '../services'
 
 export default function routes({
+  additionalSupportService,
   auditService,
   notificationsService,
   prisonerProfileService,
@@ -33,7 +34,7 @@ export default function routes({
 
   const selectVisitors = new SelectVisitors('book', prisonerVisitorsService, prisonerProfileService)
   const visitType = new VisitType('book', auditService)
-  const additionalSupport = new AdditionalSupport('book', visitSessionsService)
+  const additionalSupport = new AdditionalSupport('book', additionalSupportService)
   const dateAndTime = new DateAndTime('book', visitSessionsService, auditService)
   const mainContact = new MainContact('book')
   const checkYourBooking = new CheckYourBooking('book', visitSessionsService, auditService, notificationsService)

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -24,6 +24,7 @@ import getPrisonConfiguration from '../constants/prisonConfiguration'
 import type { Services } from '../services'
 
 export default function routes({
+  additionalSupportService,
   auditService,
   notificationsService,
   prisonerProfileService,
@@ -177,7 +178,7 @@ export default function routes({
   const selectVisitors = new SelectVisitors('update', prisonerVisitorsService, prisonerProfileService)
   const visitType = new VisitType('update', auditService)
   const dateAndTime = new DateAndTime('update', visitSessionsService, auditService)
-  const additionalSupport = new AdditionalSupport('update', visitSessionsService)
+  const additionalSupport = new AdditionalSupport('update', additionalSupportService)
   const mainContact = new MainContact('update')
   const checkYourBooking = new CheckYourBooking('update', visitSessionsService, auditService, notificationsService)
   const confirmation = new Confirmation('update')

--- a/server/routes/visitJourney/additionalSupport.ts
+++ b/server/routes/visitJourney/additionalSupport.ts
@@ -1,12 +1,12 @@
 import { Request, Response } from 'express'
 import { body, ValidationChain, validationResult } from 'express-validator'
 import { SupportType, VisitorSupport } from '../../data/orchestrationApiTypes'
-import VisitSessionsService from '../../services/visitSessionsService'
 import { getFlashFormValues } from '../visitorUtils'
 import getUrlPrefix from './visitJourneyUtils'
+import { AdditionalSupportService } from '../../services'
 
 export default class AdditionalSupport {
-  constructor(private readonly mode: string, private readonly visitSessionsService: VisitSessionsService) {}
+  constructor(private readonly mode: string, private readonly additionalSupportService: AdditionalSupportService) {}
 
   async get(req: Request, res: Response): Promise<void> {
     const isUpdate = this.mode === 'update'
@@ -14,7 +14,7 @@ export default class AdditionalSupport {
     const formValues = getFlashFormValues(req)
 
     if (!req.session.availableSupportTypes) {
-      req.session.availableSupportTypes = await this.visitSessionsService.getAvailableSupportOptions(
+      req.session.availableSupportTypes = await this.additionalSupportService.getAvailableSupportOptions(
         res.locals.user.username,
       )
     }

--- a/server/services/additionalSupportService.test.ts
+++ b/server/services/additionalSupportService.test.ts
@@ -1,0 +1,38 @@
+import TestData from '../routes/testutils/testData'
+import { createMockHmppsAuthClient, createMockOrchestrationApiClient } from '../data/testutils/mocks'
+import AdditionalSupportService from './additionalSupportService'
+
+const token = 'some token'
+
+describe('Additional support service', () => {
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const orchestrationApiClient = createMockOrchestrationApiClient()
+
+  let additionalSupportService: AdditionalSupportService
+
+  const OrchestrationApiClientFactory = jest.fn()
+
+  const availableSupportTypes = TestData.supportTypes()
+
+  beforeEach(() => {
+    OrchestrationApiClientFactory.mockReturnValue(orchestrationApiClient)
+    additionalSupportService = new AdditionalSupportService(OrchestrationApiClientFactory, hmppsAuthClient)
+
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('getAdditionalSupportOptions', () => {
+    it('should return an array of available support options', async () => {
+      orchestrationApiClient.getAvailableSupportOptions.mockResolvedValue(availableSupportTypes)
+
+      const results = await additionalSupportService.getAvailableSupportOptions('user')
+
+      expect(orchestrationApiClient.getAvailableSupportOptions).toHaveBeenCalledTimes(1)
+      expect(results).toEqual(availableSupportTypes)
+    })
+  })
+})

--- a/server/services/additionalSupportService.ts
+++ b/server/services/additionalSupportService.ts
@@ -1,0 +1,15 @@
+import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
+import { SupportType } from '../data/orchestrationApiTypes'
+
+export default class AdditionalSupportService {
+  constructor(
+    private readonly orchestrationApiClientFactory: RestClientBuilder<OrchestrationApiClient>,
+    private readonly hmppsAuthClient: HmppsAuthClient,
+  ) {}
+
+  async getAvailableSupportOptions(username: string): Promise<SupportType[]> {
+    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
+    return orchestrationApiClient.getAvailableSupportOptions()
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,4 +1,5 @@
 import { dataAccess } from '../data'
+import AdditionalSupportService from './additionalSupportService'
 import AuditService from './auditService'
 import NotificationsService from './notificationsService'
 import PrisonerProfileService from './prisonerProfileService'
@@ -21,6 +22,8 @@ export const services = () => {
     visitSchedulerApiClientBuilder,
     whereaboutsApiClientBuilder,
   } = dataAccess()
+
+  const additionalSupportService = new AdditionalSupportService(orchestrationApiClientBuilder, hmppsAuthClient)
 
   const auditService = new AuditService()
 
@@ -55,11 +58,12 @@ export const services = () => {
   const visitService = new VisitService(
     orchestrationApiClientBuilder,
     prisonerContactRegistryApiClientBuilder,
-    visitSessionsService,
+    additionalSupportService,
     hmppsAuthClient,
   )
 
   return {
+    additionalSupportService,
     auditService,
     notificationsService,
     prisonerProfileService,
@@ -75,6 +79,7 @@ export const services = () => {
 export type Services = ReturnType<typeof services>
 
 export {
+  AdditionalSupportService,
   AuditService,
   NotificationsService,
   PrisonerProfileService,

--- a/server/services/testutils/mocks.ts
+++ b/server/services/testutils/mocks.ts
@@ -1,4 +1,5 @@
 import {
+  AdditionalSupportService,
   AuditService,
   NotificationsService,
   PrisonerProfileService,
@@ -11,6 +12,9 @@ import {
 } from '..'
 
 jest.mock('..')
+
+export const createMockAdditionalSupportService = () =>
+  new AdditionalSupportService(null, null) as jest.Mocked<AdditionalSupportService>
 
 export const createMockAuditService = () => new AuditService(null, null, null, null) as jest.Mocked<AuditService>
 

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -7,7 +7,7 @@ import {
   createMockOrchestrationApiClient,
   createMockPrisonerContactRegistryApiClient,
 } from '../data/testutils/mocks'
-import { createMockVisitSessionsService } from './testutils/mocks'
+import { createMockAdditionalSupportService } from './testutils/mocks'
 
 const token = 'some token'
 
@@ -15,7 +15,7 @@ describe('Visit service', () => {
   const hmppsAuthClient = createMockHmppsAuthClient()
   const orchestrationApiClient = createMockOrchestrationApiClient()
   const prisonerContactRegistryApiClient = createMockPrisonerContactRegistryApiClient()
-  const visitSessionsService = createMockVisitSessionsService()
+  const additionalSupportService = createMockAdditionalSupportService()
 
   let visitService: VisitService
 
@@ -31,7 +31,7 @@ describe('Visit service', () => {
     visitService = new VisitService(
       OrchestrationApiClientFactory,
       PrisonerContactRegistryApiClientFactory,
-      visitSessionsService,
+      additionalSupportService,
       hmppsAuthClient,
     )
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
@@ -96,13 +96,13 @@ describe('Visit service', () => {
         }
 
         prisonerContactRegistryApiClient.getPrisonerSocialContacts.mockResolvedValue(contacts)
-        visitSessionsService.getAvailableSupportOptions.mockResolvedValue(availableSupportTypes)
+        additionalSupportService.getAvailableSupportOptions.mockResolvedValue(availableSupportTypes)
         orchestrationApiClient.getVisitHistory.mockResolvedValue(visitHistoryDetails)
 
         const result = await visitService.getFullVisitDetails({ username: 'user', reference: 'ab-cd-ef-gh' })
 
         expect(prisonerContactRegistryApiClient.getPrisonerSocialContacts).toHaveBeenCalledTimes(1)
-        expect(visitSessionsService.getAvailableSupportOptions).toHaveBeenCalledTimes(1)
+        expect(additionalSupportService.getAvailableSupportOptions).toHaveBeenCalledTimes(1)
         expect(orchestrationApiClient.getVisitHistory).toHaveBeenCalledTimes(1)
         expect(result).toEqual(expectedResult)
       })

--- a/server/services/visitService.ts
+++ b/server/services/visitService.ts
@@ -3,13 +3,13 @@ import { VisitHistoryDetails } from '../data/orchestrationApiTypes'
 import buildVisitorListItem from '../utils/visitorUtils'
 import { getSupportTypeDescriptions } from '../routes/visitorUtils'
 import { HmppsAuthClient, OrchestrationApiClient, PrisonerContactRegistryApiClient, RestClientBuilder } from '../data'
-import VisitSessionsService from './visitSessionsService'
+import AdditionalSupportService from './additionalSupportService'
 
 export default class VisitService {
   constructor(
     private readonly orchestrationApiClientFactory: RestClientBuilder<OrchestrationApiClient>,
     private readonly prisonerContactRegistryApiClientFactory: RestClientBuilder<PrisonerContactRegistryApiClient>,
-    private readonly visitSessionsService: VisitSessionsService,
+    private readonly additionalSupportService: AdditionalSupportService,
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
 
@@ -34,7 +34,7 @@ export default class VisitService {
       .map(contact => buildVisitorListItem(contact))
 
     const additionalSupport = getSupportTypeDescriptions(
-      await this.visitSessionsService.getAvailableSupportOptions(username),
+      await this.additionalSupportService.getAvailableSupportOptions(username),
       visit.visitorSupport,
     )
 

--- a/server/services/visitSessionsService.test.ts
+++ b/server/services/visitSessionsService.test.ts
@@ -33,7 +33,6 @@ describe('Visit sessions service', () => {
   const WhereaboutsApiClientFactory = jest.fn()
 
   const prisonId = 'HEI'
-  const availableSupportTypes = TestData.supportTypes()
 
   beforeEach(() => {
     PrisonerContactRegistryApiClientFactory.mockReturnValue(prisonerContactRegistryApiClient)
@@ -51,17 +50,6 @@ describe('Visit sessions service', () => {
 
   afterEach(() => {
     jest.resetAllMocks()
-  })
-
-  describe('getAdditionalSupportOptions', () => {
-    it('should return an array of available support options', async () => {
-      visitSchedulerApiClient.getAvailableSupportOptions.mockResolvedValue(availableSupportTypes)
-
-      const results = await visitSessionsService.getAvailableSupportOptions('user')
-
-      expect(visitSchedulerApiClient.getAvailableSupportOptions).toHaveBeenCalledTimes(1)
-      expect(results).toEqual(availableSupportTypes)
-    })
   })
 
   describe('getVisitSessions', () => {

--- a/server/services/visitSessionsService.ts
+++ b/server/services/visitSessionsService.ts
@@ -10,14 +10,7 @@ import {
   VisitSessionData,
   VisitsPageSlot,
 } from '../@types/bapv'
-import {
-  VisitSession,
-  Visit,
-  SupportType,
-  OutcomeDto,
-  SessionCapacity,
-  SessionSchedule,
-} from '../data/orchestrationApiTypes'
+import { VisitSession, Visit, OutcomeDto, SessionCapacity, SessionSchedule } from '../data/orchestrationApiTypes'
 import { ScheduledEvent } from '../data/whereaboutsApiTypes'
 import { prisonerDateTimePretty, prisonerTimePretty } from '../utils/utils'
 import buildVisitorListItem from '../utils/visitorUtils'
@@ -39,12 +32,6 @@ export default class VisitSessionsService {
     private readonly whereaboutsApiClientFactory: RestClientBuilder<WhereaboutsApiClient>,
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
-
-  async getAvailableSupportOptions(username: string): Promise<SupportType[]> {
-    const token = await this.hmppsAuthClient.getSystemClientToken(username)
-    const visitSchedulerApiClient = this.visitSchedulerApiClientFactory(token)
-    return visitSchedulerApiClient.getAvailableSupportOptions()
-  }
 
   async getVisitSessions({
     username,


### PR DESCRIPTION
Part of refactoring from using visit scheduler to orchestration service.

* Move `getAvailableSupportOptions()` API call to `orchestrationApiClient`
* Move `getAvailableSupportOptions()` from `VisitSessionsService` to a new `AdditionalSupportService`