### PR TITLE
VB-3283 Cancellation SMS - handle prisons with no phone number

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -130,6 +130,7 @@ export default {
       templates: {
         bookingConfirmation: '85904166-e539-43f5-9f51-7ba106cc61bd',
         cancellationConfirmation: '42a995f2-abbc-474b-8563-ca2995529111',
+        cancellationConfirmationNoPrisonPhone: '3103b319-267d-4265-83a6-a38e93fc2342',
         updateConfirmation: '386e83ff-5734-4d99-8279-b3eacb7cc8b8',
       },
     },

--- a/server/data/notificationsApiClient.test.ts
+++ b/server/data/notificationsApiClient.test.ts
@@ -1,7 +1,8 @@
 import config from '../config'
 import NotificationsApiClient from './notificationsApiClient'
 
-const { bookingConfirmation, cancellationConfirmation, updateConfirmation } = config.apis.notifications.templates
+const { bookingConfirmation, cancellationConfirmation, cancellationConfirmationNoPrisonPhone, updateConfirmation } =
+  config.apis.notifications.templates
 const mockSendSms = jest.fn()
 
 jest.mock('notifications-node-client', () => {
@@ -51,16 +52,16 @@ describe('GOV.UK Notify client', () => {
   })
 
   describe('sendCancellationSms', () => {
-    const cancellationDetails = {
-      phoneNumber: '07123456789',
-      prisonPhoneNumber: '01234443225',
-      prisonName: 'Hewell',
-      visitTime: '10:00am',
-      visitDate: '1 August 2022',
-      reference: 'ab-cd-ef-gh',
-    }
+    it('should call notifications client sendCancellationSms() with the correct booking cancellation parameters - WITH prison phone number', async () => {
+      const cancellationDetails = {
+        phoneNumber: '07123456789',
+        prisonPhoneNumber: '01234443225',
+        prisonName: 'Hewell',
+        visitTime: '10:00am',
+        visitDate: '1 August 2022',
+        reference: 'ab-cd-ef-gh',
+      }
 
-    it('should call notifications client sendCancellationSms() with the correct booking cancellation parameters', async () => {
       await notificationsApiClient.sendCancellationSms(cancellationDetails)
 
       expect(mockSendSms).toHaveBeenCalledTimes(1)
@@ -68,6 +69,29 @@ describe('GOV.UK Notify client', () => {
         personalisation: {
           prison: cancellationDetails.prisonName,
           'prison phone number': cancellationDetails.prisonPhoneNumber,
+          time: cancellationDetails.visitTime,
+          date: cancellationDetails.visitDate,
+          reference: cancellationDetails.reference,
+        },
+      })
+    })
+
+    it('should call notifications client sendCancellationSms() with the correct booking cancellation parameters - WITHOUT prison phone number', async () => {
+      const cancellationDetails = {
+        phoneNumber: '07123456789',
+        prisonPhoneNumber: '',
+        prisonName: 'Hewell',
+        visitTime: '10:00am',
+        visitDate: '1 August 2022',
+        reference: 'ab-cd-ef-gh',
+      }
+
+      await notificationsApiClient.sendCancellationSms(cancellationDetails)
+
+      expect(mockSendSms).toHaveBeenCalledTimes(1)
+      expect(mockSendSms).toHaveBeenCalledWith(cancellationConfirmationNoPrisonPhone, cancellationDetails.phoneNumber, {
+        personalisation: {
+          prison: cancellationDetails.prisonName,
           time: cancellationDetails.visitTime,
           date: cancellationDetails.visitDate,
           reference: cancellationDetails.reference,

--- a/server/data/notificationsApiClient.ts
+++ b/server/data/notificationsApiClient.ts
@@ -54,15 +54,24 @@ export default class NotificationsApiClient {
     prisonPhoneNumber: string
     reference: string
   }): Promise<SmsResponse> {
-    return this.notificationsApiClient.sendSms(templates.cancellationConfirmation, phoneNumber, {
-      personalisation: {
-        prison: prisonName,
-        time: visitTime,
-        date: visitDate,
-        'prison phone number': prisonPhoneNumber,
-        reference,
-      },
-    })
+    return prisonPhoneNumber !== ''
+      ? this.notificationsApiClient.sendSms(templates.cancellationConfirmation, phoneNumber, {
+          personalisation: {
+            prison: prisonName,
+            time: visitTime,
+            date: visitDate,
+            'prison phone number': prisonPhoneNumber,
+            reference,
+          },
+        })
+      : this.notificationsApiClient.sendSms(templates.cancellationConfirmationNoPrisonPhone, phoneNumber, {
+          personalisation: {
+            prison: prisonName,
+            time: visitTime,
+            date: visitDate,
+            reference,
+          },
+        })
   }
 
   async sendUpdateSms({


### PR DESCRIPTION
When sending a cancellation SMS, if a prison doesn't have a contact number use a different Notify template that doesn't include this data.