### PR TITLE
VB-2376 Temporary fix - don't disable visitor checkboxes (unless banned)

### DIFF
--- a/server/routes/visitJourney/selectVisitors.test.ts
+++ b/server/routes/visitJourney/selectVisitors.test.ts
@@ -387,7 +387,7 @@ testJourneys.forEach(journey => {
           expect($('input[name="visitors"]').length).toBe(1)
           expect($('[data-test="submit"]').length).toBe(0)
           expect($('[data-test="back-to-start"]').length).toBe(1)
-          expect($('#visitor-4324').attr('disabled')).toBe('disabled')
+          // expect($('#visitor-4324').attr('disabled')).toBe('disabled')
           expect($('.govuk-warning-text__text').text().replace(/\s+/g, ' ')).toContain(
             'There are no approved visitors over 18 for this prisoner. A booking cannot be made at this time.',
           )

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -26,7 +26,7 @@
   {% set checkbox -%}
   <div class="govuk-checkboxes__item">
     <input class="govuk-checkboxes__input" id="visitor-{{ visitor.personId }}" name="visitors" type="checkbox" value="{{ visitor.personId }}"
-    {{- " checked" if formValues.visitors and visitor.personId | string in formValues.visitors }}{{ " disabled" if visitor.banned or eligibleVisitorsCount === 0}}>
+    {{- " checked" if formValues.visitors and visitor.personId | string in formValues.visitors }}{{ " disabled" if visitor.banned }}>
     <label class="govuk-label govuk-checkboxes__label" for="visitor-{{ visitor.personId }}">
       <span class="govuk-visually-hidden">Select {{ visitor.name }}</span>
     </label>


### PR DESCRIPTION
Temporary fix to issue whereby child visitor checkboxes are being wrongly disabled. This fix stops checkboxes being disabled unless the visitor is banned.