### PR TITLE
VB-2125, added no approved/permitted warning message

### DIFF
--- a/server/routes/visitJourney/selectVisitors.test.ts
+++ b/server/routes/visitJourney/selectVisitors.test.ts
@@ -384,6 +384,7 @@ testJourneys.forEach(journey => {
           expect($('input[name="visitors"]').length).toBe(1)
           expect($('[data-test="submit"]').length).toBe(0)
           expect($('[data-test="back-to-start"]').length).toBe(1)
+          expect($('#visitor-4324').attr('disabled')).toBe('disabled')
           expect($('.govuk-warning-text__text').text()).toContain('There are no')
           expect($('.govuk-warning-text__text').text()).toContain('approved')
           expect($('.govuk-warning-text__text').text()).toContain(
@@ -395,7 +396,7 @@ testJourneys.forEach(journey => {
     it('should show back to start button and warning message if only banned visitors listed', () => {
       returnData = [
         {
-          personId: 4324,
+          personId: 3984,
           name: 'John Smith',
           dateOfBirth: '2000-03-02',
           adult: true,
@@ -417,6 +418,7 @@ testJourneys.forEach(journey => {
           expect($('input[name="visitors"]').length).toBe(1)
           expect($('[data-test="submit"]').length).toBe(0)
           expect($('[data-test="back-to-start"]').length).toBe(1)
+          expect($('#visitor-3984').attr('disabled')).toBe('disabled')
           expect($('.govuk-warning-text__text').text()).toContain('There are no')
           expect($('.govuk-warning-text__text').text()).toContain('permitted')
           expect($('.govuk-warning-text__text').text()).toContain(

--- a/server/routes/visitJourney/selectVisitors.test.ts
+++ b/server/routes/visitJourney/selectVisitors.test.ts
@@ -388,7 +388,7 @@ testJourneys.forEach(journey => {
           expect($('.govuk-warning-text__text').text()).toContain('There are no')
           expect($('.govuk-warning-text__text').text()).toContain('approved')
           expect($('.govuk-warning-text__text').text()).toContain(
-            'visitors over 18 for this prisoner. A booking cannot be made at this time',
+            'visitors over 18 for this prisoner. A booking cannot be made at this time.',
           )
         })
     })
@@ -422,7 +422,7 @@ testJourneys.forEach(journey => {
           expect($('.govuk-warning-text__text').text()).toContain('There are no')
           expect($('.govuk-warning-text__text').text()).toContain('permitted')
           expect($('.govuk-warning-text__text').text()).toContain(
-            'visitors over 18 for this prisoner. A booking cannot be made at this time',
+            'visitors over 18 for this prisoner. A booking cannot be made at this time.',
           )
         })
     })

--- a/server/routes/visitJourney/selectVisitors.test.ts
+++ b/server/routes/visitJourney/selectVisitors.test.ts
@@ -385,10 +385,8 @@ testJourneys.forEach(journey => {
           expect($('[data-test="submit"]').length).toBe(0)
           expect($('[data-test="back-to-start"]').length).toBe(1)
           expect($('#visitor-4324').attr('disabled')).toBe('disabled')
-          expect($('.govuk-warning-text__text').text()).toContain('There are no')
-          expect($('.govuk-warning-text__text').text()).toContain('approved')
-          expect($('.govuk-warning-text__text').text()).toContain(
-            'visitors over 18 for this prisoner. A booking cannot be made at this time.',
+          expect($('.govuk-warning-text__text').text().replace(/\s+/g, ' ')).toContain(
+            'There are no approved visitors over 18 for this prisoner. A booking cannot be made at this time.',
           )
         })
     })
@@ -419,10 +417,8 @@ testJourneys.forEach(journey => {
           expect($('[data-test="submit"]').length).toBe(0)
           expect($('[data-test="back-to-start"]').length).toBe(1)
           expect($('#visitor-3984').attr('disabled')).toBe('disabled')
-          expect($('.govuk-warning-text__text').text()).toContain('There are no')
-          expect($('.govuk-warning-text__text').text()).toContain('permitted')
-          expect($('.govuk-warning-text__text').text()).toContain(
-            'visitors over 18 for this prisoner. A booking cannot be made at this time.',
+          expect($('.govuk-warning-text__text').text().replace(/\s+/g, ' ')).toContain(
+            'There are no permitted visitors over 18 for this prisoner. A booking cannot be made at this time.',
           )
         })
     })

--- a/server/routes/visitJourney/selectVisitors.test.ts
+++ b/server/routes/visitJourney/selectVisitors.test.ts
@@ -359,24 +359,8 @@ testJourneys.forEach(journey => {
         })
     })
 
-    it('should show back to start rather than continue button if only child or banned visitors listed', () => {
+    it('should show back to start button and warning message if only child visitors listed', () => {
       returnData = [
-        {
-          personId: 4322,
-          name: 'Bob Smith',
-          dateOfBirth: undefined,
-          adult: undefined,
-          relationshipDescription: 'Brother',
-          address: '1st listed address',
-          restrictions: [
-            {
-              restrictionType: 'BAN',
-              restrictionTypeDescription: 'Banned',
-              startDate: '2022-01-01',
-            },
-          ],
-          banned: true,
-        },
         {
           personId: 4324,
           name: 'Anne Smith',
@@ -397,9 +381,47 @@ testJourneys.forEach(journey => {
           const $ = cheerio.load(res.text)
           expect($('h1').text().trim()).toBe('Select visitors from the prisoner’s approved visitor list')
           expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
-          expect($('input[name="visitors"]').length).toBe(2)
+          expect($('input[name="visitors"]').length).toBe(1)
           expect($('[data-test="submit"]').length).toBe(0)
           expect($('[data-test="back-to-start"]').length).toBe(1)
+          expect($('.govuk-warning-text__text').text()).toContain('There are no')
+          expect($('.govuk-warning-text__text').text()).toContain('approved')
+          expect($('.govuk-warning-text__text').text()).toContain(
+            'visitors over 18 for this prisoner. A booking cannot be made at this time',
+          )
+        })
+    })
+
+    it('should show back to start button and warning message if only banned visitors listed', () => {
+      returnData = [
+        {
+          personId: 4324,
+          name: 'John Smith',
+          dateOfBirth: '2000-03-02',
+          adult: true,
+          relationshipDescription: 'Uncle',
+          address: 'Not entered',
+          restrictions: [],
+          banned: true,
+        },
+      ]
+      prisonerVisitorsService.getVisitors.mockResolvedValue(returnData)
+
+      return request(sessionApp)
+        .get(`${journey.urlPrefix}/select-visitors`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text().trim()).toBe('Select visitors from the prisoner’s approved visitor list')
+          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+          expect($('input[name="visitors"]').length).toBe(1)
+          expect($('[data-test="submit"]').length).toBe(0)
+          expect($('[data-test="back-to-start"]').length).toBe(1)
+          expect($('.govuk-warning-text__text').text()).toContain('There are no')
+          expect($('.govuk-warning-text__text').text()).toContain('permitted')
+          expect($('.govuk-warning-text__text').text()).toContain(
+            'visitors over 18 for this prisoner. A booking cannot be made at this time',
+          )
         })
     })
 

--- a/server/routes/visitJourney/selectVisitors.ts
+++ b/server/routes/visitJourney/selectVisitors.ts
@@ -25,12 +25,7 @@ export default class SelectVisitors {
     }
     req.session.visitorList.visitors = visitorList
 
-    let adultVisitors = false
-    visitorList.forEach(visitor => {
-      if (visitor.adult === true) {
-        adultVisitors = true
-      }
-    })
+    const atLeastOneAdult = visitorList.some(visitor => visitor.adult === true)
 
     const restrictions = await this.prisonerProfileService.getRestrictions(offenderNo, res.locals.user.username)
     visitSessionData.prisoner.restrictions = restrictions
@@ -48,7 +43,7 @@ export default class SelectVisitors {
       offenderNo: visitSessionData.prisoner.offenderNo,
       prisonerName: visitSessionData.prisoner.name,
       visitorList,
-      adultVisitors,
+      atLeastOneAdult,
       restrictions,
       selectVisitorsText,
       formValues,

--- a/server/routes/visitJourney/selectVisitors.ts
+++ b/server/routes/visitJourney/selectVisitors.ts
@@ -25,6 +25,13 @@ export default class SelectVisitors {
     }
     req.session.visitorList.visitors = visitorList
 
+    let adultVisitors = false
+    visitorList.forEach(visitor => {
+      if (visitor.adult === true) {
+        adultVisitors = true
+      }
+    })
+
     const restrictions = await this.prisonerProfileService.getRestrictions(offenderNo, res.locals.user.username)
     visitSessionData.prisoner.restrictions = restrictions
 
@@ -41,6 +48,7 @@ export default class SelectVisitors {
       offenderNo: visitSessionData.prisoner.offenderNo,
       prisonerName: visitSessionData.prisoner.name,
       visitorList,
+      adultVisitors,
       restrictions,
       selectVisitorsText,
       formValues,

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -128,7 +128,7 @@
         {% set noVisitorsHtml %}
           {{ govukWarningText({
             classes: "govuk-!-margin-bottom-0",
-                  html: '<span class="govuk-!-font-size-24">There are no' + noVisitorsText + 'visitors over 18 for this prisoner. A booking cannot be made at this time</span>',
+                  html: '<span class="govuk-!-font-size-24">There are no' + noVisitorsText + 'visitors over 18 for this prisoner. A booking cannot be made at this time.</span>',
             iconFallbackText: "Warning",
             attributes: {
               "data-test": "no-suitable-visitors"

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -128,7 +128,7 @@
         {% set noVisitorsHtml %}
           {{ govukWarningText({
             classes: "govuk-!-margin-bottom-0",
-                  html: '<span class="govuk-!-font-size-24">There are no' + noVisitorsText + 'visitors over 18 for this prisoner. A booking cannot be made at this time.</span>',
+            html: '<span class="govuk-!-font-size-24">There are no' + noVisitorsText + 'visitors over 18 for this prisoner. A booking cannot be made at this time.</span>',
             iconFallbackText: "Warning",
             attributes: {
               "data-test": "no-suitable-visitors"

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -1,6 +1,8 @@
 {% extends "layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{%- from "moj/components/banner/macro.njk" import mojBanner -%}
 {% from "components/visitors.njk" import visitorDateOfBirth, visitorRestrictions %}
 
 {% set pageHeaderTitle = "Select visitors from the prisoner’s approved visitor list" %}
@@ -11,6 +13,7 @@
 
 {% set visitors = [] %}
 {% set eligibleVisitorsCount = 0 %}
+{% set noVisitorsText = '' %}
 
 {% for visitor in visitorList %}
 
@@ -59,6 +62,7 @@
 {% endfor %}
 
 {% block content %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {% include "partials/errorSummary.njk" %}
@@ -111,6 +115,30 @@
           rows: prisonerRestrictions
         }) }}
       </div>
+      {% endif %}
+
+      {% set noVisitorsText %}
+        {% if adultVisitors === false %}
+          {{ 'approved' }}
+        {% elif adultVisitors === true and eligibleVisitorsCount === 0 %}
+          {{ 'permitted' }}
+        {% endif %}
+      {% endset %}
+      {% if noVisitorsText !== '' %}
+        {% set noVisitorsHtml %}
+          {{ govukWarningText({
+            classes: "govuk-!-margin-bottom-0",
+            html: '<span class="govuk-!-font-size-24">There are no' + noVisitorsText + ' visitors over 18 for this prisoner. A booking cannot be made at this time</span>',
+            iconFallbackText: "Warning",
+            attributes: {
+              "data-test": "no-suitable-visitors"
+            }
+          }) }}
+        {% endset %}
+        {{ mojBanner({
+          classes: "govuk-!-padding-left-4" ,
+          html: noVisitorsHtml
+        }) }}
       {% endif %}
 
       <h2 class="govuk-heading-m">Approved visitor list</h2>

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -118,9 +118,9 @@
       {% endif %}
 
       {% set noVisitorsText %}
-        {% if adultVisitors === false %}
+        {% if atLeastOneAdult === false %}
           {{ 'approved' }}
-        {% elif adultVisitors === true and eligibleVisitorsCount === 0 %}
+        {% elif atLeastOneAdult === true and eligibleVisitorsCount === 0 %}
           {{ 'permitted' }}
         {% endif %}
       {% endset %}

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -128,7 +128,7 @@
         {% set noVisitorsHtml %}
           {{ govukWarningText({
             classes: "govuk-!-margin-bottom-0",
-            html: '<span class="govuk-!-font-size-24">There are no' + noVisitorsText + ' visitors over 18 for this prisoner. A booking cannot be made at this time</span>',
+                  html: '<span class="govuk-!-font-size-24">There are no' + noVisitorsText + 'visitors over 18 for this prisoner. A booking cannot be made at this time</span>',
             iconFallbackText: "Warning",
             attributes: {
               "data-test": "no-suitable-visitors"

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -26,7 +26,7 @@
   {% set checkbox -%}
   <div class="govuk-checkboxes__item">
     <input class="govuk-checkboxes__input" id="visitor-{{ visitor.personId }}" name="visitors" type="checkbox" value="{{ visitor.personId }}"
-    {{- " checked" if formValues.visitors and visitor.personId | string in formValues.visitors }}{{ " disabled" if visitor.banned }}>
+    {{- " checked" if formValues.visitors and visitor.personId | string in formValues.visitors }}{{ " disabled" if visitor.banned or eligibleVisitorsCount === 0}}>
     <label class="govuk-label govuk-checkboxes__label" for="visitor-{{ visitor.personId }}">
       <span class="govuk-visually-hidden">Select {{ visitor.name }}</span>
     </label>


### PR DESCRIPTION
## Description
Added no permitted/approved visitors warning banner to select visitors page.
Test added to test for both possible messages
Also changed previous implementation on disabling the checkboxes on this page when the journey isn't able to go ahead



G3094UO - Hewell - All banned visitors

G8316GA - Hewell - Only child visitors

G9472UP - Hewell - No visitors