### PR TITLE
Add 'data-test' attribute on time slot radios

### DIFF
--- a/server/views/pages/bookAVisit/dateAndTime.njk
+++ b/server/views/pages/bookAVisit/dateAndTime.njk
@@ -39,13 +39,14 @@
       {%- endif %}
     {% endset %}
 
+    {%- set slotTimeString = slot.startTimestamp | formatTime + " to " + slot.endTimestamp | formatTime -%}
     {%- set radios = (radios.push({
       value: slot.id,
-      html: '<p class="bapv-radio-paragraph"><strong>' + slot.startTimestamp | formatTime +
-        " to " + slot.endTimestamp | formatTime + "</strong><br>" + tableText + "</p>",
+      html: '<p class="bapv-radio-paragraph"><strong>' + slotTimeString + "</strong><br>" + tableText + "</p>",
       id: slot.id,
       checked: checked,
-      disabled: (doubleBooked and not checked)
+      disabled: (doubleBooked and not checked),
+      attributes: { "data-test": slot.startTimestamp | formatDate("yyyy-MM-dd") + " - " + slotTimeString }
     }), radios) %}
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
Add a `data-test` attribute to the radio selections on the data time picker page. This is to make it easier for automated testing. The new attribute contains the date and the start/end times of the slot. For example:

```
<input class="govuk-radios__input" id="7" name="visit-date-and-time" type="radio" value="7" data-test="2023-12-15 - 9am to 10am">
```