### PR TITLE
VB-2099 Cypress-axe - fail on violations and add ignore list for known accessibility violations

### DIFF
--- a/integration_tests/pages/additionalSupport.ts
+++ b/integration_tests/pages/additionalSupport.ts
@@ -2,7 +2,11 @@ import Page, { PageElement } from './page'
 
 export default class AdditionalSupportPage extends Page {
   constructor() {
-    super('Is additional support needed for any of the visitors?')
+    super('Is additional support needed for any of the visitors?', {
+      // Known issue with radio conditional reveal. See:
+      // https://github.com/alphagov/govuk-frontend/issues/979
+      axeRulesToIgnore: ['aria-allowed-attr'],
+    })
   }
 
   additionalSupportRequired = (): PageElement => cy.get('[data-test=support-required-yes]')

--- a/integration_tests/pages/cancelVisit.ts
+++ b/integration_tests/pages/cancelVisit.ts
@@ -2,7 +2,11 @@ import Page, { PageElement } from './page'
 
 export default class CancelVisitPage extends Page {
   constructor() {
-    super('Why is this booking being cancelled?')
+    super('Why is this booking being cancelled?', {
+      // Known issue with radio conditional reveal. See:
+      // https://github.com/alphagov/govuk-frontend/issues/979
+      axeRulesToIgnore: ['aria-allowed-attr'],
+    })
   }
 
   // Cancellation reason radios

--- a/integration_tests/pages/mainContact.ts
+++ b/integration_tests/pages/mainContact.ts
@@ -2,7 +2,11 @@ import Page, { PageElement } from './page'
 
 export default class MainContactPage extends Page {
   constructor() {
-    super('Who is the main contact for this booking?')
+    super('Who is the main contact for this booking?', {
+      // Known issue with radio conditional reveal. See:
+      // https://github.com/alphagov/govuk-frontend/issues/979
+      axeRulesToIgnore: ['aria-allowed-attr'],
+    })
   }
 
   getFirstContact = (): PageElement => cy.get('#contact')

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -29,6 +29,7 @@ export default abstract class Page {
   }
 
   runAxe = (axeRulesToIgnore: string[] = []): void => {
+    // If passed, build set of axe rules to ignore for a particular page class
     const rules: axe.RuleObject = axeRulesToIgnore.reduce((acc, cur) => {
       acc[cur] = { enabled: false }
       return acc

--- a/integration_tests/pages/selectVisitDateAndTime.ts
+++ b/integration_tests/pages/selectVisitDateAndTime.ts
@@ -2,7 +2,11 @@ import Page, { PageElement } from './page'
 
 export default class SelectVisitDateAndTime extends Page {
   constructor() {
-    super('Select date and time of visit')
+    super('Select date and time of visit', {
+      // @TODO remove this ignore list once GOV.UK Frontend is released
+      // with accordion component changes in https://github.com/alphagov/govuk-frontend/pull/4628
+      axeRulesToIgnore: ['aria-prohibited-attr', 'aria-allowed-attr'],
+    })
   }
 
   expandAllSections = (): void => {

--- a/integration_tests/pages/visitsByDate.ts
+++ b/integration_tests/pages/visitsByDate.ts
@@ -2,7 +2,11 @@ import Page, { PageElement } from './page'
 
 export default class VisitsByDatePage extends Page {
   constructor() {
-    super('View visits by date')
+    super('View visits by date', {
+      // Known issue with MoJ Side navigation component when using section headers. See:
+      // https://design-patterns.service.justice.gov.uk/components/side-navigation/
+      axeRulesToIgnore: ['heading-order'],
+    })
   }
 
   today = (): PageElement => cy.get(':nth-child(1) > .moj-sub-navigation__link')


### PR DESCRIPTION
`Cypress-axe` was previously configured to only log accessibility violations. It will now fail a test if there is a violation.

Add a means to define `axeRulesToIgnore` (an array of rule names) in the `Page` test classes so that known accessibility issues (e.g. in GOV.UK components) can be ignored for that particular page.