### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/book-a-prison-visit-staff-ui/Chart.yaml
+++ b/helm_deploy/book-a-prison-visit-staff-ui/Chart.yaml
@@ -5,7 +5,7 @@ name: book-a-prison-visit-staff-ui
 version: 0.2.1
 dependencies:
   - name: generic-service
-    version: 2.8.0
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/book-a-prison-visit-staff-ui/values.yaml
+++ b/helm_deploy/book-a-prison-visit-staff-ui/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: book-a-prison-visit-staff-ui
 
@@ -7,12 +6,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/book-a-prison-visit-staff-ui
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: manage-prison-visits-cert
 
   livenessProbe:
@@ -52,30 +51,9 @@ generic-service:
       REDIS_AUTH_TOKEN: "auth_token"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    ark-dom1-psn1: 51.247.4.0/24
-    ark-dom1-psn2: 51.247.3.0/24
-    ark-nps-hmcts-ttp1: 195.59.75.0/24
-    ark-nps-hmcts-ttp2: 194.33.192.0/25
-    ark-nps-hmcts-ttp3: 194.33.193.0/25
-    ark-nps-hmcts-ttp4: 194.33.196.0/25
-    ark-nps-hmcts-ttp5: 194.33.197.0/25
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    quantum1: 62.25.109.197/32
-    quantum2: 212.137.36.230/32
-    quantum3: 195.92.38.16/28
-    moj-official-tgw-preprod: 51.149.251.0/24
-    moj-official-tgw-prod: 51.149.250.0/24
-    moj-official-ark-c-expo-e: 51.149.249.0/29
-    moj-official-ark-c-vodafone: 194.33.248.0/29
-    moj-official-ark-f-vodafone: 194.33.249.0/29
-    moj-official-ark-f-expo-e: 51.149.249.32/29
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
+    groups:
+      - internal
+      - prisons
 
 generic-prometheus-alerts:
   targetApplication: book-a-prison-visit-staff-ui

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in book-a-prison-visit-staff-ui/values.yaml
 
 generic-service:
@@ -27,52 +26,30 @@ generic-service:
     FEATURE_REVIEW_BOOKINGS: "true"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    ark-dom1-psn1: 51.247.4.0/24
-    ark-dom1-psn2: 51.247.3.0/24
-    ark-nps-hmcts-ttp1: 195.59.75.0/24
-    ark-nps-hmcts-ttp2: 194.33.192.0/25
-    ark-nps-hmcts-ttp3: 194.33.193.0/25
-    ark-nps-hmcts-ttp4: 194.33.196.0/25
-    ark-nps-hmcts-ttp5: 194.33.197.0/25
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    quantum1: 62.25.109.197/32
-    quantum2: 212.137.36.230/32
-    quantum3: 195.92.38.16/28
-    moj-official-tgw-preprod: 51.149.251.0/24
-    moj-official-tgw-prod: 51.149.250.0/24
-    moj-official-ark-c-expo-e: 51.149.249.0/29
-    moj-official-ark-c-vodafone: 194.33.248.0/29
-    moj-official-ark-f-vodafone: 194.33.249.0/29
-    moj-official-ark-f-expo-e: 51.149.249.32/29
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    circleci-1: "3.228.39.90"
-    circleci-2: "18.213.67.41"
-    circleci-3: "34.194.94.201"
-    circleci-4: "34.194.144.202"
-    circleci-5: "34.197.6.234"
-    circleci-6: "35.169.17.173"
-    circleci-7: "35.174.253.146"
-    circleci-8: "52.3.128.216"
-    circleci-9: "52.4.195.249"
-    circleci-10: "52.5.58.121"
-    circleci-11: "52.21.153.129"
-    circleci-12: "52.72.72.233"
-    circleci-13: "54.92.235.88"
-    circleci-14: "54.161.182.76"
-    circleci-15: "54.164.161.41"
-    circleci-16: "54.166.105.113"
-    circleci-17: "54.167.72.230"
-    circleci-18: "54.172.26.132"
-    circleci-19: "54.205.138.102"
-    circleci-20: "54.208.72.234"
-    circleci-21: "54.209.115.53"
+    circleci-1: 3.228.39.90/32
+    circleci-2: 18.213.67.41/32
+    circleci-3: 34.194.94.201/32
+    circleci-4: 34.194.144.202/32
+    circleci-5: 34.197.6.234/32
+    circleci-6: 35.169.17.173/32
+    circleci-7: 35.174.253.146/32
+    circleci-8: 52.3.128.216/32
+    circleci-9: 52.4.195.249/32
+    circleci-10: 52.5.58.121/32
+    circleci-11: 52.21.153.129/32
+    circleci-12: 52.72.72.233/32
+    circleci-13: 54.92.235.88/32
+    circleci-14: 54.161.182.76/32
+    circleci-15: 54.164.161.41/32
+    circleci-16: 54.166.105.113/32
+    circleci-17: 54.167.72.230/32
+    circleci-18: 54.172.26.132/32
+    circleci-19: 54.205.138.102/32
+    circleci-20: 54.208.72.234/32
+    circleci-21: 54.209.115.53/32
+    groups:
+      - internal
+      - prisons
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev
-

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in book-a-prison-visit-staff-ui/values.yaml
 
 generic-service:
