### PR TITLE
VB-2540 Update unit and integration tests to include request body for PUT /book

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -30,42 +30,12 @@ export default defineConfig({
         ...auth,
         ...tokenVerification,
 
-        // Orchestration service
-        stubBookVisit: orchestrationService.stubBookVisit,
-        stubCancelVisit: orchestrationService.stubCancelVisit,
-        stubChangeBookedVisit: orchestrationService.stubChangeBookedVisit,
-        stubChangeReservedSlot: orchestrationService.stubChangeReservedSlot,
-        stubReserveVisit: orchestrationService.stubReserveVisit,
-        stubVisit: orchestrationService.stubVisit,
-        stubVisitHistory: orchestrationService.stubVisitHistory,
-        stubUpcomingVisits: orchestrationService.stubUpcomingVisits,
-        stubVisitsByDate: orchestrationService.stubVisitsByDate,
-        stubAvailableSupport: orchestrationService.stubAvailableSupport,
-        stubVisitSessions: orchestrationService.stubVisitSessions,
-        stubSessionSchedule: orchestrationService.stubSessionSchedule,
-        stubVisitSessionCapacity: orchestrationService.stubVisitSessionCapacity,
-        stubPrisonerProfile: orchestrationService.stubPrisonerProfile,
-        stubSupportedPrisonIds: orchestrationService.stubSupportedPrisonIds,
-
-        // Prisoner contact registry
-        stubPrisonerSocialContacts: prisonerContactRegistry.stubPrisonerSocialContacts,
-
-        // Prison API
-        stubOffenderRestrictions: prisonApi.stubOffenderRestrictions,
-        stubSetActiveCaseLoad: prisonApi.stubSetActiveCaseLoad,
-        stubUserCaseloads: prisonApi.stubUserCaseloads,
-
-        // Prisoner offender search
-        stubPrisonerById: prisonerSearch.stubPrisonerById,
-        stubPrisoners: prisonerSearch.stubPrisoners,
-        stubPrisoner: prisonerSearch.stubPrisoner,
-        stubGetPrisonersByPrisonerNumbers: prisonerSearch.stubGetPrisonersByPrisonerNumbers,
-
-        // Prison register API
-        stubPrisons: prisonRegister.stubPrisons,
-
-        // Whereabouts
-        stubOffenderEvents: whereaboutsOffenderEvents.stubOffenderEvents,
+        ...orchestrationService,
+        ...prisonerContactRegistry,
+        ...prisonApi,
+        ...prisonerSearch,
+        ...prisonRegister,
+        ...whereaboutsOffenderEvents,
 
         // Log message to console
         log: (message: string) => {

--- a/integration_tests/integration/bookAVisit.cy.ts
+++ b/integration_tests/integration/bookAVisit.cy.ts
@@ -191,9 +191,8 @@ context('Book a visit', () => {
         sessionTemplateReference: visitSessions[0].sessionTemplateReference,
       }),
     )
-    cy.task(
-      'stubBookVisit',
-      TestData.visit({
+    cy.task('stubBookVisit', {
+      visit: TestData.visit({
         visitStatus: 'BOOKED',
         startTimestamp: visitSessions[0].startTimestamp,
         endTimestamp: visitSessions[0].endTimestamp,
@@ -203,7 +202,8 @@ context('Book a visit', () => {
         ],
         visitorSupport: [{ type: 'WHEELCHAIR' }, { type: 'OTHER', text: 'Some extra help!' }],
       }),
-    )
+      applicationMethod: 'NOT_KNOWN',
+    })
 
     checkYourBookingPage.bookButton().click()
     const confirmationPage = Page.verifyOnPageTitle(ConfirmationPage, 'Booking confirmed')

--- a/integration_tests/integration/checkYourBooking.cy.ts
+++ b/integration_tests/integration/checkYourBooking.cy.ts
@@ -198,9 +198,8 @@ context('Check visit details page', () => {
         sessionTemplateReference: visitSessions[1].sessionTemplateReference,
       }),
     )
-    cy.task(
-      'stubBookVisit',
-      TestData.visit({
+    cy.task('stubBookVisit', {
+      visit: TestData.visit({
         visitStatus: 'BOOKED',
         startTimestamp: visitSessions[1].startTimestamp,
         endTimestamp: visitSessions[1].endTimestamp,
@@ -211,7 +210,8 @@ context('Check visit details page', () => {
         ],
         visitorSupport: [{ type: 'WHEELCHAIR' }],
       }),
-    )
+      applicationMethod: 'NOT_KNOWN',
+    })
 
     checkYourBookingPage.bookButton().click()
     const confirmationPage = Page.verifyOnPageTitle(ConfirmationPage, 'Booking confirmed')

--- a/integration_tests/integration/updateAVisit.cy.ts
+++ b/integration_tests/integration/updateAVisit.cy.ts
@@ -157,9 +157,8 @@ context('Update a visit', () => {
         sessionTemplateReference: visitSessions[1].sessionTemplateReference,
       }),
     )
-    cy.task(
-      'stubBookVisit',
-      TestData.visit({
+    cy.task('stubBookVisit', {
+      visit: TestData.visit({
         visitStatus: 'BOOKED',
         startTimestamp: visitSessions[1].startTimestamp,
         endTimestamp: visitSessions[1].endTimestamp,
@@ -169,7 +168,8 @@ context('Update a visit', () => {
         ],
         visitorSupport: [{ type: 'WHEELCHAIR' }, { type: 'OTHER', text: 'Some extra help!' }],
       }),
-    )
+      applicationMethod: 'NOT_KNOWN',
+    })
     checkYourBookingPage.bookButton().click()
 
     // Confirmation page

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -1,6 +1,7 @@
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 import {
+  ApplicationMethodType,
   CancelVisitOrchestrationDto,
   PrisonerProfile,
   SessionCapacity,
@@ -12,11 +13,24 @@ import {
 import TestData from '../../server/routes/testutils/testData'
 
 export default {
-  stubBookVisit: (visit: Visit): SuperAgentRequest => {
+  stubBookVisit: ({
+    visit,
+    applicationMethod,
+  }: {
+    visit: Visit
+    applicationMethod: ApplicationMethodType
+  }): SuperAgentRequest => {
     return stubFor({
       request: {
         method: 'PUT',
         url: `/orchestration/visits/${visit.applicationReference}/book`,
+        bodyPatterns: [
+          {
+            equalToJson: {
+              applicationMethodType: applicationMethod,
+            },
+          },
+        ],
       },
       response: {
         status: 200,

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -3,7 +3,7 @@ import config from '../config'
 import TestData from '../routes/testutils/testData'
 import OrchestrationApiClient from './orchestrationApiClient'
 import {
-  ApplicationMethodType,
+  BookingOrchestrationRequestDto,
   CancelVisitOrchestrationDto,
   ChangeVisitSlotRequestDto,
   ReserveVisitSlotDto,
@@ -35,7 +35,9 @@ describe('orchestrationApiClient', () => {
   describe('bookVisit', () => {
     it('should book a Visit (change status from RESERVED to BOOKED), given applicationReference', async () => {
       const applicationReference = 'aaa-bbb-ccc'
-      const applicationMethod: ApplicationMethodType = 'NOT_KNOWN'
+      const bookingOrchestrationRequestDto: BookingOrchestrationRequestDto = {
+        applicationMethodType: 'NOT_KNOWN',
+      }
 
       const result: Partial<Visit> = {
         applicationReference,
@@ -44,11 +46,14 @@ describe('orchestrationApiClient', () => {
       }
 
       fakeOrchestrationApi
-        .put(`/visits/${applicationReference}/book`)
+        .put(`/visits/${applicationReference}/book`, bookingOrchestrationRequestDto)
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, result)
 
-      const output = await orchestrationApiClient.bookVisit(applicationReference, applicationMethod)
+      const output = await orchestrationApiClient.bookVisit(
+        applicationReference,
+        bookingOrchestrationRequestDto.applicationMethodType,
+      )
 
       expect(output).toEqual(result)
     })

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -73,6 +73,7 @@ describe('Visit service', () => {
         const result = await visitService.bookVisit({ username: 'user', applicationReference, applicationMethod })
 
         expect(orchestrationApiClient.bookVisit).toHaveBeenCalledTimes(1)
+        expect(orchestrationApiClient.bookVisit).toHaveBeenCalledWith(applicationReference, applicationMethod)
         expect(result).toEqual(visit)
       })
     })


### PR DESCRIPTION
Previously calling the `/book` endpoint didn't require a request body so tests weren't accounting for this. This change adds checks for the `aplicationMethod` on the request body.