### PR TITLE
VB-2416 Use updated prisoner profile (containing visitor names)

### DIFF
--- a/integration_tests/integration/bookAVisit.cy.ts
+++ b/integration_tests/integration/bookAVisit.cy.ts
@@ -98,13 +98,12 @@ context('Book a visit', () => {
 
     const { prisonerId } = profile
     // Prisoner profile page
-    cy.task('stubPrisonerSocialContacts', { offenderNo, contacts })
     cy.task('stubPrisonerProfile', { prisonId, prisonerId, profile })
-
     searchForAPrisonerResultsPage.firstResultLink().contains(prisonerDisplayName).click()
     const prisonerProfilePage = Page.verifyOnPageTitle(PrisonerProfilePage, prisonerDisplayName)
 
     // Select visitors
+    cy.task('stubPrisonerSocialContacts', { offenderNo, contacts })
     const offenderRestrictions = [TestData.offenderRestriction()]
     cy.task('stubOffenderRestrictions', { offenderNo, offenderRestrictions })
     prisonerProfilePage.bookAVisitButton().click()

--- a/integration_tests/integration/prisonerProfile.cy.ts
+++ b/integration_tests/integration/prisonerProfile.cy.ts
@@ -34,15 +34,17 @@ context('Prisoner profile page', () => {
         dateCreated: '2022-01-01',
       }),
     ]
-    const visit = TestData.visit()
-    const contacts = [TestData.contact(), TestData.contact({ personId: 4322, firstName: 'Bob' })]
-    const profile = TestData.prisonerProfile({ alerts, visits: [visit] })
+    const visitors = [
+      { nomisPersonId: 4321, firstName: 'Jeanette', lastName: 'Smith' },
+      { nomisPersonId: 4322, firstName: 'Bob', lastName: 'Smith' },
+    ]
+    const visitSummary = TestData.visitSummary({ visitors })
+    const profile = TestData.prisonerProfile({ alerts, visits: [visitSummary] })
 
     const { prisonerId } = profile
     const prisonId = 'HEI'
 
     // Prisoner profile page
-    cy.task('stubPrisonerSocialContacts', { offenderNo: prisonerId, contacts })
     cy.task('stubPrisonerProfile', { prisonId, prisonerId, profile })
 
     // Go to prisoner profile page

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -5,6 +5,7 @@ import {
   Visit,
   VisitorSupport,
   VisitSession,
+  VisitSummary,
 } from '../data/orchestrationApiTypes'
 
 export type Prison = {
@@ -50,8 +51,7 @@ export type PrisonerProfilePage = {
       nextPrivIepAdjustDate?: string
     }
   }
-  visitsByMonth: Map<string, { upcomingCount: number; pastCount: number; visits: Visit[] }>
-  contactNames: Record<number, string>
+  visitsByMonth: Map<string, { upcomingCount: number; pastCount: number; visits: VisitSummary[] }>
 }
 
 // Visit slots, for representing data derived from VisitSessions

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -441,8 +441,6 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitDto'][]
@@ -452,6 +450,8 @@ export interface components {
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
+      first?: boolean
+      last?: boolean
       empty?: boolean
     }
     PageableObject: {
@@ -732,7 +732,7 @@ export interface components {
       alerts?: components['schemas']['AlertDto'][]
       visitBalances?: components['schemas']['VisitBalancesDto']
       /** @description Past and future visits for the prisoner based on configured duration. */
-      visits: components['schemas']['VisitDto'][]
+      visits: components['schemas']['VisitSummaryDto'][]
     }
     /** @description Balances of visit orders and privilege visit orders */
     VisitBalancesDto: {
@@ -756,6 +756,78 @@ export interface components {
        * @description Date of last IEP adjustment for Privilege Visit orders
        */
       latestPrivIepAdjustDate?: string
+    }
+    /** @description Visit Summary */
+    VisitSummaryDto: {
+      /**
+       * @description Visit Reference
+       * @example v9-d7-ed-7u
+       */
+      reference: string
+      /**
+       * @description Prisoner Id
+       * @example AF34567G
+       */
+      prisonerId: string
+      /**
+       * @description Prison Id
+       * @example MDI
+       */
+      prisonId: string
+      /**
+       * @description Prison name
+       * @example MDI Prison
+       */
+      prisonName?: string
+      /**
+       * @description Visit Type
+       * @example SOCIAL
+       * @enum {string}
+       */
+      visitType: 'SOCIAL'
+      /**
+       * @description Visit Status
+       * @example RESERVED
+       * @enum {string}
+       */
+      visitStatus: 'RESERVED' | 'CHANGING' | 'BOOKED' | 'CANCELLED'
+      /**
+       * @description Visit Restriction
+       * @example OPEN
+       * @enum {string}
+       */
+      visitRestriction: 'OPEN' | 'CLOSED' | 'UNKNOWN'
+      /**
+       * Format: date-time
+       * @description The date and time of the visit
+       */
+      startTimestamp: string
+      /**
+       * Format: date-time
+       * @description The finishing date and time of the visit
+       */
+      endTimestamp: string
+      /** @description List of visitors associated with the visit */
+      visitors?: components['schemas']['VisitorSummaryDto'][]
+    }
+    /** @description Full Visitor details */
+    VisitorSummaryDto: {
+      /**
+       * Format: int64
+       * @description Person ID (nomis) of the visitor
+       * @example 1234
+       */
+      nomisPersonId: number
+      /**
+       * @description Visitor's first name
+       * @example John
+       */
+      firstName?: string
+      /**
+       * @description Visitor's last name
+       * @example Smith
+       */
+      lastName?: string
     }
   }
   responses: never

--- a/server/data/orchestrationApiTypes.ts
+++ b/server/data/orchestrationApiTypes.ts
@@ -27,5 +27,6 @@ export type VisitSession = components['schemas']['VisitSessionDto']
 export type Alert = components['schemas']['AlertDto']
 
 export type PrisonerProfile = components['schemas']['PrisonerProfileDto']
+export type VisitSummary = components['schemas']['VisitSummaryDto']
 
 export type EventAuditType = components['schemas']['EventAuditDto']['type']

--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -88,7 +88,6 @@ describe('/prisoner/:offenderNo - Prisoner profile', () => {
           nextPrivIepAdjustDate: '1 January 2022',
         },
       },
-      contactNames: {},
     }
 
     prisonerProfileService.getProfile.mockResolvedValue(prisonerProfile)
