### PR TITLE
Have migrated event audit's show as booked/cancelled instead

### DIFF
--- a/server/constants/eventAuditTypes.ts
+++ b/server/constants/eventAuditTypes.ts
@@ -4,7 +4,6 @@ const eventAuditTypes: Partial<Record<EventAuditType, string>> = {
   BOOKED_VISIT: 'Visit booked',
   UPDATED_VISIT: 'Visit updated',
   CANCELLED_VISIT: 'Visit cancelled',
-  MIGRATED_VISIT: 'Visit booked', // Will be more correct (based on information given in this event) to show visit booked
 }
 
 export default eventAuditTypes

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -210,7 +210,7 @@
 
         {% if visitHistoryDetails.eventsAudit %}
         {% for event in visitHistoryDetails.eventsAudit %}
-          {% if event.type in [ 'MIGRATED_VISIT', 'BOOKED_VISIT', 'UPDATED_VISIT', 'CANCELLED_VISIT' ] %}
+          {% if event.type in [ 'BOOKED_VISIT', 'UPDATED_VISIT', 'CANCELLED_VISIT' ] %}
             <li>
               <strong>{{ eventAuditTypes[event.type] }}</strong>
               <span data-test="{{ event.type | lower }}" >
@@ -218,6 +218,16 @@
                 at {{ event.createTimestamp | formatTime }}
                 {{ actionedByUser(event.actionedBy) }} 
                 {{ requestMethodDescriptions[event.applicationMethodType] }}
+              </span>
+            </li>
+          {% endif %}
+          {% if event.type === 'MIGRATED_VISIT' %}
+            <li>
+              <strong>{{ "Booked visit" if visit.visitStatus === 'BOOKED' else "Cancelled visit" }}</strong>
+              <span data-test="{{ event.type | lower }}" >
+                {{ event.createTimestamp | formatDate('EEEE d MMMM yyyy') }}
+                at {{ event.createTimestamp | formatTime }}
+                {{ actionedByUser(event.actionedBy) }} 
               </span>
             </li>
           {% endif %}


### PR DESCRIPTION
## Description
For migrated visits - event audit returns `Migrated_visit` as the event type, in this case it's better information for the user if we display Visit booked / Visit cancelled, as the information in the event related to who booked it and the time they did it - not who migrated and when it was done