### PR TITLE
VB-3296 Visits by date page: handle 'unknown' visits

### DIFF
--- a/integration_tests/integration/datePicker.cy.ts
+++ b/integration_tests/integration/datePicker.cy.ts
@@ -21,6 +21,7 @@ context('Date picker', () => {
     cy.signIn()
 
     cy.task('stubSessionSchedule', { prisonId, date: todayShortFormat, sessionSchedule: [] })
+    cy.task('stubGetVisitsWithoutSessionTemplate', { prisonId, sessionDate: todayShortFormat, visits: [] })
   })
 
   it('should navigate through a range of dates and correctly handle month and year boundaries', () => {

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -224,7 +224,36 @@ export default {
           prisonCode: { equalTo: prisonId },
           sessionTemplateReference: { equalTo: reference },
           sessionDate: { equalTo: sessionDate },
+          visitStatus: { equalTo: 'BOOKED' },
           visitRestrictions: { equalTo: visitRestrictions },
+        },
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: visits,
+      },
+    })
+  },
+  stubGetVisitsWithoutSessionTemplate: ({
+    prisonId,
+    sessionDate,
+    visits,
+  }: {
+    prisonId: string
+    sessionDate: string
+    visits: VisitPreview[]
+  }): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPath: '/orchestration/visits/session-template',
+        queryParameters: {
+          prisonCode: { equalTo: prisonId },
+          sessionTemplateReference: { absent: true },
+          sessionDate: { equalTo: sessionDate },
+          visitStatus: { equalTo: 'BOOKED' },
+          visitRestrictions: { absent: true },
         },
       },
       response: {

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -134,7 +134,7 @@ export type VisitInformation = {
 export type VisitsPageSideNavItem = {
   reference: string
   times: string
-  capacity: number
+  capacity?: number // optional to cater for 'unknown' visits with no session template
   queryParams: string
   active: boolean
 }
@@ -142,6 +142,7 @@ export type VisitsPageSideNavItem = {
 export type VisitsPageSideNav = {
   open?: VisitsPageSideNavItem[]
   closed?: VisitsPageSideNavItem[]
+  unknown?: VisitsPageSideNavItem[] // for visits with no session template (old, migrated data)
 }
 
 export type FlashData = Record<string, string[] | Record<string, string | string[]>[]>

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -158,7 +158,7 @@ describe('orchestrationApiClient', () => {
   })
 
   describe('getVisitsBySessionTemplate', () => {
-    it('should return visit previews details for given session template reference, date and restriction', async () => {
+    it('should return visit previews details for given session template reference, date, prison and restriction', async () => {
       const sessionTemplateReference = 'v9d.7ed.7u'
       const sessionDate = '2024-01-31'
       const visitRestrictions: VisitRestriction = 'OPEN'
@@ -181,6 +181,30 @@ describe('orchestrationApiClient', () => {
         sessionTemplateReference,
         sessionDate,
         visitRestrictions,
+      )
+
+      expect(output).toStrictEqual(visitPreviews)
+    })
+
+    it('should return visit previews details when only prison and date given (for migrated visits with no session template)', async () => {
+      const sessionDate = '2024-01-31'
+      const visitPreviews = [TestData.visitPreview()]
+
+      fakeOrchestrationApi
+        .get('/visits/session-template')
+        .query({
+          prisonCode: prisonId,
+          sessionDate,
+          visitStatus: 'BOOKED',
+        })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, visitPreviews)
+
+      const output = await orchestrationApiClient.getVisitsBySessionTemplate(
+        prisonId,
+        undefined,
+        sessionDate,
+        undefined,
       )
 
       expect(output).toStrictEqual(visitPreviews)

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -91,10 +91,10 @@ export default class OrchestrationApiClient {
       path: '/visits/session-template',
       query: new URLSearchParams({
         prisonCode: prisonId,
-        sessionTemplateReference: reference,
+        ...(reference && { sessionTemplateReference: reference }),
         sessionDate,
         visitStatus: 'BOOKED',
-        visitRestrictions,
+        ...(visitRestrictions && { visitRestrictions }),
       }).toString(),
     })
   }

--- a/server/routes/visits.test.ts
+++ b/server/routes/visits.test.ts
@@ -45,194 +45,441 @@ describe('GET /visits', () => {
 
   beforeEach(() => {
     jest.useFakeTimers({ advanceTimers: true, now: fakeDateTime })
-    visitSessionsService.getSessionSchedule.mockResolvedValue(sessionSchedule)
-    visitService.getVisitsBySessionTemplate.mockResolvedValue(visits)
   })
 
   afterEach(() => {
     jest.useRealTimers()
   })
 
-  it('should render date tabs, side-nav and visits for default date (today)', () => {
-    return request(app)
-      .get('/visits')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('h1').text()).toBe('View visits by date')
-        expect($('.govuk-back-link').attr('href')).toBe('/')
+  describe('open & closed visits (these have a session template)', () => {
+    beforeEach(() => {
+      visitSessionsService.getSessionSchedule.mockResolvedValue(sessionSchedule)
+      visitService.getVisitsBySessionTemplate.mockResolvedValue(visits)
+      visitService.getVisitsWithoutSessionTemplate.mockResolvedValue([])
+    })
 
-        // date tabs
-        expect($('.moj-sub-navigation__link').length).toBe(3)
-        expect($('.moj-sub-navigation__link').eq(0).text()).toBe('Thursday 1 February 2024')
-        expect($('.moj-sub-navigation__link').eq(0).attr('href')).toBe(
-          '/visits?selectedDate=2024-02-01&firstTabDate=2024-02-01',
-        )
-        expect($('.moj-sub-navigation__link').eq(0).attr('aria-current')).toBe('page')
+    it('should render date tabs, side-nav and visits for default date (today)', () => {
+      return request(app)
+        .get('/visits')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('View visits by date')
+          expect($('.govuk-back-link').attr('href')).toBe('/')
 
-        expect($('.moj-sub-navigation__link').eq(1).text()).toBe('Friday 2 February 2024')
-        expect($('.moj-sub-navigation__link').eq(1).attr('href')).toBe(
-          '/visits?selectedDate=2024-02-02&firstTabDate=2024-02-01',
-        )
-        expect($('.moj-sub-navigation__link').eq(1).attr('aria-current')).toBe(undefined)
+          // date tabs
+          expect($('.moj-sub-navigation__link').length).toBe(3)
+          expect($('.moj-sub-navigation__link').eq(0).text()).toBe('Thursday 1 February 2024')
+          expect($('.moj-sub-navigation__link').eq(0).attr('href')).toBe(
+            '/visits?selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-sub-navigation__link').eq(0).attr('aria-current')).toBe('page')
 
-        expect($('.moj-sub-navigation__link').eq(2).text()).toBe('Saturday 3 February 2024')
-        expect($('.moj-sub-navigation__link').eq(2).attr('href')).toBe(
-          '/visits?selectedDate=2024-02-03&firstTabDate=2024-02-01',
-        )
-        expect($('.moj-sub-navigation__link').eq(2).attr('aria-current')).toBe(undefined)
+          expect($('.moj-sub-navigation__link').eq(1).text()).toBe('Friday 2 February 2024')
+          expect($('.moj-sub-navigation__link').eq(1).attr('href')).toBe(
+            '/visits?selectedDate=2024-02-02&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-sub-navigation__link').eq(1).attr('aria-current')).toBe(undefined)
 
-        // side-nav
-        expect($('.moj-side-navigation h4').eq(0).text()).toBe('Open visits')
-        expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('1:45pm to 3:45pm')
-        expect($('.moj-side-navigation ul').eq(0).find('a').first().attr('href')).toBe(
-          '/visits?type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
-        )
-        expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
-          '/visits?type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
-        )
+          expect($('.moj-sub-navigation__link').eq(2).text()).toBe('Saturday 3 February 2024')
+          expect($('.moj-sub-navigation__link').eq(2).attr('href')).toBe(
+            '/visits?selectedDate=2024-02-03&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-sub-navigation__link').eq(2).attr('aria-current')).toBe(undefined)
 
-        expect($('.moj-side-navigation h4').eq(1).text()).toBe('Closed visits')
-        expect($('.moj-side-navigation ul').eq(1).find('a').text()).toBe('1:45pm to 3:45pm')
-        expect($('.moj-side-navigation ul').eq(1).find('a').first().attr('href')).toBe(
-          '/visits?type=CLOSED&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
-        )
+          // side-nav
+          expect($('.moj-side-navigation h4').eq(0).text()).toBe('Open visits')
+          expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('1:45pm to 3:45pm')
+          expect($('.moj-side-navigation ul').eq(0).find('a').first().attr('href')).toBe(
+            '/visits?type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
+            '/visits?type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
 
-        // Visits
-        expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 1:45pm to 3:45pm')
-        expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 of 20 tables booked')
-        expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+          expect($('.moj-side-navigation h4').eq(1).text()).toBe('Closed visits')
+          expect($('.moj-side-navigation ul').eq(1).find('a').text()).toBe('1:45pm to 3:45pm')
+          expect($('.moj-side-navigation ul').eq(1).find('a').first().attr('href')).toBe(
+            '/visits?type=CLOSED&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
 
-        expect($('[data-test="prisoner-name"]').eq(0).text().trim()).toBe('Smith, John')
-        expect($('[data-test="prisoner-number"]').eq(0).text().trim()).toBe('A1234BC')
-        expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe(
-          '/visit/ab-cd-ef-gh?query=type%3DOPEN%26sessionReference%3D-afe.dcc.0f%26selectedDate%3D2024-02-01%26firstTabDate%3D2024-02-01&from=visits',
-        )
+          // Visits
+          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 1:45pm to 3:45pm')
+          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 of 20 tables booked')
+          expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
 
-        expect($('#search-results-none').length).toBe(0)
+          expect($('[data-test="prisoner-name"]').eq(0).text().trim()).toBe('Smith, John')
+          expect($('[data-test="prisoner-number"]').eq(0).text().trim()).toBe('A1234BC')
+          expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe(
+            '/visit/ab-cd-ef-gh?query=type%3DOPEN%26sessionReference%3D-afe.dcc.0f%26selectedDate%3D2024-02-01%26firstTabDate%3D2024-02-01&from=visits',
+          )
 
-        expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
-          username: 'user1',
-          prisonId,
-          date: today,
+          expect($('#search-results-none').length).toBe(0)
+
+          expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            date: today,
+          })
+          expect(visitService.getVisitsBySessionTemplate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            reference: sessionSchedule[0].sessionTemplateReference,
+            sessionDate: today,
+            visitRestrictions: 'OPEN',
+          })
+          expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            sessionDate: today,
+          })
+          expect(auditService.viewedVisits).toHaveBeenCalledWith({
+            viewDate: today,
+            prisonId,
+            username: 'user1',
+            operationId: undefined,
+          })
         })
-        expect(visitService.getVisitsBySessionTemplate).toHaveBeenCalledWith({
-          username: 'user1',
-          prisonId,
-          reference: sessionSchedule[0].sessionTemplateReference,
-          sessionDate: today,
-          visitRestrictions: 'OPEN',
+    })
+
+    it('should render date tabs, side-nav and visits for a specific date and closed session', () => {
+      return request(app)
+        .get('/visits?type=CLOSED&sessionReference=-afe.dcc.0f&selectedDate=2024-02-02&firstTabDate=2024-02-01')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('View visits by date')
+          expect($('.govuk-back-link').attr('href')).toBe('/')
+
+          // date tabs
+          expect($('.moj-sub-navigation__link').length).toBe(3)
+          expect($('.moj-sub-navigation__link').eq(1).attr('aria-current')).toBe('page')
+
+          // side-nav
+          expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
+            '/visits?type=CLOSED&sessionReference=-afe.dcc.0f&selectedDate=2024-02-02&firstTabDate=2024-02-01',
+          )
+
+          // Visits
+          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Closed visits, 1:45pm to 3:45pm')
+          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 of 5 tables booked')
+          expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+
+          expect($('[data-test="prisoner-name"]').eq(0).text().trim()).toBe('Smith, John')
+          expect($('[data-test="prisoner-number"]').eq(0).text().trim()).toBe('A1234BC')
+          expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe(
+            '/visit/ab-cd-ef-gh?query=type%3DCLOSED%26sessionReference%3D-afe.dcc.0f%26selectedDate%3D2024-02-02%26firstTabDate%3D2024-02-01&from=visits',
+          )
+
+          expect($('#search-results-none').length).toBe(0)
+
+          expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            date: '2024-02-02',
+          })
+          expect(visitService.getVisitsBySessionTemplate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            reference: sessionSchedule[0].sessionTemplateReference,
+            sessionDate: '2024-02-02',
+            visitRestrictions: 'CLOSED',
+          })
+          expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            sessionDate: '2024-02-02',
+          })
+          expect(auditService.viewedVisits).toHaveBeenCalledWith({
+            viewDate: '2024-02-02',
+            prisonId,
+            username: 'user1',
+            operationId: undefined,
+          })
         })
