### PR TITLE
VB-3181 Use new 'prison names' Prison Register endpoint

### DIFF
--- a/integration_tests/integration/bookAVisit.cy.ts
+++ b/integration_tests/integration/bookAVisit.cy.ts
@@ -38,7 +38,7 @@ context('Book a visit', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
   })

--- a/integration_tests/integration/cancelVisit.cy.ts
+++ b/integration_tests/integration/cancelVisit.cy.ts
@@ -30,7 +30,7 @@ context('Cancel visit journey', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
 

--- a/integration_tests/integration/changeEstablishment.cy.ts
+++ b/integration_tests/integration/changeEstablishment.cy.ts
@@ -9,7 +9,7 @@ context('Change establishment', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
   })

--- a/integration_tests/integration/checkYourBooking.cy.ts
+++ b/integration_tests/integration/checkYourBooking.cy.ts
@@ -20,7 +20,7 @@ context('Check visit details page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
   })

--- a/integration_tests/integration/home.cy.ts
+++ b/integration_tests/integration/home.cy.ts
@@ -10,7 +10,7 @@ context('Home page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', { notificationCount })
     cy.signIn()
   })

--- a/integration_tests/integration/login.cy.ts
+++ b/integration_tests/integration/login.cy.ts
@@ -10,7 +10,7 @@ context('SignIn', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
   })
 

--- a/integration_tests/integration/prisonerProfile.cy.ts
+++ b/integration_tests/integration/prisonerProfile.cy.ts
@@ -11,7 +11,7 @@ context('Prisoner profile page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
   })

--- a/integration_tests/integration/searchForABooking.cy.ts
+++ b/integration_tests/integration/searchForABooking.cy.ts
@@ -22,7 +22,7 @@ context('Search for a booking by reference', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
   })

--- a/integration_tests/integration/searchForAPrisoner.cy.ts
+++ b/integration_tests/integration/searchForAPrisoner.cy.ts
@@ -13,7 +13,7 @@ context('Search for a prisoner', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
   })

--- a/integration_tests/integration/updateAVisit.cy.ts
+++ b/integration_tests/integration/updateAVisit.cy.ts
@@ -20,7 +20,7 @@ context('Update a visit', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
   })

--- a/integration_tests/integration/visitDetails.cy.ts
+++ b/integration_tests/integration/visitDetails.cy.ts
@@ -12,7 +12,7 @@ context('Visit details page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
   })

--- a/integration_tests/integration/visitTimetable.cy.ts
+++ b/integration_tests/integration/visitTimetable.cy.ts
@@ -17,7 +17,7 @@ context('View visit schedule timetable', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
   })

--- a/integration_tests/integration/visitsByDate.cy.ts
+++ b/integration_tests/integration/visitsByDate.cy.ts
@@ -36,7 +36,7 @@ context('View visit schedule timetable', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubSupportedPrisonIds')
-    cy.task('stubPrisons')
+    cy.task('stubPrisonNames')
     cy.task('stubGetNotificationCount', {})
     cy.signIn()
   })

