### PR TITLE
Changed 'visit migrated' on summary page to show 'visit booked'

### DIFF
--- a/server/constants/eventAuditTypes.ts
+++ b/server/constants/eventAuditTypes.ts
@@ -4,7 +4,7 @@ const eventAuditTypes: Partial<Record<EventAuditType, string>> = {
   BOOKED_VISIT: 'Visit booked',
   UPDATED_VISIT: 'Visit updated',
   CANCELLED_VISIT: 'Visit cancelled',
-  MIGRATED_VISIT: 'Visit migrated',
+  MIGRATED_VISIT: 'Visit booked', // Will be more correct (based on information given in this event) to show visit booked
 }
 
 export default eventAuditTypes


### PR DESCRIPTION
## Description
For migrated visit event, the information included is actually about who booked the visit and when they booked the visit, so showing `Visit booked` on the visit summary page is more correct