-        expect(auditService.viewedVisits).toHaveBeenCalledWith({
-          viewDate: today,
-          prisonId,
-          username: 'user1',
-          operationId: undefined,
+    })
+
+    it('should render default (today) if invalid query parameters passed', () => {
+      return request(app)
+        .get('/visits?type=INVALID&sessionReference=REFERENCE&selectedDate=2024-99-01&firstTabDate=2024-99-01')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('View visits by date')
+          expect($('.govuk-back-link').attr('href')).toBe('/')
+
+          // date tabs
+          expect($('.moj-sub-navigation__link').length).toBe(3)
+          expect($('.moj-sub-navigation__link').eq(0).text()).toBe('Thursday 1 February 2024')
+          expect($('.moj-sub-navigation__link').eq(0).attr('href')).toBe(
+            '/visits?selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-sub-navigation__link').eq(0).attr('aria-current')).toBe('page')
+
+          // side-nav
+          expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
+            '/visits?type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+
+          // Visits
+          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 1:45pm to 3:45pm')
+          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 of 20 tables booked')
+          expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+
+          expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            date: today,
+          })
+          expect(visitService.getVisitsBySessionTemplate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            reference: sessionSchedule[0].sessionTemplateReference,
+            sessionDate: today,
+            visitRestrictions: 'OPEN',
+          })
+          expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            sessionDate: today,
+          })
+          expect(auditService.viewedVisits).toHaveBeenCalledWith({
+            viewDate: today,
+            prisonId,
+            username: 'user1',
+            operationId: undefined,
+          })
         })
