### PR TITLE
VB-3200 Fix 'change establishment' error when user has unsupported case load

### DIFF
--- a/integration_tests/integration/changeEstablishment.cy.ts
+++ b/integration_tests/integration/changeEstablishment.cy.ts
@@ -28,6 +28,7 @@ context('Change establishment', () => {
 
     const changeEstablishmentPage = Page.verifyOnPage(ChangeEstablishmentPage)
     changeEstablishmentPage.selectEstablishment('BLI')
+    cy.task('stubGetPrison', TestData.prisonDto({ code: 'BLI' }))
     changeEstablishmentPage.continueButton().click()
 
     homePage = Page.verifyOnPage(HomePage)

--- a/server/routes/changeEstablishment.test.ts
+++ b/server/routes/changeEstablishment.test.ts
@@ -27,7 +27,7 @@ beforeEach(() => {
   supportedPrisonsService.getPolicyNoticeDaysMin.mockResolvedValue(2)
 
   userService.getUser.mockResolvedValue(user as UserDetails)
-  userService.getActiveCaseLoadId.mockResolvedValue('HEI')
+  userService.getActiveCaseLoadId.mockResolvedValue('XYZ') // assume user coming with an unsupported case load
 
   app = appWithAllRoutes({ services: { supportedPrisonsService } })
 })
@@ -164,6 +164,7 @@ describe('POST /change-establishment', () => {
           { location: 'body', msg: 'No prison selected', path: 'establishment', type: 'field', value: '' },
         ])
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(0)
+        expect(supportedPrisonsService.getPolicyNoticeDaysMin).not.toHaveBeenCalled()
         expect(auditService.changeEstablishment).toHaveBeenCalledTimes(0)
         expect(userService.setActiveCaseLoad).not.toHaveBeenCalled()
       })
@@ -181,6 +182,7 @@ describe('POST /change-establishment', () => {
           { location: 'body', msg: 'No prison selected', path: 'establishment', type: 'field', value: 'HEX' },
         ])
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(0)
+        expect(supportedPrisonsService.getPolicyNoticeDaysMin).not.toHaveBeenCalled()
         expect(auditService.changeEstablishment).toHaveBeenCalledTimes(0)
         expect(userService.setActiveCaseLoad).not.toHaveBeenCalled()
       })
@@ -197,6 +199,7 @@ describe('POST /change-establishment', () => {
       .expect(() => {
         expect(sessionData.selectedEstablishment).toStrictEqual(newEstablishment)
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
+        expect(supportedPrisonsService.getPolicyNoticeDaysMin).toHaveBeenCalledWith('user1', 'HEI')
         expect(auditService.changeEstablishment).toHaveBeenCalledWith({
           previousEstablishment: 'BLI',
           newEstablishment: 'HEI',
@@ -218,6 +221,7 @@ describe('POST /change-establishment', () => {
       .expect(() => {
         expect(sessionData.selectedEstablishment).toStrictEqual(newEstablishment)
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
+        expect(supportedPrisonsService.getPolicyNoticeDaysMin).toHaveBeenCalledWith('user1', 'HEI')
         expect(auditService.changeEstablishment).toHaveBeenCalledTimes(1)
         expect(userService.setActiveCaseLoad).toHaveBeenCalledWith('HEI', 'user1')
       })
@@ -234,6 +238,7 @@ describe('POST /change-establishment', () => {
       .expect(() => {
         expect(sessionData.selectedEstablishment).toStrictEqual(newEstablishment)
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
+        expect(supportedPrisonsService.getPolicyNoticeDaysMin).toHaveBeenCalledWith('user1', 'HEI')
         expect(auditService.changeEstablishment).toHaveBeenCalledTimes(1)
         expect(userService.setActiveCaseLoad).toHaveBeenCalledWith('HEI', 'user1')
       })

--- a/server/routes/changeEstablishment.ts
+++ b/server/routes/changeEstablishment.ts
@@ -59,7 +59,7 @@ export default function routes({ auditService, supportedPrisonsService, userServ
 
     const policyNoticeDaysMin = await supportedPrisonsService.getPolicyNoticeDaysMin(
       res.locals.user.username,
-      res.locals.user.activeCaseLoadId,
+      req.body.establishment,
     )
 
     const previousEstablishment = req.session.selectedEstablishment?.prisonId


### PR DESCRIPTION
Fix issue where user arriving in the service (from DPS) with an unsupported caseload would not be able to successfully change to a supported caseload.