### PR TITLE
VB-3586, remove second paragraph

### DIFF
--- a/server/views/pages/timetable.njk
+++ b/server/views/pages/timetable.njk
@@ -156,15 +156,11 @@
     <div class="govuk-grid-column-three-quarters">
 
       <h2 class="govuk-heading-m" data-test="change-timetable">Request changes to the timetable</h2>
-      <p>You should provide six weeks' notice to change the timetable. To request a change,
-          <a href="https://request-changes-to-the-visits-timetable.form.service.justice.gov.uk/" target="_blank" data-test="change-request">complete the request form (opens in a new tab)</a>.
-          We will respond within 5 working days.
+      <p>
+        You should provide six weeks' notice to change the timetable. To request a change,
+        <a href="https://request-changes-to-the-visits-timetable.form.service.justice.gov.uk/" target="_blank" data-test="change-request">complete the request form (opens in a new tab)</a>.
+        We will respond within 5 working days.
       </p>
-      <p>In exceptional circumstances when you need to make a change to the timetable within the next six weeks,
-          email or call the Family Services Contact Centre. They will need to cancel any visits already booked
-          for these dates and tell booking staff to not make further bookings for this visit session.
-      </p>
-
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Description

Remove second paragraph on timetable page, as no longer required