-      })
+    })
   })
 
-  it('should render date tabs, side-nav and visits for a specific date and closed session', () => {
-    return request(app)
-      .get('/visits?type=CLOSED&sessionReference=-afe.dcc.0f&selectedDate=2024-02-02&firstTabDate=2024-02-01')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('h1').text()).toBe('View visits by date')
-        expect($('.govuk-back-link').attr('href')).toBe('/')
+  describe('unknown visits (those with no session template)', () => {
+    beforeEach(() => {
+      visitSessionsService.getSessionSchedule.mockResolvedValue([])
+      visitService.getVisitsBySessionTemplate.mockResolvedValue([])
+      visitService.getVisitsWithoutSessionTemplate.mockResolvedValue(visits)
+    })
 
-        // date tabs
-        expect($('.moj-sub-navigation__link').length).toBe(3)
-        expect($('.moj-sub-navigation__link').eq(1).attr('aria-current')).toBe('page')
+    it('should render date tabs, side-nav and visits for default date (today)', () => {
+      return request(app)
+        .get('/visits')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('View visits by date')
+          expect($('.govuk-back-link').attr('href')).toBe('/')
 
-        // side-nav
-        expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
-          '/visits?type=CLOSED&sessionReference=-afe.dcc.0f&selectedDate=2024-02-02&firstTabDate=2024-02-01',
-        )
+          // date tabs
+          expect($('.moj-sub-navigation__link').length).toBe(3)
+          expect($('.moj-sub-navigation__link').eq(0).text()).toBe('Thursday 1 February 2024')
+          expect($('.moj-sub-navigation__link').eq(0).attr('href')).toBe(
+            '/visits?selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-sub-navigation__link').eq(0).attr('aria-current')).toBe('page')
 
-        // Visits
-        expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Closed visits, 1:45pm to 3:45pm')
-        expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 of 5 tables booked')
-        expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+          expect($('.moj-sub-navigation__link').eq(1).text()).toBe('Friday 2 February 2024')
+          expect($('.moj-sub-navigation__link').eq(1).attr('href')).toBe(
+            '/visits?selectedDate=2024-02-02&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-sub-navigation__link').eq(1).attr('aria-current')).toBe(undefined)
 
-        expect($('[data-test="prisoner-name"]').eq(0).text().trim()).toBe('Smith, John')
-        expect($('[data-test="prisoner-number"]').eq(0).text().trim()).toBe('A1234BC')
-        expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe(
-          '/visit/ab-cd-ef-gh?query=type%3DCLOSED%26sessionReference%3D-afe.dcc.0f%26selectedDate%3D2024-02-02%26firstTabDate%3D2024-02-01&from=visits',
-        )
+          expect($('.moj-sub-navigation__link').eq(2).text()).toBe('Saturday 3 February 2024')
+          expect($('.moj-sub-navigation__link').eq(2).attr('href')).toBe(
+            '/visits?selectedDate=2024-02-03&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-sub-navigation__link').eq(2).attr('aria-current')).toBe(undefined)
 
-        expect($('#search-results-none').length).toBe(0)
+          // side-nav
+          expect($('.moj-side-navigation h4').eq(0).text()).toBe('All visits')
+          expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('1:45pm to 3:45pm')
+          expect($('.moj-side-navigation ul').eq(0).find('a').first().attr('href')).toBe(
+            '/visits?type=UNKNOWN&sessionReference=13%3A45-15%3A45&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
+            '/visits?type=UNKNOWN&sessionReference=13%3A45-15%3A45&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
 
-        expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
-          username: 'user1',
-          prisonId,
-          date: '2024-02-02',
+          // Visits
+          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('All visits, 1:45pm to 3:45pm')
+          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 table booked')
+          expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+
+          expect($('[data-test="prisoner-name"]').eq(0).text().trim()).toBe('Smith, John')
+          expect($('[data-test="prisoner-number"]').eq(0).text().trim()).toBe('A1234BC')
+          expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe(
+            '/visit/ab-cd-ef-gh?query=type%3DUNKNOWN%26sessionReference%3D13%253A45-15%253A45%26selectedDate%3D2024-02-01%26firstTabDate%3D2024-02-01&from=visits',
+          )
+
+          expect($('#search-results-none').length).toBe(0)
+
+          expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            date: today,
+          })
+          expect(visitService.getVisitsBySessionTemplate).not.toHaveBeenCalled()
+          expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            sessionDate: today,
+          })
+          expect(auditService.viewedVisits).toHaveBeenCalledWith({
+            viewDate: today,
+            prisonId,
+            username: 'user1',
+            operationId: undefined,
+          })
         })
-        expect(visitService.getVisitsBySessionTemplate).toHaveBeenCalledWith({
-          username: 'user1',
-          prisonId,
-          reference: sessionSchedule[0].sessionTemplateReference,
-          sessionDate: '2024-02-02',
-          visitRestrictions: 'CLOSED',
+    })
+
+    it('should render date tabs, side-nav and visits for a specific unknown visits time slot reference', () => {
+      return request(app)
+        .get('/visits?type=UNKNOWN&sessionReference=13%3A45-15%3A45&selectedDate=2024-02-02&firstTabDate=2024-02-01')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('View visits by date')
+          expect($('.govuk-back-link').attr('href')).toBe('/')
+
+          // date tabs
+          expect($('.moj-sub-navigation__link').length).toBe(3)
+          expect($('.moj-sub-navigation__link').eq(1).attr('aria-current')).toBe('page')
+
+          // side-nav
+          expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
+            '/visits?type=UNKNOWN&sessionReference=13%3A45-15%3A45&selectedDate=2024-02-02&firstTabDate=2024-02-01',
+          )
+
+          // Visits
+          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('All visits, 1:45pm to 3:45pm')
+          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 table booked')
+          expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+
+          expect($('[data-test="prisoner-name"]').eq(0).text().trim()).toBe('Smith, John')
+          expect($('[data-test="prisoner-number"]').eq(0).text().trim()).toBe('A1234BC')
+          expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe(
+            '/visit/ab-cd-ef-gh?query=type%3DUNKNOWN%26sessionReference%3D13%253A45-15%253A45%26selectedDate%3D2024-02-02%26firstTabDate%3D2024-02-01&from=visits',
+          )
+
+          expect($('#search-results-none').length).toBe(0)
+
+          expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            date: '2024-02-02',
+          })
+          expect(visitService.getVisitsBySessionTemplate).not.toHaveBeenCalled()
+          expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
+            prisonId,
+            sessionDate: '2024-02-02',
+            username: 'user1',
+          })
+          expect(auditService.viewedVisits).toHaveBeenCalledWith({
+            viewDate: '2024-02-02',
+            prisonId,
+            username: 'user1',
+            operationId: undefined,
+          })
         })