@@ -169,19 +168,31 @@ describe('/prisoner/:offenderNo - Prisoner profile', () => {
       const fakeDateTime = '2023-03-01T09:00'
       jest.useFakeTimers({ advanceTimers: true, now: new Date(fakeDateTime) })
 
-      const upcomingVisit = TestData.visit({ startTimestamp: '2023-03-02T10:00', endTimestamp: '2023-03-02T11:00' })
-      const pastVisit = TestData.visit({ startTimestamp: '2023-02-03T10:00', endTimestamp: '2023-02-03T11:00' })
-      const cancelledVisit = TestData.visit({
+      const visitors = [
+        { nomisPersonId: 4321, firstName: 'Jeanette', lastName: 'Smith' },
+        { nomisPersonId: 4322, firstName: 'Bob', lastName: 'Smith' },
+      ]
+      const upcomingVisit = TestData.visitSummary({
+        startTimestamp: '2023-03-02T10:00',
+        endTimestamp: '2023-03-02T11:00',
+        visitors,
+      })
+      const pastVisit = TestData.visitSummary({
+        startTimestamp: '2023-02-03T10:00',
+        endTimestamp: '2023-02-03T11:00',
+        visitors,
+      })
+      const cancelledVisit = TestData.visitSummary({
         startTimestamp: '2023-02-03T10:00',
         endTimestamp: '2023-02-03T11:00',
         visitStatus: 'CANCELLED',
+        visitors,
       })
 
       prisonerProfile.visitsByMonth = new Map([
         ['March 2023', { upcomingCount: 1, pastCount: 0, visits: [upcomingVisit] }],
         ['February 2023', { upcomingCount: 0, pastCount: 1, visits: [pastVisit, cancelledVisit] }],
       ])
-      prisonerProfile.contactNames = { 4321: 'Jeanette Smith', 4322: 'Bob Smith' }
 
       return request(app)
         .get('/prisoner/A1234BC')

--- a/server/routes/prisoner.ts
+++ b/server/routes/prisoner.ts
@@ -11,7 +11,6 @@ export default function routes({
   auditService,
   prisonerProfileService,
   prisonerSearchService,
-  supportedPrisonsService,
   visitService,
 }: Services): Router {
   const router = Router()
@@ -26,7 +25,6 @@ export default function routes({
     const queryParamsForBackLink = search !== '' ? new URLSearchParams({ search }).toString() : ''
 
     const prisonerProfile = await prisonerProfileService.getProfile(prisonId, prisonerId, res.locals.user.username)
-    const supportedPrisons = await supportedPrisonsService.getSupportedPrisons(res.locals.user.username)
 
     await auditService.viewPrisoner({
       prisonerId,
@@ -38,7 +36,6 @@ export default function routes({
     return res.render('pages/prisoner/profile', {
       errors: req.flash('errors'),
       ...prisonerProfile,
-      supportedPrisons,
       queryParamsForBackLink,
     })
   })

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -8,6 +8,7 @@ import {
   Visit,
   VisitHistoryDetails,
   VisitSession,
+  VisitSummary,
 } from '../../data/orchestrationApiTypes'
 import { CaseLoad, OffenderRestriction } from '../../data/prisonApiTypes'
 import { CurrentIncentive, Prisoner } from '../../data/prisonerOffenderSearchTypes'
@@ -418,4 +419,35 @@ export default class TestData {
     endTimestamp,
     sessionConflicts,
   })
+
+  static visitSummary = ({
+    reference = 'ab-cd-ef-gh',
+    prisonerId = 'A1234BC',
+    prisonId = 'HEI',
+    prisonName = 'Hewell (HMP)',
+    visitType = 'SOCIAL',
+    visitStatus = 'BOOKED',
+    visitRestriction = 'OPEN',
+    startTimestamp = '2022-01-14T10:00:00',
+    endTimestamp = '2022-01-14T11:00:00',
+    visitors = [
+      {
+        nomisPersonId: 4321,
+        firstName: 'Jeanette',
+        lastName: 'Smith',
+      },
+    ],
+  }: Partial<VisitSummary> = {}): VisitSummary =>
+    ({
+      reference,
+      prisonerId,
+      prisonId,
+      prisonName,
+      visitType,
+      visitStatus,
+      visitRestriction,
+      startTimestamp,
+      endTimestamp,
+      visitors,
+    } as VisitSummary)
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -37,7 +37,6 @@ export const services = () => {
   const prisonerProfileService = new PrisonerProfileService(
     orchestrationApiClientBuilder,
     prisonApiClientBuilder,
-    prisonerContactRegistryApiClientBuilder,
     hmppsAuthClient,
   )
 

--- a/server/services/prisonerProfileService.test.ts
+++ b/server/services/prisonerProfileService.test.ts
@@ -9,7 +9,6 @@ import {
   createMockPrisonApiClient,
   createMockPrisonerSearchClient,
 } from '../data/testutils/mocks'
-import { createMockSupportedPrisonsService } from './testutils/mocks'
 
 const token = 'some token'
 
@@ -18,7 +17,6 @@ describe('Prisoner profile service', () => {
   const orchestrationApiClient = createMockOrchestrationApiClient()
   const prisonApiClient = createMockPrisonApiClient()
   const prisonerSearchClient = createMockPrisonerSearchClient()
-  const supportedPrisonsService = createMockSupportedPrisonsService()
 
   let prisonerProfileService: PrisonerProfileService
 
@@ -47,12 +45,6 @@ describe('Prisoner profile service', () => {
   })
 
   describe('getProfile', () => {
-    const supportedPrisons = TestData.supportedPrisons()
-
-    beforeEach(() => {
-      supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
-    })
-
     it('should retrieve and process data for prisoner profile', async () => {
       const prisonerProfile = TestData.prisonerProfile()
       orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)

--- a/server/services/prisonerProfileService.ts
+++ b/server/services/prisonerProfileService.ts
@@ -3,13 +3,7 @@ import { format, isBefore } from 'date-fns'
 import { PrisonerProfilePage } from '../@types/bapv'
 import { nextIepAdjustDate, nextPrivIepAdjustDate, prisonerDateTimePretty, properCaseFullName } from '../utils/utils'
 import { Alert, OffenderRestriction } from '../data/prisonApiTypes'
-import {
-  HmppsAuthClient,
-  OrchestrationApiClient,
-  PrisonApiClient,
-  PrisonerContactRegistryApiClient,
-  RestClientBuilder,
-} from '../data'
+import { HmppsAuthClient, OrchestrationApiClient, PrisonApiClient, RestClientBuilder } from '../data'
 
 export default class PrisonerProfileService {
   private alertCodesToFlag = ['UPIU', 'RCDR', 'URCU']
@@ -17,7 +11,6 @@ export default class PrisonerProfileService {
   constructor(
     private readonly orchestrationApiClientFactory: RestClientBuilder<OrchestrationApiClient>,
     private readonly prisonApiClientFactory: RestClientBuilder<PrisonApiClient>,
-    private readonly prisonerContactRegistryApiClientFactory: RestClientBuilder<PrisonerContactRegistryApiClient>,
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
 
@@ -25,14 +18,6 @@ export default class PrisonerProfileService {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
     const prisonerProfile = await orchestrationApiClient.getPrisonerProfile(prisonId, prisonerId)
-
-    // To remove when VB-2060 done - build list of contact IDs => contact name
-    const prisonerContactRegistryApiClient = this.prisonerContactRegistryApiClientFactory(token)
-    const socialContacts = await prisonerContactRegistryApiClient.getPrisonerSocialContacts(prisonerId)
-    const contactNames: Record<number, string> = {}
-    socialContacts.forEach(contact => {
-      contactNames[contact.personId] = `${contact.firstName} ${contact.lastName}`
-    })
 
     const alerts = prisonerProfile.alerts || []
     const activeAlerts: Alert[] = alerts.filter(alert => alert.active)
@@ -92,7 +77,6 @@ export default class PrisonerProfileService {
       flaggedAlerts,
       prisonerDetails,
       visitsByMonth,
-      contactNames,
     }
   }
 

--- a/server/services/testutils/mocks.ts
+++ b/server/services/testutils/mocks.ts
@@ -21,7 +21,7 @@ export const createMockAuditService = () => new AuditService(null) as jest.Mocke
 export const createMockNotificationsService = () => new NotificationsService(null) as jest.Mocked<NotificationsService>
 
 export const createMockPrisonerProfileService = () =>
-  new PrisonerProfileService(null, null, null, null) as jest.Mocked<PrisonerProfileService>
+  new PrisonerProfileService(null, null, null) as jest.Mocked<PrisonerProfileService>
 
 export const createMockPrisonerSearchService = () =>
   new PrisonerSearchService(null, null) as jest.Mocked<PrisonerSearchService>

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -148,7 +148,7 @@
                 attributes: { "data-test": "tab-visits-type" }
               },
               {
-                text: supportedPrisons[visit.prisonId],
+                text: visit.prisonName,
                 attributes: { "data-test": "tab-visits-location" }
               },
               {

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -133,9 +133,9 @@
           {% set visitRows = [] %}
           {% for visit in data.visits %}
 
-            {% set visitors = [] %}
+            {% set visitorNames = [] %}
             {% for visitor in visit.visitors %}
-              {% set visitors = (visitors.push(contactNames[visitor.nomisPersonId]), visitors) %}
+              {% set visitorNames = (visitorNames.push(visitor.firstName + ' ' + visitor.lastName), visitorNames) %}
             {% endfor %}
 
             {% set visitRows = (visitRows.push([
@@ -157,7 +157,7 @@
                 attributes: { "data-test": "tab-visits-date-and-time" }
               },
               {
-                html: visitors | join('<br>'),
+                html: visitorNames | join('<br>'),
                 attributes: { "data-test": "tab-visits-visitors" }
               },
               {


### PR DESCRIPTION
Use updated `PrisonerProfileDto` that contains visits as `VisitSummaryDto`. These include prison name and visitor names. This avoids having to make an additional calls to look these up separately in the contact registry / prison register.