@@ -27,52 +26,30 @@ generic-service:
     FEATURE_REVIEW_BOOKINGS: "false"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    ark-dom1-psn1: 51.247.4.0/24
-    ark-dom1-psn2: 51.247.3.0/24
-    ark-nps-hmcts-ttp1: 195.59.75.0/24
-    ark-nps-hmcts-ttp2: 194.33.192.0/25
-    ark-nps-hmcts-ttp3: 194.33.193.0/25
-    ark-nps-hmcts-ttp4: 194.33.196.0/25
-    ark-nps-hmcts-ttp5: 194.33.197.0/25
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    quantum1: 62.25.109.197/32
-    quantum2: 212.137.36.230/32
-    quantum3: 195.92.38.16/28
-    moj-official-tgw-preprod: 51.149.251.0/24
-    moj-official-tgw-prod: 51.149.250.0/24
-    moj-official-ark-c-expo-e: 51.149.249.0/29
-    moj-official-ark-c-vodafone: 194.33.248.0/29
-    moj-official-ark-f-vodafone: 194.33.249.0/29
-    moj-official-ark-f-expo-e: 51.149.249.32/29
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    circleci-1: "3.228.39.90"
-    circleci-2: "18.213.67.41"
-    circleci-3: "34.194.94.201"
-    circleci-4: "34.194.144.202"
-    circleci-5: "34.197.6.234"
-    circleci-6: "35.169.17.173"
-    circleci-7: "35.174.253.146"
-    circleci-8: "52.3.128.216"
-    circleci-9: "52.4.195.249"
-    circleci-10: "52.5.58.121"
-    circleci-11: "52.21.153.129"
-    circleci-12: "52.72.72.233"
-    circleci-13: "54.92.235.88"
-    circleci-14: "54.161.182.76"
-    circleci-15: "54.164.161.41"
-    circleci-16: "54.166.105.113"
-    circleci-17: "54.167.72.230"
-    circleci-18: "54.172.26.132"
-    circleci-19: "54.205.138.102"
-    circleci-20: "54.208.72.234"
-    circleci-21: "54.209.115.53"
+    circleci-1: 3.228.39.90/32
+    circleci-2: 18.213.67.41/32
+    circleci-3: 34.194.94.201/32
+    circleci-4: 34.194.144.202/32
+    circleci-5: 34.197.6.234/32
+    circleci-6: 35.169.17.173/32
+    circleci-7: 35.174.253.146/32
+    circleci-8: 52.3.128.216/32
+    circleci-9: 52.4.195.249/32
+    circleci-10: 52.5.58.121/32
+    circleci-11: 52.21.153.129/32
+    circleci-12: 52.72.72.233/32
+    circleci-13: 54.92.235.88/32
+    circleci-14: 54.161.182.76/32
+    circleci-15: 54.164.161.41/32
+    circleci-16: 54.166.105.113/32
+    circleci-17: 54.167.72.230/32
+    circleci-18: 54.172.26.132/32
+    circleci-19: 54.205.138.102/32
+    circleci-20: 54.208.72.234/32
+    circleci-21: 54.209.115.53/32
+    groups:
+      - internal
+      - prisons
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev
-


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

3 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/book-a-prison-visit-staff-ui/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons`
- The size of the allowlist defined in this file will change: `24 => 0 (24 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

- ark-dom1-psn1
  

- ark-dom1-psn2
  

- quantum
  

- quantum_alt
  

- quantum3
  

## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons`
- The size of the allowlist defined in this file will change: `45 => 21 (24 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

- ark-dom1-psn1
  

- ark-dom1-psn2
  

- quantum
  

- quantum_alt
  

- quantum3
  

## Allowlist: helm_deploy/values-staging.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons`
- The size of the allowlist defined in this file will change: `45 => 21 (24 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

- ark-dom1-psn1
  

- ark-dom1-psn2
  

- quantum
  

- quantum_alt
  

- quantum3
  