-        expect(auditService.viewedVisits).toHaveBeenCalledWith({
-          viewDate: '2024-02-02',
-          prisonId,
-          username: 'user1',
-          operationId: undefined,
-        })
-      })
+    })
   })
 
-  it('should render default (today) if invalid query parameters passed', () => {
-    return request(app)
-      .get('/visits?type=INVALID&sessionReference=REFERENCE&selectedDate=2024-99-01&firstTabDate=2024-99-01')
-      .expect(200)
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        const $ = cheerio.load(res.text)
-        expect($('h1').text()).toBe('View visits by date')
-        expect($('.govuk-back-link').attr('href')).toBe('/')
+  describe('open & closed visits - plus unknown visits', () => {
+    beforeEach(() => {
+      visitSessionsService.getSessionSchedule.mockResolvedValue(sessionSchedule)
+      visitService.getVisitsBySessionTemplate.mockResolvedValue([])
+      visitService.getVisitsWithoutSessionTemplate.mockResolvedValue(visits)
+    })
 
-        // date tabs
-        expect($('.moj-sub-navigation__link').length).toBe(3)
-        expect($('.moj-sub-navigation__link').eq(0).text()).toBe('Thursday 1 February 2024')
-        expect($('.moj-sub-navigation__link').eq(0).attr('href')).toBe(
-          '/visits?selectedDate=2024-02-01&firstTabDate=2024-02-01',
-        )
-        expect($('.moj-sub-navigation__link').eq(0).attr('aria-current')).toBe('page')
+    it('should render date tabs, side-nav and visits for default date (today)', () => {
+      return request(app)
+        .get('/visits')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('View visits by date')
+          expect($('.govuk-back-link').attr('href')).toBe('/')
 
-        // side-nav
-        expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
-          '/visits?type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
-        )
+          // date tabs
+          expect($('.moj-sub-navigation__link').length).toBe(3)
+          expect($('.moj-sub-navigation__link').eq(0).text()).toBe('Thursday 1 February 2024')
+          expect($('.moj-sub-navigation__link').eq(0).attr('href')).toBe(
+            '/visits?selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-sub-navigation__link').eq(0).attr('aria-current')).toBe('page')
 
-        // Visits
-        expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 1:45pm to 3:45pm')
-        expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 of 20 tables booked')
-        expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+          expect($('.moj-sub-navigation__link').eq(1).text()).toBe('Friday 2 February 2024')
+          expect($('.moj-sub-navigation__link').eq(1).attr('href')).toBe(
+            '/visits?selectedDate=2024-02-02&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-sub-navigation__link').eq(1).attr('aria-current')).toBe(undefined)
 
-        expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
-          username: 'user1',
-          prisonId,
-          date: today,
+          expect($('.moj-sub-navigation__link').eq(2).text()).toBe('Saturday 3 February 2024')
+          expect($('.moj-sub-navigation__link').eq(2).attr('href')).toBe(
+            '/visits?selectedDate=2024-02-03&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-sub-navigation__link').eq(2).attr('aria-current')).toBe(undefined)
+
+          // side-nav
+          expect($('.moj-side-navigation h4').eq(0).text()).toBe('Open visits')
+          expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('1:45pm to 3:45pm')
+          expect($('.moj-side-navigation ul').eq(0).find('a').first().attr('href')).toBe(
+            '/visits?type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
+            '/visits?type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+
+          expect($('.moj-side-navigation h4').eq(1).text()).toBe('Closed visits')
+          expect($('.moj-side-navigation ul').eq(1).find('a').text()).toBe('1:45pm to 3:45pm')
+          expect($('.moj-side-navigation ul').eq(1).find('a').first().attr('href')).toBe(
+            '/visits?type=CLOSED&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+
+          expect($('.moj-side-navigation h4').eq(2).text()).toBe('All visits')
+          expect($('.moj-side-navigation ul').eq(2).find('a').text()).toBe('1:45pm to 3:45pm')
+          expect($('.moj-side-navigation ul').eq(2).find('a').first().attr('href')).toBe(
+            '/visits?type=UNKNOWN&sessionReference=13%3A45-15%3A45&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+
+          // Visits
+          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 1:45pm to 3:45pm')
+          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('0 of 20 tables booked')
+          expect($('[data-test="visit-visitors-total"]').length).toBe(0)
+
+          expect($('#search-results-none').length).toBe(0)
+
+          expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            date: today,
+          })
+          expect(visitService.getVisitsBySessionTemplate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            reference: sessionSchedule[0].sessionTemplateReference,
+            sessionDate: today,
+            visitRestrictions: 'OPEN',
+          })
+          expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            sessionDate: today,
+          })
+          expect(auditService.viewedVisits).toHaveBeenCalledWith({
+            viewDate: today,
+            prisonId,
+            username: 'user1',
+            operationId: undefined,
+          })
         })
-        expect(visitService.getVisitsBySessionTemplate).toHaveBeenCalledWith({
-          username: 'user1',
-          prisonId,
-          reference: sessionSchedule[0].sessionTemplateReference,
-          sessionDate: today,
-          visitRestrictions: 'OPEN',
-        })
-        expect(auditService.viewedVisits).toHaveBeenCalledWith({
-          viewDate: today,
-          prisonId,
-          username: 'user1',
-          operationId: undefined,
-        })
-      })
+    })
   })
 })
 

--- a/server/routes/visitsUtils.test.ts
+++ b/server/routes/visitsUtils.test.ts
@@ -1,7 +1,7 @@
 import { VisitsPageSideNav } from '../@types/bapv'
 import { SessionSchedule, VisitPreview, VisitRestriction } from '../data/orchestrationApiTypes'
 import TestData from './testutils/testData'
