### PR TITLE
Fix test attribute

### DIFF
--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -239,7 +239,7 @@
                   text: "Additional support"
                 },
                 value: {
-                  html: '<span data-test="additional-support">' + additionalSupport  if additionalSupport | length else "None" + '</span>'
+                  html: '<span data-test="additional-support">' + (additionalSupport  if additionalSupport | length else "None") + '</span>'
                 }
               }
             ]


### PR DESCRIPTION
Missing parentheses meant that the `<span>` with the `data-test` attribute wasn't getting generated properly.