### PR TITLE
Change service level implementation when returning additional support

### DIFF
--- a/server/services/visitService.ts
+++ b/server/services/visitService.ts
@@ -144,7 +144,7 @@ export default class VisitService {
       ? await orchestrationApiClient.getVisitNotifications(reference)
       : []
 
-    const additionalSupport = visit.visitorSupport.description
+    const additionalSupport = visit.visitorSupport ? visit.visitorSupport.description : ''
 
     return { visitHistoryDetails, visitors, notifications, additionalSupport }
   }


### PR DESCRIPTION
## Description

If no additional support set, orchestration doesn't return the `visitorSupport` object, this checks if the object exists before defining in local session data 