-import { getDateTabs, getSelectedOrDefaultSession, getSessionsSideNav } from './visitsUtils'
+import { getDateTabs, getSelectedOrDefaultSessionTemplate, getSessionsSideNav } from './visitsUtils'
 
 describe('getDateTabs', () => {
   const todayString = '2022-05-24'
@@ -106,18 +106,17 @@ describe('getSelectedOrDefaultSession', () => {
     const sessionReference = 'reference'
     const type: VisitRestriction = 'OPEN'
 
-    const result = getSelectedOrDefaultSession(sessionSchedule, sessionReference, type)
+    const result = getSelectedOrDefaultSessionTemplate(sessionSchedule, sessionReference, type)
 
     expect(result).toBe(null)
   })
 
-  // UNKNOWN not supported yet
   it('should return null if UNKNOWN visit type selected', () => {
     const sessionSchedule: SessionSchedule[] = []
     const sessionReference = 'reference'
     const type: VisitRestriction = 'UNKNOWN'
 
-    const result = getSelectedOrDefaultSession(sessionSchedule, sessionReference, type)
+    const result = getSelectedOrDefaultSessionTemplate(sessionSchedule, sessionReference, type)
 
     expect(result).toBe(null)
   })
@@ -138,7 +137,7 @@ describe('getSelectedOrDefaultSession', () => {
     const sessionReference: string = undefined
     const type: VisitRestriction = undefined
 
-    const result = getSelectedOrDefaultSession(sessionSchedule, sessionReference, type)
+    const result = getSelectedOrDefaultSessionTemplate(sessionSchedule, sessionReference, type)
 
     expect(result).toStrictEqual({
       sessionReference: '2',
@@ -159,7 +158,7 @@ describe('getSelectedOrDefaultSession', () => {
     const sessionReference: string = undefined
     const type: VisitRestriction = undefined
 
-    const result = getSelectedOrDefaultSession(sessionSchedule, sessionReference, type)
+    const result = getSelectedOrDefaultSessionTemplate(sessionSchedule, sessionReference, type)
 
     expect(result).toStrictEqual({
       sessionReference: '1',
@@ -174,7 +173,7 @@ describe('getSelectedOrDefaultSession', () => {
     const sessionReference: string = sessionSchedule[0].sessionTemplateReference
     const type: VisitRestriction = 'OPEN'
 
-    const result = getSelectedOrDefaultSession(sessionSchedule, sessionReference, type)
+    const result = getSelectedOrDefaultSessionTemplate(sessionSchedule, sessionReference, type)
 
     expect(result).toStrictEqual({
       sessionReference: sessionSchedule[0].sessionTemplateReference,
@@ -189,7 +188,7 @@ describe('getSelectedOrDefaultSession', () => {
     const sessionReference: string = 'invalid reference'
     const type: VisitRestriction = 'OPEN'
 
-    const result = getSelectedOrDefaultSession(sessionSchedule, sessionReference, type)
+    const result = getSelectedOrDefaultSessionTemplate(sessionSchedule, sessionReference, type)
 
     expect(result).toStrictEqual({
       sessionReference: sessionSchedule[0].sessionTemplateReference,
@@ -204,7 +203,7 @@ describe('getSelectedOrDefaultSession', () => {
     const sessionReference: string = sessionSchedule[0].sessionTemplateReference
     const type: VisitRestriction = 'CLOSED'
 
-    const result = getSelectedOrDefaultSession(sessionSchedule, sessionReference, type)
+    const result = getSelectedOrDefaultSessionTemplate(sessionSchedule, sessionReference, type)
 
     expect(result).toStrictEqual({
       sessionReference: sessionSchedule[0].sessionTemplateReference,
@@ -432,6 +431,39 @@ describe('getSessionsSideNav', () => {
         firstTimeSlotReference,
         'UNKNOWN',
       )
+
+      expect(result).toStrictEqual(expectedResult)
+    })
+
+    it('should build two side nav entries and select the first by default if no open/closed sessions present and no query params set', () => {
+      const sessionSchedule: SessionSchedule[] = []
+      const firstVisitTimeSlot = { startTime: '10:00', endTime: '11:00' }
+      const firstTimeSlotReference = '10:00-11:00'
+      const secondVisitTimeSlot = { startTime: '13:45', endTime: '16:00' }
+      const secondTimeSlotReference = '13:45-16:00'
+      const unknownVisits: VisitPreview[] = [
+        TestData.visitPreview({ visitTimeSlot: secondVisitTimeSlot }),
+        TestData.visitPreview({ visitTimeSlot: firstVisitTimeSlot }),
+      ]
+
+      const expectedResult: VisitsPageSideNav = {
+        unknown: [
+          {
+            times: '10am to 11am',
+            reference: firstTimeSlotReference,
+            queryParams: `type=UNKNOWN&sessionReference=${encodeURIComponent(firstTimeSlotReference)}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: true,
+          },
+          {
+            times: '1:45pm to 4pm',
+            reference: secondTimeSlotReference,
+            queryParams: `type=UNKNOWN&sessionReference=${encodeURIComponent(secondTimeSlotReference)}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: false,
+          },
+        ],
+      }
+
+      const result = getSessionsSideNav(sessionSchedule, unknownVisits, selectedDate, firstTabDate, '', undefined)
 
       expect(result).toStrictEqual(expectedResult)
     })

--- a/server/routes/visitsUtils.test.ts
+++ b/server/routes/visitsUtils.test.ts
@@ -1,5 +1,5 @@
 import { VisitsPageSideNav } from '../@types/bapv'
-import { SessionSchedule, VisitRestriction } from '../data/orchestrationApiTypes'
+import { SessionSchedule, VisitPreview, VisitRestriction } from '../data/orchestrationApiTypes'
 import TestData from './testutils/testData'
 import { getDateTabs, getSelectedOrDefaultSession, getSessionsSideNav } from './visitsUtils'
 
@@ -219,138 +219,221 @@ describe('getSessionsSideNav', () => {
   const selectedDate = '2024-01-29'
   const firstTabDate = '2024-01-29'
 
-  it('should handle empty session schedule', () => {
-    const sessionSchedule: SessionSchedule[] = []
-    const expectedResult: VisitsPageSideNav = {}
+  describe('open & closed visits (these have a session template)', () => {
+    it('should handle empty session schedule', () => {
+      const sessionSchedule: SessionSchedule[] = []
+      const unknownVisits: VisitPreview[] = []
+      const expectedResult: VisitsPageSideNav = {}
 
-    const result = getSessionsSideNav(sessionSchedule, selectedDate, firstTabDate, '', 'OPEN')
+      const result = getSessionsSideNav(sessionSchedule, unknownVisits, selectedDate, firstTabDate, '', 'OPEN')
 
-    expect(result).toStrictEqual(expectedResult)
+      expect(result).toStrictEqual(expectedResult)
+    })
+
+    it('should build side nav data for an open only session', () => {
+      const sessionSchedule = [
+        TestData.sessionSchedule({
+          capacity: { open: 20, closed: 0 },
+          sessionTimeSlot: { startTime: '10:00', endTime: '14:30' },
+        }),
+      ]
+      const unknownVisits: VisitPreview[] = []
+
+      const expectedResult: VisitsPageSideNav = {
+        open: [
+          {
+            times: '10am to 2:30pm',
+            reference: sessionSchedule[0].sessionTemplateReference,
+            capacity: 20,
+            queryParams: `type=OPEN&sessionReference=${sessionSchedule[0].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: true,
+          },
+        ],
+      }
+
+      const result = getSessionsSideNav(
+        sessionSchedule,
+        unknownVisits,
+        selectedDate,
+        firstTabDate,
+        sessionSchedule[0].sessionTemplateReference,
+        'OPEN',
+      )
+
+      expect(result).toStrictEqual(expectedResult)
+    })
+
+    it('should build side nav data for a closed only session', () => {
+      const sessionSchedule = [
+        TestData.sessionSchedule({
+          capacity: { open: 0, closed: 20 },
+          sessionTimeSlot: { startTime: '10:00', endTime: '14:30' },
+        }),
+      ]
+      const unknownVisits: VisitPreview[] = []
+
+      const expectedResult: VisitsPageSideNav = {
+        closed: [
+          {
+            times: '10am to 2:30pm',
+            reference: sessionSchedule[0].sessionTemplateReference,
+            capacity: 20,
+            queryParams: `type=CLOSED&sessionReference=${sessionSchedule[0].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: true,
+          },
+        ],
+      }
+
+      const result = getSessionsSideNav(
+        sessionSchedule,
+        unknownVisits,
+        selectedDate,
+        firstTabDate,
+        sessionSchedule[0].sessionTemplateReference,
+        'CLOSED',
+      )
+
+      expect(result).toStrictEqual(expectedResult)
+    })
+
+    it('should build side nav data for mixed open and closed sessions', () => {
+      const sessionSchedule = [
+        TestData.sessionSchedule({
+          capacity: { open: 20, closed: 0 },
+          sessionTimeSlot: { startTime: '10:00', endTime: '14:30' },
+        }),
+        TestData.sessionSchedule({
+          sessionTemplateReference: '-bfe.dcc.0f',
+          capacity: { open: 15, closed: 10 },
+          sessionTimeSlot: { startTime: '15:00', endTime: '16:00' },
+        }),
+        TestData.sessionSchedule({
+          sessionTemplateReference: '-cfe.dcc.0f',
+          capacity: { open: 0, closed: 5 },
+          sessionTimeSlot: { startTime: '16:30', endTime: '18:00' },
+        }),
+      ]
+      const unknownVisits: VisitPreview[] = []
+
+      const expectedResult: VisitsPageSideNav = {
+        open: [
+          {
+            times: '10am to 2:30pm',
+            reference: sessionSchedule[0].sessionTemplateReference,
+            capacity: 20,
+            queryParams: `type=OPEN&sessionReference=${sessionSchedule[0].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: false,
+          },
+          {
+            times: '3pm to 4pm',
+            reference: sessionSchedule[1].sessionTemplateReference,
+            capacity: 15,
+            queryParams: `type=OPEN&sessionReference=${sessionSchedule[1].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: false,
+          },
+        ],
+        closed: [
+          {
+            times: '3pm to 4pm',
+            reference: sessionSchedule[1].sessionTemplateReference,
+            capacity: 10,
+            queryParams: `type=CLOSED&sessionReference=${sessionSchedule[1].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: true,
+          },
+          {
+            times: '4:30pm to 6pm',
+            reference: sessionSchedule[2].sessionTemplateReference,
+            capacity: 5,
+            queryParams: `type=CLOSED&sessionReference=${sessionSchedule[2].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: false,
+          },
+        ],
+      }
+
+      const result = getSessionsSideNav(
+        sessionSchedule,
+        unknownVisits,
+        selectedDate,
+        firstTabDate,
+        sessionSchedule[1].sessionTemplateReference,
+        'CLOSED',
+      )
+
+      expect(result).toStrictEqual(expectedResult)
+    })
   })
 
-  it('should build side nav data for an open only session', () => {
-    const sessionSchedule = [
-      TestData.sessionSchedule({
-        capacity: { open: 20, closed: 0 },
-        sessionTimeSlot: { startTime: '10:00', endTime: '14:30' },
-      }),
-    ]
+  describe('unknown visits (those with no session template)', () => {
+    it('should build one side nav entry for multiple visits with same times', () => {
+      const sessionSchedule: SessionSchedule[] = []
+      const visitTimeSlot = { startTime: '13:45', endTime: '16:00' }
+      const timeSlotReference = '13:45-16:00'
+      const unknownVisits: VisitPreview[] = [
+        TestData.visitPreview({ visitTimeSlot }),
+        TestData.visitPreview({ visitTimeSlot }),
+      ]
 
-    const expectedResult: VisitsPageSideNav = {
-      open: [
-        {
-          times: '10am to 2:30pm',
-          reference: sessionSchedule[0].sessionTemplateReference,
-          capacity: 20,
-          queryParams: `type=OPEN&sessionReference=${sessionSchedule[0].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
-          active: true,
-        },
-      ],
-    }
+      const expectedResult: VisitsPageSideNav = {
+        unknown: [
+          {
+            times: '1:45pm to 4pm',
+            reference: timeSlotReference,
+            queryParams: `type=UNKNOWN&sessionReference=${encodeURIComponent(timeSlotReference)}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: true,
+          },
+        ],
+      }
 
-    const result = getSessionsSideNav(
-      sessionSchedule,
-      selectedDate,
-      firstTabDate,
-      sessionSchedule[0].sessionTemplateReference,
-      'OPEN',
-    )
+      const result = getSessionsSideNav(
+        sessionSchedule,
+        unknownVisits,
+        selectedDate,
+        firstTabDate,
+        timeSlotReference,
+        'UNKNOWN',
+      )
 
-    expect(result).toStrictEqual(expectedResult)
-  })
+      expect(result).toStrictEqual(expectedResult)
+    })
 
-  it('should build side nav data for a closed only session', () => {
-    const sessionSchedule = [
-      TestData.sessionSchedule({
-        capacity: { open: 0, closed: 20 },
-        sessionTimeSlot: { startTime: '10:00', endTime: '14:30' },
-      }),
-    ]
+    it('should build two side nav entries ordered by start time for visits with different times', () => {
+      const sessionSchedule: SessionSchedule[] = []
+      const firstVisitTimeSlot = { startTime: '10:00', endTime: '11:00' }
+      const firstTimeSlotReference = '10:00-11:00'
+      const secondVisitTimeSlot = { startTime: '13:45', endTime: '16:00' }
+      const secondTimeSlotReference = '13:45-16:00'
+      const unknownVisits: VisitPreview[] = [
+        TestData.visitPreview({ visitTimeSlot: secondVisitTimeSlot }),
+        TestData.visitPreview({ visitTimeSlot: firstVisitTimeSlot }),
+      ]
 
-    const expectedResult: VisitsPageSideNav = {
-      closed: [
-        {
-          times: '10am to 2:30pm',
-          reference: sessionSchedule[0].sessionTemplateReference,
-          capacity: 20,
-          queryParams: `type=CLOSED&sessionReference=${sessionSchedule[0].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
-          active: true,
-        },
-      ],
-    }
+      const expectedResult: VisitsPageSideNav = {
+        unknown: [
+          {
+            times: '10am to 11am',
+            reference: firstTimeSlotReference,
+            queryParams: `type=UNKNOWN&sessionReference=${encodeURIComponent(firstTimeSlotReference)}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: true,
+          },
+          {
+            times: '1:45pm to 4pm',
+            reference: secondTimeSlotReference,
+            queryParams: `type=UNKNOWN&sessionReference=${encodeURIComponent(secondTimeSlotReference)}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
+            active: false,
+          },
+        ],
+      }
 
-    const result = getSessionsSideNav(
-      sessionSchedule,
-      selectedDate,
-      firstTabDate,
-      sessionSchedule[0].sessionTemplateReference,
-      'CLOSED',
-    )
+      const result = getSessionsSideNav(
+        sessionSchedule,
+        unknownVisits,
+        selectedDate,
+        firstTabDate,
+        firstTimeSlotReference,
+        'UNKNOWN',
+      )
 
-    expect(result).toStrictEqual(expectedResult)
-  })
-
-  it('should build side nav data for mixed open and closed sessions', () => {
-    const sessionSchedule = [
-      TestData.sessionSchedule({
-        capacity: { open: 20, closed: 0 },
-        sessionTimeSlot: { startTime: '10:00', endTime: '14:30' },
-      }),
-      TestData.sessionSchedule({
-        sessionTemplateReference: '-bfe.dcc.0f',
-        capacity: { open: 15, closed: 10 },
-        sessionTimeSlot: { startTime: '15:00', endTime: '16:00' },
-      }),
-      TestData.sessionSchedule({
-        sessionTemplateReference: '-cfe.dcc.0f',
-        capacity: { open: 0, closed: 5 },
-        sessionTimeSlot: { startTime: '16:30', endTime: '18:00' },
-      }),
-    ]
-
-    const expectedResult: VisitsPageSideNav = {
-      open: [
-        {
-          times: '10am to 2:30pm',
-          reference: sessionSchedule[0].sessionTemplateReference,
-          capacity: 20,
-          queryParams: `type=OPEN&sessionReference=${sessionSchedule[0].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
-          active: false,
-        },
-        {
-          times: '3pm to 4pm',
-          reference: sessionSchedule[1].sessionTemplateReference,
-          capacity: 15,
-          queryParams: `type=OPEN&sessionReference=${sessionSchedule[1].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
-          active: false,
-        },
-      ],
-      closed: [
-        {
-          times: '3pm to 4pm',
-          reference: sessionSchedule[1].sessionTemplateReference,
-          capacity: 10,
-          queryParams: `type=CLOSED&sessionReference=${sessionSchedule[1].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
-          active: true,
-        },
-        {
-          times: '4:30pm to 6pm',
-          reference: sessionSchedule[2].sessionTemplateReference,
-          capacity: 5,
-          queryParams: `type=CLOSED&sessionReference=${sessionSchedule[2].sessionTemplateReference}&selectedDate=${selectedDate}&firstTabDate=${firstTabDate}`,
-          active: false,
-        },
-      ],
-    }
-
-    const result = getSessionsSideNav(
-      sessionSchedule,
-      selectedDate,
-      firstTabDate,
-      sessionSchedule[1].sessionTemplateReference,
-      'CLOSED',
-    )
-
-    expect(result).toStrictEqual(expectedResult)
+      expect(result).toStrictEqual(expectedResult)
+    })
   })
 })

--- a/server/routes/visitsUtils.ts
+++ b/server/routes/visitsUtils.ts
@@ -36,7 +36,7 @@ export const getDateTabs = (
   return tabs
 }
 
-export function getSelectedOrDefaultSession(
+export function getSelectedOrDefaultSessionTemplate(
   sessionSchedule: SessionSchedule[],
   sessionReference: string,
   type: VisitRestriction,
@@ -158,6 +158,12 @@ export function getSessionsSideNav(
     }
   })
   unknown.sort((a, b) => a.reference.localeCompare(b.reference))
+  // default first unknown session to selected if no open/closed
+  const unknownOnly = unknown.length && !open.length && !closed.length
+  const isASelectedUnknownSession = unknown.some(u => u.active)
+  if (unknownOnly && !isASelectedUnknownSession) {
+    unknown[0].active = true
+  }
 
   return {
     ...(open.length && { open }),

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -328,7 +328,7 @@ describe('Visit service', () => {
     })
 
     describe('getVisitsBySessionTemplate', () => {
-      it('should return visit previews details for given session template reference, date and restriction', async () => {
+      it('should return visit previews for given session template reference, date, prison and restriction', async () => {
         const reference = 'v9d.7ed.7u'
         const sessionDate = '2024-01-31'
         const visitRestrictions: VisitRestriction = 'OPEN'
@@ -349,6 +349,29 @@ describe('Visit service', () => {
           reference,
           sessionDate,
           visitRestrictions,
+        )
+        expect(result).toStrictEqual(visitPreviews)
+      })
+    })
+
+    describe('getVisitsWithoutSessionTemplate', () => {
+      it('should return visit previews for given date and prison (for migrated visits that have no session template)', async () => {
+        const sessionDate = '2024-01-31'
+        const visitPreviews = [TestData.visitPreview()]
+
+        orchestrationApiClient.getVisitsBySessionTemplate.mockResolvedValue(visitPreviews)
+
+        const result = await visitService.getVisitsWithoutSessionTemplate({
+          username: 'user',
+          prisonId,
+          sessionDate,
+        })
+
+        expect(orchestrationApiClient.getVisitsBySessionTemplate).toHaveBeenCalledWith(
+          prisonId,
+          undefined,
+          sessionDate,
+          undefined,
         )
         expect(result).toStrictEqual(visitPreviews)
       })

--- a/server/services/visitService.ts
+++ b/server/services/visitService.ts
@@ -176,6 +176,21 @@ export default class VisitService {
     return orchestrationApiClient.getVisitsBySessionTemplate(prisonId, reference, sessionDate, visitRestrictions)
   }
 
+  async getVisitsWithoutSessionTemplate({
+    username,
+    prisonId,
+    sessionDate,
+  }: {
+    username: string
+    prisonId: string
+    sessionDate: string
+  }): Promise<VisitPreview[]> {
+    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
+
+    return orchestrationApiClient.getVisitsBySessionTemplate(prisonId, undefined, sessionDate, undefined)
+  }
+
   private buildVisitInformation(visit: Visit): VisitInformation {
     const visitTime = `${prisonerTimePretty(visit.startTimestamp)} to ${prisonerTimePretty(visit.endTimestamp)}`
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -6,12 +6,11 @@ import {
   prisonerDateTimePretty,
   properCaseFullName,
   properCase,
-  sortByTimestamp,
   safeReturnUrl,
   getParsedDateFromQueryString,
   getWeekOfDatesStartingMonday,
 } from './utils'
-import { getResultsPagingLinksTestData, sortByTimestampData } from './utils.testData'
+import getResultsPagingLinksTestData from './utils.testData'
 
 describe('Convert to title case', () => {
   it('null string', () => {
@@ -90,14 +89,6 @@ describe('properCase', () => {
   })
   it('empty string', () => {
     expect(properCase('')).toEqual('')
-  })
-})
-
-describe('Sort by timestamp', () => {
-  sortByTimestampData.forEach(testData => {
-    it(testData.description, () => {
-      expect(sortByTimestamp(testData.a, testData.b)).toEqual(testData.result)
-    })
   })
 })
 

--- a/server/utils/utils.testData.ts
+++ b/server/utils/utils.testData.ts
@@ -6,7 +6,7 @@ const getSingleRow = (selected: boolean, page: number): { href: string; selected
   }
 }
 
-export const getResultsPagingLinksTestData = [
+const getResultsPagingLinksTestData = [
   {
     description: 'Show 1 page, 1 page available, current page is 1',
     params: {
@@ -141,41 +141,4 @@ export const getResultsPagingLinksTestData = [
   },
 ]
 
-export const sortByTimestampData = [
-  {
-    description: 'a and b are equal',
-    a: {
-      visitTime: 'Test',
-      sortField: '2020-04-05T12:12:00',
-    },
-    b: {
-      visitTime: 'Test',
-      sortField: '2020-04-05T12:12:00',
-    },
-    result: 0,
-  },
-  {
-    description: 'a is greater than b',
-    a: {
-      visitTime: 'Test',
-      sortField: '2020-04-06T12:12:00',
-    },
-    b: {
-      visitTime: 'Test',
-      sortField: '2020-04-05T12:12:00',
-    },
-    result: 1,
-  },
-  {
-    description: 'a is less than b',
-    a: {
-      visitTime: 'Test',
-      sortField: '2020-04-05T12:12:00',
-    },
-    b: {
-      visitTime: 'Test',
-      sortField: '2020-04-06T12:12:00',
-    },
-    result: -1,
-  },
-]
+export default getResultsPagingLinksTestData

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -127,20 +127,6 @@ export const nextPrivIepAdjustDate = (latestPrivIepAdjustDate: string): string =
 
 export const formatVisitType = (visitType: string): string => properCase(visitType)
 
-export const sortByTimestamp = (
-  a: { visitTime: string; sortField: string },
-  b: { visitTime: string; sortField: string },
-) => {
-  if (a.sortField > b.sortField) {
-    return 1
-  }
-  if (a.sortField < b.sortField) {
-    return -1
-  }
-
-  return 0
-}
-
 export function safeReturnUrl(originalUrl: string) {
   return originalUrl.length === 0 || originalUrl.indexOf('://') > 0 || originalUrl.indexOf('//') === 0
     ? '/'

--- a/server/views/pages/visits/summary.njk
+++ b/server/views/pages/visits/summary.njk
@@ -70,6 +70,7 @@
   </div>
   <div class="govuk-grid-row">
 
+    {% set selectedTimeSlotLabel = "" %}
     {% if sessionsSideNav | length %}
       <div class="govuk-grid-column-one-quarter">
         {# build side nav time slot nav for open/closed sections #}
@@ -77,15 +78,16 @@
         {% for heading, items in sessionsSideNav %}
           {% set sectionItems = [] %}
           {% for item in items %}
-          {% set sectionItems = (sectionItems.push({
-              text: item.times,
-              href: "/visits?" + item.queryParams,
-              active: item.active
-            }), sectionItems) %}
+            {% set sectionItems = (sectionItems.push({
+                text: item.times,
+                href: "/visits?" + item.queryParams,
+                active: item.active
+              }), sectionItems) %}
+              {% set selectedTimeSlotLabel = item.times if item.active else selectedTimeSlotLabel %}
           {% endfor %}
           {% set sessionSideNavSections = (sessionSideNavSections.push({
             heading: {
-              text: heading | capitalize + " visits",
+              text: ("all" if heading == "unknown" else heading) | capitalize + " visits",
               classes: "govuk-!-padding-top-0"
             },
             items: sectionItems
@@ -102,13 +104,13 @@
 
     <div class="govuk-grid-column-three-quarters">
 
-      {% if selectedSession %}
+      {% if sessionsSideNav | length %}
         <h2 class="govuk-heading-m" data-test="visit-session-heading">
-          {{ selectedSession.type | capitalize }} visits, {{ selectedSession.times }}
+          {{ (selectedSessionTemplate.type or "all") | capitalize }} visits, {{ selectedTimeSlotLabel }}
         </h2>
-        
+
         <p data-test="visit-tables-booked">
-          {{ visits | length }} of {{ selectedSession.capacity }} {{ "table" | pluralise(selectedSession.capacity )}} booked
+          {{ visits | length }}{{ (" of " + selectedSessionTemplate.capacity) if selectedSessionTemplate.capacity }} {{ "table" | pluralise(selectedSessionTemplate.capacity or visits | length)}} booked
         </p>
       {% else %}
         <p class="govuk-!-margin-top-0" id="search-results-none">
@@ -157,8 +159,8 @@
           ],
           rows: visitsRows
         }) }}
-      </div>
-    {% endif %}
+      {% endif %}
+    </div>
   </div>
 {% endblock %}
 

--- a/server/views/pages/visits/summary.test.ts
+++ b/server/views/pages/visits/summary.test.ts
@@ -83,12 +83,12 @@ describe('Views - Visits summary', () => {
           reference: 'ref-2',
           capacity: 10,
           queryParams: 'query-2',
-          active: true,
+          active: false,
         },
       ],
     }
 
-    const selectedSession = {
+    const selectedSessionTemplate = {
       sessionReference: 'ref-1',
       type: 'OPEN',
       times: '10am to 11am',
@@ -98,7 +98,13 @@ describe('Views - Visits summary', () => {
     const visits: VisitPreview[] = []
     const visitorsTotal = 0
 
-    viewContext = { selectedSession, sessionsSideNav, queryParamsForBackLink, visits, visitorsTotal }
+    viewContext = {
+      selectedSessionTemplate,
+      sessionsSideNav,
+      queryParamsForBackLink,
+      visits,
+      visitorsTotal,
+    }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
@@ -131,7 +137,7 @@ describe('Views - Visits summary', () => {
       ],
     }
 
-    const selectedSession = {
+    const selectedSessionTemplate = {
       sessionReference: 'ref-1',
       type: 'OPEN',
       times: '10am to 11am',
@@ -141,7 +147,7 @@ describe('Views - Visits summary', () => {
     const visits = [TestData.visitPreview()]
     const visitorsTotal = 2
 
-    viewContext = { selectedSession, sessionsSideNav, queryParamsForBackLink, visits, visitorsTotal }
+    viewContext = { selectedSessionTemplate, sessionsSideNav, queryParamsForBackLink, visits, visitorsTotal }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 


### PR DESCRIPTION
Building on #717, this adds support for 'unknown' visits to the re-implementation of the View visits by date page. 'unknown' visits means those that have been migrated and therefore don't have a session template reference and may also have a restriction type of `UNKNOWN` instead of `OPEN / CLOSED`.

Because the session schedule and visits-by-template-reference endpoints cannot retrieve these visits, they need to be looked up separately and parsed to construct a navigation based on the time slots that are discovered.

On the page, these are shown under the heading 'All visits', e.g.:

![Screenshot 2024-03-25 at 15 43 24](https://github.com/ministryofjustice/book-a-prison-visit-staff-ui/assets/1441286/2aceb92f-8037-442d-8577-f96fee519bcb)

