### PR TITLE
VB-3177, VB-3182 Fix Date Picker month/year navigation and missing dates

### DIFF
--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -474,14 +474,14 @@ Datepicker.prototype.focusLastDayOfWeek = function () {
 Datepicker.prototype.focusNextMonth = function (event, focus = true) {
   event.preventDefault()
   const date = new Date(this.currentDate)
-  date.setMonth(date.getMonth() + 1)
+  date.setMonth(date.getMonth() + 1, 1)
   this.goToDate(date, focus)
 }
 
 Datepicker.prototype.focusPreviousMonth = function (event, focus = true) {
   event.preventDefault()
   const date = new Date(this.currentDate)
-  date.setMonth(date.getMonth() - 1)
+  date.setMonth(date.getMonth() - 1, 1)
   this.goToDate(date, focus)
 }
 
@@ -489,14 +489,14 @@ Datepicker.prototype.focusPreviousMonth = function (event, focus = true) {
 Datepicker.prototype.focusNextYear = function (event, focus = true) {
   event.preventDefault()
   const date = new Date(this.currentDate)
-  date.setFullYear(date.getFullYear() + 1)
+  date.setFullYear(date.getFullYear() + 1, date.getMonth(), 1)
   this.goToDate(date, focus)
 }
 
 Datepicker.prototype.focusPreviousYear = function (event, focus = true) {
   event.preventDefault()
   const date = new Date(this.currentDate)
-  date.setFullYear(date.getFullYear() - 1)
+  date.setFullYear(date.getFullYear() - 1, date.getMonth(), 1)
   this.goToDate(date, focus)
 }
 

--- a/assets/js/datepicker.js
+++ b/assets/js/datepicker.js
@@ -295,7 +295,11 @@ Datepicker.prototype.updateCalendar = function () {
   const firstOfMonth = new Date(day.getFullYear(), day.getMonth(), 1)
   const dayOfWeek = firstOfMonth.getDay()
 
-  firstOfMonth.setDate(firstOfMonth.getDate() - dayOfWeek + 1)
+  if (firstOfMonth.getDate() === 1 && firstOfMonth.getDay() === 0) {
+    firstOfMonth.setDate(firstOfMonth.getDate() - 6)
+  } else {
+    firstOfMonth.setDate(firstOfMonth.getDate() - dayOfWeek + 1)
+  }
 
   const thisDay = new Date(firstOfMonth)
 

--- a/integration_tests/integration/datePicker.cy.ts
+++ b/integration_tests/integration/datePicker.cy.ts
@@ -1,0 +1,75 @@
+import { format } from 'date-fns'
+import HomePage from '../pages/home'
+import Page from '../pages/page'
+import VisitsByDatePage from '../pages/visitsByDate'
+
+context('Date picker', () => {
+  const shortDateFormat = 'yyyy-MM-dd'
+  const today = new Date()
+  const todayShortFormat = format(today, shortDateFormat)
+  const prisonId = 'HEI'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+    cy.task('stubSupportedPrisonIds')
+    cy.task('stubPrisons')
+    cy.task('stubGetNotificationCount', {})
+    cy.signIn()
+
+    const startDateTime = `${todayShortFormat}T00:00:00`
+    const endDateTime = `${todayShortFormat}T23:59:59`
+    cy.task('stubVisitsByDate', {
+      startDateTime,
+      endDateTime,
+      prisonId,
+      visits: [],
+    })
+  })
+
+  it('should navigate through a range of dates and correctly handle month and year boundaries', () => {
+    const homePage = Page.verifyOnPage(HomePage)
+    homePage.viewVisitsTile().click()
+    const visitsByDatePage = Page.verifyOnPage(VisitsByDatePage)
+
+    // open 'another date' form
+    visitsByDatePage.toggleChooseAnotherDatePopUp()
+
+    // go to date, move back a month then select same day number
+    visitsByDatePage.datePickerEnterDate('05/10/2023')
+    visitsByDatePage.datePickerGoToPreviousMonth()
+    visitsByDatePage.datePickerSelectDay(5)
+    visitsByDatePage.datePickerGetEnteredDate().should('have.value', '05/09/2023')
+
+    // go to date, move back a month then select same day number
+    visitsByDatePage.datePickerEnterDate('05/10/2023')
+    visitsByDatePage.datePickerGoToNextMonth()
+    visitsByDatePage.datePickerSelectDay(5)
+    visitsByDatePage.datePickerGetEnteredDate().should('have.value', '05/11/2023')
+
+    // go to date on 31st, move back to a month with 30 days; select 1st and should be previous month
+    visitsByDatePage.datePickerEnterDate('31/10/2023')
+    visitsByDatePage.datePickerGoToPreviousMonth()
+    visitsByDatePage.datePickerSelectDay(1)
+    visitsByDatePage.datePickerGetEnteredDate().should('have.value', '01/09/2023')
+
+    // go to date on 31st, move forward to a month with 30 days; select 1st and should be next month
+    visitsByDatePage.datePickerEnterDate('31/10/2023')
+    visitsByDatePage.datePickerGoToNextMonth()
+    visitsByDatePage.datePickerSelectDay(1)
+    visitsByDatePage.datePickerGetEnteredDate().should('have.value', '01/11/2023')
+
+    // handle leap year - when moving back a year
+    visitsByDatePage.datePickerEnterDate('29/02/2024')
+    visitsByDatePage.datePickerGoToPreviousYear()
+    visitsByDatePage.datePickerSelectDay(1)
+    visitsByDatePage.datePickerGetEnteredDate().should('have.value', '01/02/2023')
+
+    // handle leap year - when moving forward a year
+    visitsByDatePage.datePickerEnterDate('29/02/2024')
+    visitsByDatePage.datePickerGoToNextYear()
+    visitsByDatePage.datePickerSelectDay(1)
+    visitsByDatePage.datePickerGetEnteredDate().should('have.value', '01/02/2025')
+  })
+})

--- a/integration_tests/integration/datePicker.cy.ts
+++ b/integration_tests/integration/datePicker.cy.ts
@@ -14,7 +14,7 @@ context('Date picker', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
 
@@ -71,5 +71,10 @@ context('Date picker', () => {
     visitsByDatePage.datePickerGoToNextYear()
     visitsByDatePage.datePickerSelectDay(1)
     visitsByDatePage.datePickerGetEnteredDate().should('have.value', '01/02/2025')
+
+    // handle months where the 1st is a Sunday (i.e not truncate this date)
+    visitsByDatePage.datePickerEnterDate('01/10/2023')
+    visitsByDatePage.datePickerSelectDay(1)
+    visitsByDatePage.datePickerGetEnteredDate().should('have.value', '01/10/2023')
   })
 })