--- a/integration_tests/mockApis/prisonRegister.ts
+++ b/integration_tests/mockApis/prisonRegister.ts
@@ -1,14 +1,14 @@
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 import TestData from '../../server/routes/testutils/testData'
-import { Prison } from '../../server/@types/bapv'
+import { PrisonName } from '../../server/data/prisonRegisterApiTypes'
 
 export default {
-  stubPrisons: (prisons: Prison[] = TestData.prisons()): SuperAgentRequest => {
+  stubPrisonNames: (prisons: PrisonName[] = TestData.prisonNames()): SuperAgentRequest => {
     return stubFor({
       request: {
         method: 'GET',
-        url: '/prisonRegister/prisons',
+        url: '/prisonRegister/prisons/names',
       },
       response: {
         status: 200,

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -8,11 +8,6 @@ import {
   VisitSummary,
 } from '../data/orchestrationApiTypes'
 
-export type Prison = {
-  prisonId: string
-  prisonName: string
-}
-
 export type PrisonerDetailsItem = {
   html?: string
   text?: string

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,6 @@
 import { SupportType } from '../../data/orchestrationApiTypes'
-import { Prison, VisitorListItem, VisitSessionData } from '../bapv'
+import { VisitorListItem, VisitSessionData } from '../bapv'
+import { PrisonName } from '../../data/prisonRegisterApiTypes'
 
 export default {}
 
@@ -13,7 +14,7 @@ declare module 'express-session' {
     adultVisitors: { adults: VisitorListItem[] }
     slotsList: VisitSlotList
     visitSessionData: VisitSessionData
-    selectedEstablishment: Prison
+    selectedEstablishment: PrisonName
   }
 }
 

--- a/server/@types/prison-register-api.d.ts
+++ b/server/@types/prison-register-api.d.ts
@@ -5,20 +5,48 @@
 
 export interface paths {
   '/secure/prisons/id/{prisonId}/videolink-conferencing-centre/email-address': {
-    /** Get a prison's Videolink Conferencing Centre email address */
+    /**
+     * Get a prison's Videolink Conferencing Centre email address
+     * @deprecated
+     */
     get: operations['getEmailForVideoConferencingCentre']
-    /** Set or change a prison's Videolink Conferencing Centre email address */
+    /**
+     * Set or change a prison's Videolink Conferencing Centre email address
+     * @deprecated
+     */
     put: operations['putEmailAddressForVideolinkConferencingCentre']
-    /** Remove a prison's Videolink Conferencing Centre email address */
+    /**
+     * Remove a prison's Videolink Conferencing Centre email address
+     * @deprecated
+     */
     delete: operations['deleteEmailAddressForVideolinkConferencingCentre']
   }
   '/secure/prisons/id/{prisonId}/offender-management-unit/email-address': {
-    /** Get a prison's Offender Management Unit email address */
+    /**
+     * Get a prison's Offender Management Unit email address
+     * @deprecated
+     */
     get: operations['getEmailForOffenderManagementUnit']
-    /** Set or change a prison's Offender Management Unit email address */
+    /**
+     * Set or change a prison's Offender Management Unit email address
+     * @deprecated
+     */
     put: operations['putEmailAddressForOffenderManagementUnit']
-    /** Remove a prison's Offender Management Unit email address */
+    /**
+     * Remove a prison's Offender Management Unit email address
+     * @deprecated
+     */
     delete: operations['deleteEmailAddressForOffenderManagementUnit']
+  }
+  '/secure/prisons/id/{prisonId}/department/contact-details': {
+    /** Get a prison department's contact details */
+    get: operations['getContactDetails']
+    /** Change a prison department's contact details */
+    put: operations['updateContactDetails']
+    /** Create a prison department's contact details */
+    post: operations['createContactDetails']
+    /** Remove a prison department's contact details */
+    delete: operations['deletePhoneNumber']
   }
   '/queue-admin/retry-dlq/{dlqName}': {
     put: operations['retryDlq']
@@ -32,33 +60,33 @@ export interface paths {
   '/prison-maintenance/id/{prisonId}': {
     /**
      * Update specified prison details
-     * @description Updates prison information, role required is MAINTAIN_REF_DATA
+     * @description Updates prison information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
      */
     put: operations['updatePrison']
   }
   '/prison-maintenance/id/{prisonId}/address/{addressId}': {
     /**
      * Update specified address details
-     * @description Updates address information, role required is MAINTAIN_REF_DATA
+     * @description Updates address information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
      */
     put: operations['updateAddress']
     /**
      * Delete specified address for specified Prison
-     * @description Deletes address information for a Prison, role required is MAINTAIN_REF_DATA
+     * @description Deletes address information for a Prison, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
      */
     delete: operations['deleteAddress']
   }
   '/prison-maintenance': {
     /**
      * Adds a new prison
-     * @description Adds new prison information, role required is MAINTAIN_REF_DATA
+     * @description Adds new prison information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
      */
     post: operations['insertPrison']
   }
   '/prison-maintenance/id/{prisonId}/address': {
     /**
      * Add Address to existing Prison
-     * @description Adds an additional Address to an existing Prison, role required is MAINTAIN_REF_DATA
+     * @description Adds an additional Address to an existing Prison, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
      */
     post: operations['addAddress']
   }
@@ -78,6 +106,13 @@ export interface paths {
      * @description All prisons
      */
     get: operations['getPrisonsBySearchFilter']
+  }
+  '/prisons/names': {
+    /**
+     * Get prison names
+     * @description prison id and full name
+     */
+    get: operations['getPrisonNames']
   }
   '/prisons/id/{prisonId}': {
     /**
@@ -107,6 +142,39 @@ export type webhooks = Record<string, never>
 
 export interface components {
   schemas: {
+    /** @description Contact information for a prison department */
+    ContactDetailsDto: {
+      /**
+       * @description Department Type
+       * @example SOCIAL_VISIT or PRISON
+       * @enum {string}
+       */
+      type: 'PRISON' | 'SOCIAL_VISIT' | 'VIDEOLINK_CONFERENCING_CENTRE' | 'OFFENDER_MANAGEMENT_UNIT'
+      /**
+       * @description email address
+       * @example example@example.com
+       */
+      emailAddress?: string
+      /**
+       * @description Phone Number
+       * @example 01234567890
+       */
+      phoneNumber?: string
+      /**
+       * @description Web address
+       * @example https://www.example.co.uk
+       */
+      webAddress?: string
+    }
+    ErrorResponse: {
+      /** Format: int32 */
+      status: number
+      /** Format: int32 */
+      errorCode?: number
+      userMessage?: string
+      developerMessage?: string
+      moreInfo?: string
+    }
     DlqMessage: {
       body: {
         [key: string]: Record<string, never>
@@ -141,15 +209,6 @@ export interface components {
       prisonTypes: ('HMP' | 'YOI' | 'IRC' | 'STC' | 'YCS')[]
       /** @description Set of categories for this prison */
       categories: ('A' | 'B' | 'C' | 'D')[]
-    }
-    ErrorResponse: {
-      /** Format: int32 */
-      status: number
-      /** Format: int32 */
-      errorCode?: number
-      userMessage?: string
-      developerMessage?: string
-      moreInfo?: string
     }
     /** @description List of address for this prison */
     AddressDto: {
@@ -311,6 +370,19 @@ export interface components {
       messagesReturnedCount: number
       messages: components['schemas']['DlqMessage'][]
     }
+    /** @description Full name of prison with id */
+    PrisonNameDto: {
+      /**
+       * @description Prison ID
+       * @example MDI
+       */
+      prisonId: string
+      /**
+       * @description Name of the prison
+       * @example Moorland HMP
+       */
+      prisonName: string
+    }
   }
   responses: never
   parameters: never
@@ -324,7 +396,10 @@ export type $defs = Record<string, never>
 export type external = Record<string, never>
 
 export interface operations {
-  /** Get a prison's Videolink Conferencing Centre email address */
+  /**
+   * Get a prison's Videolink Conferencing Centre email address
+   * @deprecated
+   */
   getEmailForVideoConferencingCentre: {
     parameters: {
       path: {
@@ -356,7 +431,10 @@ export interface operations {
       }
     }
   }
-  /** Set or change a prison's Videolink Conferencing Centre email address */
+  /**
+   * Set or change a prison's Videolink Conferencing Centre email address
+   * @deprecated
+   */
   putEmailAddressForVideolinkConferencingCentre: {
     parameters: {
       path: {
@@ -391,7 +469,10 @@ export interface operations {
       }
     }
   }
-  /** Remove a prison's Videolink Conferencing Centre email address */
+  /**
+   * Remove a prison's Videolink Conferencing Centre email address
+   * @deprecated
+   */
   deleteEmailAddressForVideolinkConferencingCentre: {
     parameters: {
       path: {
@@ -413,7 +494,10 @@ export interface operations {
       }
     }
   }
-  /** Get a prison's Offender Management Unit email address */
+  /**
+   * Get a prison's Offender Management Unit email address
+   * @deprecated
+   */
   getEmailForOffenderManagementUnit: {
     parameters: {
       path: {
@@ -445,7 +529,10 @@ export interface operations {
       }
     }
   }
-  /** Set or change a prison's Offender Management Unit email address */
+  /**
+   * Set or change a prison's Offender Management Unit email address
+   * @deprecated
+   */
   putEmailAddressForOffenderManagementUnit: {
     parameters: {
       path: {
@@ -480,7 +567,10 @@ export interface operations {
       }
     }
   }
-  /** Remove a prison's Offender Management Unit email address */
+  /**
+   * Remove a prison's Offender Management Unit email address
+   * @deprecated
+   */
   deleteEmailAddressForOffenderManagementUnit: {
     parameters: {
       path: {
@@ -499,6 +589,234 @@ export interface operations {
       /** @description Client error - invalid prisonId or similar */
       400: {
         content: never
+      }
+    }
+  }
+  /** Get a prison department's contact details */
+  getContactDetails: {
+    parameters: {
+      query: {
+        /**
+         * @description Department type
+         * @example SOCIAL_VISIT
+         */
+        departmentType: string
+      }
+      path: {
+        /**
+         * @description Prison ID
+         * @example MDI
+         */
+        prisonId: string
+      }
+    }
+    responses: {
+      /** @description Returns the departments contact details */
+      200: {
+        content: {
+          'application/json': components['schemas']['ContactDetailsDto']
+        }
+      }
+      /** @description Client error - invalid prisonId or similar */
+      400: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description The prison does not have contact details for this department */
+      404: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  /** Change a prison department's contact details */
+  updateContactDetails: {
+    parameters: {
+      query?: {
+        /**
+         * @description if true individual contact details are removed if null
+         * @example true
+         */
+        removeIfNull?: string
+      }
+      path: {
+        /**
+         * @description Prison ID
+         * @example MDI
+         */
+        prisonId: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ContactDetailsDto']
+      }
+    }
+    responses: {
+      /** @description The Contact details have been updated */
+      200: {
+        content: {
+          'application/json': components['schemas']['ContactDetailsDto']
+        }
+      }
+      /** @description Client error - invalid prisonId, contact details, media type or similar */
+      400: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description The given prison or contact details for this prison cannot be found. */
+      404: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  /** Create a prison department's contact details */
+  createContactDetails: {
+    parameters: {
+      path: {
+        /**
+         * @description Prison ID
+         * @example MDI
+         */
+        prisonId: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ContactDetailsDto']
+      }
+    }
+    responses: {
+      /** @description Contact details have been created */
+      201: {
+        content: {
+          'application/json': components['schemas']['ContactDetailsDto']
+        }
+      }
+      /** @description Client error - invalid prisonId, contact details, media type or similar */
+      400: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description The prison does not exist */
+      404: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  /** Remove a prison department's contact details */
+  deletePhoneNumber: {
+    parameters: {
+      query: {
+        /**
+         * @description Department type
+         * @example SOCIAL_VISIT
+         */
+        departmentType: string
+      }
+      path: {
+        /**
+         * @description Prison ID
+         * @example MDI
+         */
+        prisonId: string
+      }
+    }
+    responses: {
+      /** @description The contact details were removed */
+      204: {
+        content: {
+          'application/json':
+            | '100 CONTINUE'
+            | '101 SWITCHING_PROTOCOLS'
+            | '102 PROCESSING'
+            | '103 EARLY_HINTS'
+            | '103 CHECKPOINT'
+            | '200 OK'
+            | '201 CREATED'
+            | '202 ACCEPTED'
+            | '203 NON_AUTHORITATIVE_INFORMATION'
+            | '204 NO_CONTENT'
+            | '205 RESET_CONTENT'
+            | '206 PARTIAL_CONTENT'
+            | '207 MULTI_STATUS'
+            | '208 ALREADY_REPORTED'
+            | '226 IM_USED'
+            | '300 MULTIPLE_CHOICES'
+            | '301 MOVED_PERMANENTLY'
+            | '302 FOUND'
+            | '302 MOVED_TEMPORARILY'
+            | '303 SEE_OTHER'
+            | '304 NOT_MODIFIED'
+            | '305 USE_PROXY'
+            | '307 TEMPORARY_REDIRECT'
+            | '308 PERMANENT_REDIRECT'
+            | '400 BAD_REQUEST'
+            | '401 UNAUTHORIZED'
+            | '402 PAYMENT_REQUIRED'
+            | '403 FORBIDDEN'
+            | '404 NOT_FOUND'
+            | '405 METHOD_NOT_ALLOWED'
+            | '406 NOT_ACCEPTABLE'
+            | '407 PROXY_AUTHENTICATION_REQUIRED'
+            | '408 REQUEST_TIMEOUT'
+            | '409 CONFLICT'
+            | '410 GONE'
+            | '411 LENGTH_REQUIRED'
+            | '412 PRECONDITION_FAILED'
+            | '413 PAYLOAD_TOO_LARGE'
+            | '413 REQUEST_ENTITY_TOO_LARGE'
+            | '414 URI_TOO_LONG'
+            | '414 REQUEST_URI_TOO_LONG'
+            | '415 UNSUPPORTED_MEDIA_TYPE'
+            | '416 REQUESTED_RANGE_NOT_SATISFIABLE'
+            | '417 EXPECTATION_FAILED'
+            | '418 I_AM_A_TEAPOT'
+            | '419 INSUFFICIENT_SPACE_ON_RESOURCE'
+            | '420 METHOD_FAILURE'
+            | '421 DESTINATION_LOCKED'
+            | '422 UNPROCESSABLE_ENTITY'
+            | '423 LOCKED'
+            | '424 FAILED_DEPENDENCY'
+            | '425 TOO_EARLY'
+            | '426 UPGRADE_REQUIRED'
+            | '428 PRECONDITION_REQUIRED'
+            | '429 TOO_MANY_REQUESTS'
+            | '431 REQUEST_HEADER_FIELDS_TOO_LARGE'
+            | '451 UNAVAILABLE_FOR_LEGAL_REASONS'
+            | '500 INTERNAL_SERVER_ERROR'
+            | '501 NOT_IMPLEMENTED'
+            | '502 BAD_GATEWAY'
+            | '503 SERVICE_UNAVAILABLE'
+            | '504 GATEWAY_TIMEOUT'
+            | '505 HTTP_VERSION_NOT_SUPPORTED'
+            | '506 VARIANT_ALSO_NEGOTIATES'
+            | '507 INSUFFICIENT_STORAGE'
+            | '508 LOOP_DETECTED'
+            | '509 BANDWIDTH_LIMIT_EXCEEDED'
+            | '510 NOT_EXTENDED'
+            | '511 NETWORK_AUTHENTICATION_REQUIRED'
+        }
+      }
+      /** @description Client error - invalid prisonId or similar */
+      400: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description The contact details for this prison cannot be found. */
+      404: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
       }
     }
   }
@@ -544,7 +862,7 @@ export interface operations {
   }
   /**
    * Update specified prison details
-   * @description Updates prison information, role required is MAINTAIN_REF_DATA
+   * @description Updates prison information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
    */
   updatePrison: {
     parameters: {
@@ -596,7 +914,7 @@ export interface operations {
   }
   /**
    * Update specified address details
-   * @description Updates address information, role required is MAINTAIN_REF_DATA
+   * @description Updates address information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
    */
   updateAddress: {
     parameters: {
@@ -653,7 +971,7 @@ export interface operations {
   }
   /**
    * Delete specified address for specified Prison
-   * @description Deletes address information for a Prison, role required is MAINTAIN_REF_DATA
+   * @description Deletes address information for a Prison, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
    */
   deleteAddress: {
     parameters: {
@@ -697,7 +1015,7 @@ export interface operations {
   }
   /**
    * Adds a new prison
-   * @description Adds new prison information, role required is MAINTAIN_REF_DATA
+   * @description Adds new prison information, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
    */
   insertPrison: {
     requestBody: {
@@ -734,7 +1052,7 @@ export interface operations {
   }
   /**
    * Add Address to existing Prison
-   * @description Adds an additional Address to an existing Prison, role required is MAINTAIN_REF_DATA
+   * @description Adds an additional Address to an existing Prison, role required is MAINTAIN_REF_DATA or MAINTAIN_PRISON_DATA
    */
   addAddress: {
     parameters: {
@@ -850,6 +1168,20 @@ export interface operations {
       200: {
         content: {
           'application/json': components['schemas']['PrisonDto'][]
+        }
+      }
+    }
+  }
+  /**
+   * Get prison names
+   * @description prison id and full name
+   */
+  getPrisonNames: {
+    responses: {
+      /** @description Successful Operation */
+      200: {
+        content: {
+          'application/json': components['schemas']['PrisonNameDto'][]
         }
       }
     }

--- a/server/data/prisonRegisterApiClient.test.ts
+++ b/server/data/prisonRegisterApiClient.test.ts
@@ -7,7 +7,7 @@ describe('prisonRegisterApiClient', () => {
   let fakePrisonRegisterApi: nock.Scope
   let prisonRegisterApiClient: PrisonRegisterApiClient
   const token = 'token-1'
-  const allPrisons = TestData.prisons()
+  const prisonNames = TestData.prisonNames()
 
   beforeEach(() => {
     fakePrisonRegisterApi = nock(config.apis.prisonRegister.url)
@@ -23,11 +23,14 @@ describe('prisonRegisterApiClient', () => {
     nock.cleanAll()
   })
 
-  describe('getPrisons', () => {
-    it('should return all prisons from the Prison Register', async () => {
-      fakePrisonRegisterApi.get('/prisons').matchHeader('authorization', `Bearer ${token}`).reply(200, allPrisons)
-      const output = await prisonRegisterApiClient.getPrisons()
-      expect(output).toEqual(allPrisons)
+  describe('getPrisonNames', () => {
+    it('should return all prison names from the Prison Register', async () => {
+      fakePrisonRegisterApi
+        .get('/prisons/names')
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, prisonNames)
+      const output = await prisonRegisterApiClient.getPrisonNames()
+      expect(output).toEqual(prisonNames)
     })
   })
 })

--- a/server/data/prisonRegisterApiClient.ts
+++ b/server/data/prisonRegisterApiClient.ts
@@ -1,6 +1,6 @@
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
-import { PrisonDto } from './prisonRegisterApiTypes'
+import { PrisonName } from './prisonRegisterApiTypes'
 
 export default class PrisonRegisterApiClient {
   private restClient: RestClient
@@ -9,7 +9,7 @@ export default class PrisonRegisterApiClient {
     this.restClient = new RestClient('prisonRegisterApiClient', config.apis.prisonRegister as ApiConfig, token)
   }
 
-  async getPrisons(): Promise<PrisonDto[]> {
-    return this.restClient.get({ path: '/prisons' })
+  async getPrisonNames(): Promise<PrisonName[]> {
+    return this.restClient.get({ path: '/prisons/names' })
   }
 }

--- a/server/data/prisonRegisterApiTypes.ts
+++ b/server/data/prisonRegisterApiTypes.ts
@@ -1,3 +1,3 @@
 import { components } from '../@types/prison-register-api'
 
-export type PrisonDto = components['schemas']['PrisonDto']
+export type PrisonName = components['schemas']['PrisonNameDto']

--- a/server/middleware/populateSelectedEstablishment.test.ts
+++ b/server/middleware/populateSelectedEstablishment.test.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from 'express'
 import { Cookie } from 'express-session'
-import { Prison } from '../@types/bapv'
 import type { User } from '../data/hmppsAuthClient'
 import TestData from '../routes/testutils/testData'
 import { createMockSupportedPrisonsService } from '../services/testutils/mocks'
 import populateSelectedEstablishment from './populateSelectedEstablishment'
+import { PrisonName } from '../data/prisonRegisterApiTypes'
 
 const supportedPrisonsService = createMockSupportedPrisonsService()
 
@@ -35,7 +35,7 @@ describe('populateSelectedEstablishment', () => {
     } as unknown as Request
 
     res.locals = {
-      selectedEstablishment: <Prison>undefined,
+      selectedEstablishment: <PrisonName>undefined,
       user: <User>{ activeCaseLoadId: 'HEI' },
     }
   })
@@ -48,7 +48,7 @@ describe('populateSelectedEstablishment', () => {
     it('should set establishment in session and populate res.locals if active caseload is a supported prison', async () => {
       res.locals.user.activeCaseLoadId = 'BLI'
 
-      const expectedEstablishment: Prison = { prisonId: 'BLI', prisonName: supportedPrisons.BLI }
+      const expectedEstablishment: PrisonName = { prisonId: 'BLI', prisonName: supportedPrisons.BLI }
 
       await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
 

--- a/server/routes/changeEstablishment.test.ts
+++ b/server/routes/changeEstablishment.test.ts
@@ -5,13 +5,13 @@ import { SessionData } from 'express-session'
 import { appWithAllRoutes, flashProvider } from './testutils/appSetup'
 import * as visitorUtils from './visitorUtils'
 import TestData from './testutils/testData'
-import { Prison } from '../@types/bapv'
 import config from '../config'
 import {
   createMockAuditService,
   createMockSupportedPrisonsService,
   createMockUserService,
 } from '../services/testutils/mocks'
+import { PrisonName } from '../data/prisonRegisterApiTypes'
 
 let app: Express
 
@@ -132,7 +132,7 @@ describe('GET /change-establishment', () => {
 
 describe('POST /change-establishment', () => {
   let sessionData: SessionData
-  let selectedEstablishment: Prison
+  let selectedEstablishment: PrisonName
 
   beforeEach(() => {
     jest.spyOn(visitorUtils, 'clearSession')
@@ -182,7 +182,7 @@ describe('POST /change-establishment', () => {
   })
 
   it('should clear session, set selected establishment and redirect to home page', () => {
-    const newEstablishment: Prison = { prisonId: 'HEI', prisonName: supportedPrisons.HEI }
+    const newEstablishment: PrisonName = { prisonId: 'HEI', prisonName: supportedPrisons.HEI }
 
     return request(app)
       .post(`/change-establishment`)
@@ -203,7 +203,7 @@ describe('POST /change-establishment', () => {
   })
 
   it('should clear session, set selected establishment and redirect to / not the set referrer', () => {
-    const newEstablishment: Prison = { prisonId: 'HEI', prisonName: supportedPrisons.HEI }
+    const newEstablishment: PrisonName = { prisonId: 'HEI', prisonName: supportedPrisons.HEI }
 
     return request(app)
       .post(`/change-establishment?referrer=//search/prisoner/`)
@@ -219,7 +219,7 @@ describe('POST /change-establishment', () => {
   })
 
   it('should redirect to valid page when passed in querystring', () => {
-    const newEstablishment: Prison = { prisonId: 'HEI', prisonName: supportedPrisons.HEI }
+    const newEstablishment: PrisonName = { prisonId: 'HEI', prisonName: supportedPrisons.HEI }
 
     return request(app)
       .post(`/change-establishment?referrer=/search/prisoner/`)

--- a/server/routes/changeEstablishment.ts
+++ b/server/routes/changeEstablishment.ts
@@ -3,8 +3,8 @@ import { body, validationResult } from 'express-validator'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import { clearSession } from './visitorUtils'
 import { safeReturnUrl } from '../utils/utils'
-import { Prison } from '../@types/bapv'
 import type { Services, SupportedPrisonsService, UserService } from '../services'
+import { PrisonName } from '../data/prisonRegisterApiTypes'
 
 export default function routes({ auditService, supportedPrisonsService, userService }: Services): Router {
   const router = Router()
@@ -58,7 +58,7 @@ export default function routes({ auditService, supportedPrisonsService, userServ
     clearSession(req)
 
     const previousEstablishment = req.session.selectedEstablishment?.prisonId
-    const newEstablishment: Prison = {
+    const newEstablishment: PrisonName = {
       prisonId: req.body.establishment,
       prisonName: availablePrisons[req.body.establishment],
     }

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -1,4 +1,3 @@
-import { Prison } from '../../@types/bapv'
 import {
   Alert,
   NotificationCount,
@@ -15,6 +14,7 @@ import { CaseLoad, OffenderRestriction } from '../../data/prisonApiTypes'
 import { CurrentIncentive, Prisoner } from '../../data/prisonerOffenderSearchTypes'
 import { Address, Contact, Restriction } from '../../data/prisonerContactRegistryApiTypes'
 import { ScheduledEvent } from '../../data/whereaboutsApiTypes'
+import { PrisonName } from '../../data/prisonRegisterApiTypes'
 
 export default class TestData {
   static address = ({
@@ -165,7 +165,7 @@ export default class TestData {
       currentIncentive,
     }) as Prisoner
 
-  static prisons = ({
+  static prisonNames = ({
     prisons = [
       {
         prisonId: 'HEI',
@@ -175,8 +175,8 @@ export default class TestData {
         prisonId: 'BLI',
         prisonName: 'Bristol (HMP & YOI)',
       },
-    ] as Prison[],
-  } = {}): Prison[] => prisons
+    ] as PrisonName[],
+  } = {}): PrisonName[] => prisons
 
   static prisonerProfile = ({
     prisonerId = 'A1234BC',

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -1,6 +1,6 @@
 import { Request } from 'express'
 import { Session, SessionData } from 'express-session'
-import { Prison, VisitSlot, VisitSlotList } from '../@types/bapv'
+import { VisitSlot, VisitSlotList } from '../@types/bapv'
 import { clearSession, getFlashFormValues, getSelectedSlot, getSlotByTimeAndRestriction } from './visitorUtils'
 
 const prisonId = 'HEI'
@@ -183,7 +183,7 @@ describe('clearSession', () => {
     adultVisitors: { adults: [] },
     slotsList: {},
     visitSessionData: { prisoner: undefined },
-    selectedEstablishment: { prisonId: 'HEI', prisonName: 'Hewell (HMP)' } as Prison,
+    selectedEstablishment: { prisonId: 'HEI', prisonName: 'Hewell (HMP)' },
   }
 
   req.session = sessionData as Session & SessionData

--- a/server/services/supportedPrisonsService.test.ts
+++ b/server/services/supportedPrisonsService.test.ts
@@ -1,6 +1,5 @@
 import SupportedPrisonsService from './supportedPrisonsService'
 import TestData from '../routes/testutils/testData'
-import { PrisonDto } from '../data/prisonRegisterApiTypes'
 import {
   createMockHmppsAuthClient,
   createMockOrchestrationApiClient,
@@ -19,7 +18,7 @@ describe('Supported prisons service', () => {
   const OrchestrationApiClientFactory = jest.fn()
   const PrisonRegisterApiClientFactory = jest.fn()
 
-  const allPrisons = TestData.prisons()
+  const prisonNames = TestData.prisonNames()
   const supportedPrisons = TestData.supportedPrisons()
   const supportedPrisonIds = TestData.supportedPrisonIds()
 
@@ -32,7 +31,7 @@ describe('Supported prisons service', () => {
       hmppsAuthClient,
     )
 
-    prisonRegisterApiClient.getPrisons.mockResolvedValue(allPrisons as PrisonDto[])
+    prisonRegisterApiClient.getPrisonNames.mockResolvedValue(prisonNames)
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
   })
 
@@ -82,7 +81,7 @@ describe('Supported prisons service', () => {
 
       expect(results[0]).toEqual(supportedPrisons)
       expect(results[1]).toEqual(supportedPrisons)
-      expect(prisonRegisterApiClient.getPrisons).toHaveBeenCalledTimes(1)
+      expect(prisonRegisterApiClient.getPrisonNames).toHaveBeenCalledTimes(1)
     })
 
     it('should refresh internal cache of all prisons after 24 hours', async () => {
@@ -99,7 +98,7 @@ describe('Supported prisons service', () => {
       expect(results[0]).toEqual(supportedPrisons)
       expect(results[1]).toEqual(supportedPrisons)
       expect(results[2]).toEqual(supportedPrisons)
-      expect(prisonRegisterApiClient.getPrisons).toHaveBeenCalledTimes(2)
+      expect(prisonRegisterApiClient.getPrisonNames).toHaveBeenCalledTimes(2)
 
       jest.useRealTimers()
     })


### PR DESCRIPTION
Use new endpoint that just returns prison code/name (`/prisons/names`) in place of the existing `/prisons` that returns a lot of unnecessary data. The list of names is still cached within the `SupportedPrisonsService`.

Most of the changes are actually just updating variable names to be more appropriate.