--- a/integration_tests/pages/visitsByDate.ts
+++ b/integration_tests/pages/visitsByDate.ts
@@ -29,13 +29,39 @@ export default class VisitsByDatePage extends Page {
 
   noResultsMessage = (): PageElement => cy.get('#search-results-none')
 
-  // another date
+  // another date form
   toggleChooseAnotherDatePopUp = (): void => {
     cy.get('[data-test="another-date-button"]').click()
   }
 
+  // Date picker
+  datePickerEnterDate = (date: string): void => {
+    cy.get('.js-datepicker-cancel').click({ force: true })
+    cy.get('.hmpps-js-datepicker-input').clear()
+    cy.get('.hmpps-js-datepicker-input').type(`${date}{enter}`)
+    this.datePickerToggleCalendar()
+  }
+
+  datePickerGetEnteredDate = (): PageElement => cy.get('.hmpps-js-datepicker-input')
+
+  datePickerToggleCalendar = (): void => {
+    cy.get('.hmpps-js-datepicker-button').click()
+  }
+
+  datePickerGoToPreviousYear = (): void => {
+    cy.get('[data-button="button-datepicker-prevyear"]').click()
+  }
+
+  datePickerGoToPreviousMonth = (): void => {
+    cy.get('[data-button="button-datepicker-prevmonth"]').click()
+  }
+
   datePickerGoToNextMonth = (): void => {
     cy.get('[data-button="button-datepicker-nextmonth"]').click()
+  }
+
+  datePickerGoToNextYear = (): void => {
+    cy.get('[data-button="button-datepicker-nextyear"]').click()
   }
 
   datePickerSelectDay = (day: number) => {


### PR DESCRIPTION
Fix two bugs found in the date picker component:

* bug where navigating between months / years would go to the wrong month. E.g. with 31st October selected, pressing the 'next month' button would take you to December instead of November. The cause was not handling JavaScript dates wrapping if trying to set an invalid date (e.g. in the previous example, 31st November would be invalid so it wrapped to December)
* bug where the month would be truncated to not show the '1st' if this day fell on a Sunday (e.g. Sunday 1st October 2023)

Some Cypress test coverage has been added for these scenarios (ideally to be removed if/when this component is moved to a pattern library)