### PR TITLE
VB-3729 Use the prison's configured maximum total visitors when validating on 'Select visitors' page

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -158,6 +158,7 @@ export type VisitsReviewListItem = {
 
 export interface Prison extends PrisonName {
   policyNoticeDaysMin: number
+  maxTotalVisitors: number
 }
 
 export type FilterField = { id: string; label: string; items: { label: string; value: string; checked: boolean }[] }

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -630,12 +630,10 @@ export interface components {
       visitTimeSlot: components['schemas']['SessionTimeSlotDto']
     }
     PageVisitDto: {
-      /** Format: int32 */
-      totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
+      /** Format: int32 */
+      totalPages?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitDto'][]
@@ -645,6 +643,8 @@ export interface components {
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
+      first?: boolean
+      last?: boolean
       empty?: boolean
     }
     PageableObject: {
@@ -652,9 +652,9 @@ export interface components {
       offset?: number
       sort?: components['schemas']['SortObject'][]
       /** Format: int32 */
-      pageSize?: number
-      /** Format: int32 */
       pageNumber?: number
+      /** Format: int32 */
+      pageSize?: number
       paged?: boolean
       unpaged?: boolean
     }
@@ -1082,6 +1082,26 @@ export interface components {
        * @example 28
        */
       policyNoticeDaysMax: number
+      /**
+       * Format: int32
+       * @description Max number of total visitors
+       */
+      maxTotalVisitors: number
+      /**
+       * Format: int32
+       * @description Max number of adults
+       */
+      maxAdultVisitors: number
+      /**
+       * Format: int32
+       * @description Max number of children
+       */
+      maxChildVisitors: number
+      /**
+       * Format: int32
+       * @description Age of adults in years
+       */
+      adultAgeYears: number
       /** @description exclude dates */
       excludeDates: string[]
     }

--- a/server/middleware/populateSelectedEstablishment.ts
+++ b/server/middleware/populateSelectedEstablishment.ts
@@ -15,7 +15,7 @@ export default function populateSelectedEstablishment(
         return res.redirect('/change-establishment')
       }
 
-      const policyNoticeDaysMin = await supportedPrisonsService.getPolicyNoticeDaysMin(
+      const { maxTotalVisitors, policyNoticeDaysMin } = await supportedPrisonsService.getPrisonConfig(
         res.locals.user.username,
         activeCaseLoadId,
       )
@@ -23,6 +23,7 @@ export default function populateSelectedEstablishment(
       req.session.selectedEstablishment = {
         prisonId: activeCaseLoadId,
         prisonName: supportedPrisons[activeCaseLoadId],
+        maxTotalVisitors,
         policyNoticeDaysMin,
       }
     }

--- a/server/middleware/sessionCheckMiddleware.test.ts
+++ b/server/middleware/sessionCheckMiddleware.test.ts
@@ -62,7 +62,12 @@ describe('sessionCheckMiddleware', () => {
         save: jest.fn(),
         touch: jest.fn(),
         cookie: new Cookie(),
-        selectedEstablishment: { prisonId, prisonName: supportedPrisons[prisonId], policyNoticeDaysMin: 2 },
+        selectedEstablishment: {
+          prisonId,
+          prisonName: supportedPrisons[prisonId],
+          maxTotalVisitors: 6,
+          policyNoticeDaysMin: 2,
+        },
       },
     }
     mockResponse = {
@@ -77,7 +82,12 @@ describe('sessionCheckMiddleware', () => {
   })
 
   it('should redirect to the start page if prisonId in originalVisitSlot (set for update journey) does not match selected establishment', () => {
-    req.session.selectedEstablishment = { prisonId: 'BLI', prisonName: supportedPrisons.BLI, policyNoticeDaysMin: 2 }
+    req.session.selectedEstablishment = {
+      prisonId: 'BLI',
+      prisonName: supportedPrisons.BLI,
+      maxTotalVisitors: 6,
+      policyNoticeDaysMin: 2,
+    }
     req.session.visitSessionData = { originalVisitSlot: visitSlot } as VisitSessionData
 
     sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
@@ -242,7 +252,12 @@ describe('sessionCheckMiddleware', () => {
     })
 
     it('should redirect to the start page if prisonId in visitSlot does not match selected establishment', () => {
-      req.session.selectedEstablishment = { prisonId: 'BLI', prisonName: supportedPrisons.BLI, policyNoticeDaysMin: 2 }
+      req.session.selectedEstablishment = {
+        prisonId: 'BLI',
+        prisonName: supportedPrisons.BLI,
+        maxTotalVisitors: 6,
+        policyNoticeDaysMin: 2,
+      }
       req.session.visitSessionData = {
         applicationReference: 'aaa-bbb-ccc',
         prisoner: prisonerData,

--- a/server/routes/changeEstablishment.test.ts
+++ b/server/routes/changeEstablishment.test.ts
@@ -24,7 +24,7 @@ const supportedPrisons = TestData.supportedPrisons()
 
 beforeEach(() => {
   supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
-  supportedPrisonsService.getPolicyNoticeDaysMin.mockResolvedValue(2)
+  supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors: 6, policyNoticeDaysMin: 2 })
 
   userService.getUser.mockResolvedValue(user as UserDetails)
   userService.getActiveCaseLoadId.mockResolvedValue('XYZ') // assume user coming with an unsupported case load
@@ -142,7 +142,12 @@ describe('POST /change-establishment', () => {
   beforeEach(() => {
     jest.spyOn(visitorUtils, 'clearSession')
 
-    selectedEstablishment = { prisonId: 'BLI', prisonName: supportedPrisons.BLI, policyNoticeDaysMin: 2 }
+    selectedEstablishment = {
+      prisonId: 'BLI',
+      prisonName: supportedPrisons.BLI,
+      maxTotalVisitors: 6,
+      policyNoticeDaysMin: 2,
+    }
     sessionData = { selectedEstablishment } as SessionData
     userService.getUserCaseLoadIds.mockResolvedValue(TestData.supportedPrisonIds())
 
@@ -164,7 +169,7 @@ describe('POST /change-establishment', () => {
           { location: 'body', msg: 'No prison selected', path: 'establishment', type: 'field', value: '' },
         ])
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(0)
-        expect(supportedPrisonsService.getPolicyNoticeDaysMin).not.toHaveBeenCalled()
+        expect(supportedPrisonsService.getPrisonConfig).not.toHaveBeenCalled()
         expect(auditService.changeEstablishment).toHaveBeenCalledTimes(0)
         expect(userService.setActiveCaseLoad).not.toHaveBeenCalled()
       })
@@ -182,14 +187,19 @@ describe('POST /change-establishment', () => {
           { location: 'body', msg: 'No prison selected', path: 'establishment', type: 'field', value: 'HEX' },
         ])
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(0)
-        expect(supportedPrisonsService.getPolicyNoticeDaysMin).not.toHaveBeenCalled()
+        expect(supportedPrisonsService.getPrisonConfig).not.toHaveBeenCalled()
         expect(auditService.changeEstablishment).toHaveBeenCalledTimes(0)
         expect(userService.setActiveCaseLoad).not.toHaveBeenCalled()
       })
   })
 
   it('should clear session, set selected establishment and redirect to home page', () => {
-    const newEstablishment: Prison = { prisonId: 'HEI', prisonName: supportedPrisons.HEI, policyNoticeDaysMin: 2 }
+    const newEstablishment: Prison = {
+      prisonId: 'HEI',
+      prisonName: supportedPrisons.HEI,
+      maxTotalVisitors: 6,
+      policyNoticeDaysMin: 2,
+    }
 
     return request(app)
       .post(`/change-establishment`)
@@ -199,7 +209,7 @@ describe('POST /change-establishment', () => {
       .expect(() => {
         expect(sessionData.selectedEstablishment).toStrictEqual(newEstablishment)
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
-        expect(supportedPrisonsService.getPolicyNoticeDaysMin).toHaveBeenCalledWith('user1', 'HEI')
+        expect(supportedPrisonsService.getPrisonConfig).toHaveBeenCalledWith('user1', 'HEI')
         expect(auditService.changeEstablishment).toHaveBeenCalledWith({
           previousEstablishment: 'BLI',
           newEstablishment: 'HEI',
@@ -211,7 +221,12 @@ describe('POST /change-establishment', () => {
   })
 
   it('should clear session, set selected establishment and redirect to / not the set referrer', () => {
-    const newEstablishment: Prison = { prisonId: 'HEI', prisonName: supportedPrisons.HEI, policyNoticeDaysMin: 2 }
+    const newEstablishment: Prison = {
+      prisonId: 'HEI',
+      prisonName: supportedPrisons.HEI,
+      maxTotalVisitors: 6,
+      policyNoticeDaysMin: 2,
+    }
 
     return request(app)
       .post(`/change-establishment?referrer=//search/prisoner/`)
@@ -221,14 +236,19 @@ describe('POST /change-establishment', () => {
       .expect(() => {
         expect(sessionData.selectedEstablishment).toStrictEqual(newEstablishment)
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
-        expect(supportedPrisonsService.getPolicyNoticeDaysMin).toHaveBeenCalledWith('user1', 'HEI')
+        expect(supportedPrisonsService.getPrisonConfig).toHaveBeenCalledWith('user1', 'HEI')
         expect(auditService.changeEstablishment).toHaveBeenCalledTimes(1)
         expect(userService.setActiveCaseLoad).toHaveBeenCalledWith('HEI', 'user1')
       })
   })
 
   it('should redirect to valid page when passed in querystring', () => {
-    const newEstablishment: Prison = { prisonId: 'HEI', prisonName: supportedPrisons.HEI, policyNoticeDaysMin: 2 }
+    const newEstablishment: Prison = {
+      prisonId: 'HEI',
+      prisonName: supportedPrisons.HEI,
+      maxTotalVisitors: 6,
+      policyNoticeDaysMin: 2,
+    }
 
     return request(app)
       .post(`/change-establishment?referrer=/search/prisoner/`)
@@ -238,7 +258,7 @@ describe('POST /change-establishment', () => {
       .expect(() => {
         expect(sessionData.selectedEstablishment).toStrictEqual(newEstablishment)
         expect(visitorUtils.clearSession).toHaveBeenCalledTimes(1)
-        expect(supportedPrisonsService.getPolicyNoticeDaysMin).toHaveBeenCalledWith('user1', 'HEI')
+        expect(supportedPrisonsService.getPrisonConfig).toHaveBeenCalledWith('user1', 'HEI')
         expect(auditService.changeEstablishment).toHaveBeenCalledTimes(1)
         expect(userService.setActiveCaseLoad).toHaveBeenCalledWith('HEI', 'user1')
       })

--- a/server/routes/changeEstablishment.ts
+++ b/server/routes/changeEstablishment.ts
@@ -57,7 +57,7 @@ export default function routes({ auditService, supportedPrisonsService, userServ
 
     clearSession(req)
 
-    const policyNoticeDaysMin = await supportedPrisonsService.getPolicyNoticeDaysMin(
+    const { maxTotalVisitors, policyNoticeDaysMin } = await supportedPrisonsService.getPrisonConfig(
       res.locals.user.username,
       req.body.establishment,
     )
@@ -66,6 +66,7 @@ export default function routes({ auditService, supportedPrisonsService, userServ
     const newEstablishment: Prison = {
       prisonId: req.body.establishment,
       prisonName: availablePrisons[req.body.establishment],
+      maxTotalVisitors,
       policyNoticeDaysMin,
     }
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -85,8 +85,11 @@ class MockSupportedPrisonsService extends SupportedPrisonsService {
     return TestData.supportedPrisons()
   }
 
-  async getPolicyNoticeDaysMin(_username: string, _prisonCode: string): Promise<number> {
-    return 2
+  async getPrisonConfig(
+    _username: string,
+    _prisonCode: string,
+  ): Promise<{ maxTotalVisitors: number; policyNoticeDaysMin: number }> {
+    return { maxTotalVisitors: 6, policyNoticeDaysMin: 2 }
   }
 }
 

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -368,6 +368,10 @@ export default class TestData {
     active = true,
     policyNoticeDaysMax = 28,
     policyNoticeDaysMin = 3,
+    maxTotalVisitors = 6,
+    maxAdultVisitors = 3,
+    maxChildVisitors = 3,
+    adultAgeYears = 18,
     excludeDates = [],
   }: Partial<PrisonDto> = {}): PrisonDto =>
     ({
@@ -375,6 +379,10 @@ export default class TestData {
       active,
       policyNoticeDaysMax,
       policyNoticeDaysMin,
+      maxTotalVisitors,
+      maxAdultVisitors,
+      maxChildVisitors,
+      adultAgeYears,
       excludeDates,
     }) as PrisonDto
 

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -125,7 +125,7 @@ describe('/visit/:reference', () => {
     prisonerVisitorsService.getVisitors.mockResolvedValue(visitors)
     supportedPrisonsService.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
     supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
-    supportedPrisonsService.getPolicyNoticeDaysMin.mockResolvedValue(2)
+    supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors: 6, policyNoticeDaysMin: 2 })
 
     visitSessionData = { prisoner: undefined }
 
@@ -986,6 +986,7 @@ describe('POST /visit/:reference/cancel', () => {
 
     visitService.cancelVisit = jest.fn().mockResolvedValue(cancelledVisit)
     supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
+    supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors: 6, policyNoticeDaysMin: 2 })
 
     app = appWithAllRoutes({
       services: {

--- a/server/routes/visitJourney/selectVisitors.test.ts
+++ b/server/routes/visitJourney/selectVisitors.test.ts
@@ -6,7 +6,12 @@ import { FlashData, VisitorListItem, VisitSessionData } from '../../@types/bapv'
 import { OffenderRestriction } from '../../data/prisonApiTypes'
 import { appWithAllRoutes, flashProvider } from '../testutils/appSetup'
 import { Restriction } from '../../data/prisonerContactRegistryApiTypes'
-import { createMockPrisonerProfileService, createMockPrisonerVisitorsService } from '../../services/testutils/mocks'
+import {
+  createMockPrisonerProfileService,
+  createMockPrisonerVisitorsService,
+  createMockSupportedPrisonsService,
+} from '../../services/testutils/mocks'
+import TestData from '../testutils/testData'
 
 let sessionApp: Express
 
@@ -14,6 +19,7 @@ let flashData: FlashData
 
 const prisonerVisitorsService = createMockPrisonerVisitorsService()
 const prisonerProfileService = createMockPrisonerProfileService()
+const supportedPrisonsService = createMockSupportedPrisonsService()
 
 let visitSessionData: VisitSessionData
 
@@ -527,105 +533,105 @@ testJourneys.forEach(journey => {
     const adultVisitors: { adults: VisitorListItem[] } = { adults: [] }
     const visitReference = 'ab-cd-ef-gh'
 
-    beforeEach(() => {
-      const visitorList: { visitors: VisitorListItem[] } = {
-        visitors: [
-          {
-            personId: 4000,
-            name: 'Keith Daniels',
-            dateOfBirth: '1980-02-28',
-            adult: true,
-            relationshipDescription: 'Brother',
-            address: 'Not entered',
-            restrictions: [
-              {
-                restrictionType: 'BAN',
-                restrictionTypeDescription: 'Banned',
-                startDate: '2022-01-01',
-                expiryDate: '2023-12-14',
-                comment: 'Ban details',
-              },
-            ],
-            banned: false,
-          },
-          {
-            personId: 4321,
-            name: 'Jeanette Smith',
-            dateOfBirth: '1986-07-28',
-            adult: true,
-            relationshipDescription: 'Sister',
-            address:
-              'Premises,<br>Flat 23B,<br>123 The Street,<br>Springfield,<br>Coventry,<br>West Midlands,<br>C1 2AB,<br>England',
-            restrictions: [
-              {
-                restrictionType: 'BAN',
-                restrictionTypeDescription: 'Banned',
-                startDate: '2022-01-01',
-                expiryDate: '2022-07-31',
-                comment: 'Ban details',
-              },
-            ],
-            banned: true,
-          },
-          {
-            personId: 4322,
-            name: 'Bob Smith',
-            dateOfBirth: '1986-07-28',
-            adult: true,
-            relationshipDescription: 'Brother',
-            address: '1st listed address',
-            restrictions: [],
-            banned: false,
-          },
-          {
-            personId: 4323,
-            name: 'Ted Smith',
-            dateOfBirth: '1968-07-28',
-            adult: true,
-            relationshipDescription: 'Father',
-            address: '1st listed address',
-            restrictions: [],
-            banned: false,
-          },
-          {
-            personId: 4324,
-            name: 'Anne Smith',
-            dateOfBirth: '2018-03-02',
-            adult: false,
-            relationshipDescription: 'Niece',
-            address: 'Not entered',
-            restrictions: [],
-            banned: false,
-          },
-          {
-            personId: 4325,
-            name: 'Bill Smith',
-            dateOfBirth: '2018-03-02',
-            adult: false,
-            relationshipDescription: 'Nephew',
-            address: 'Not entered',
-            restrictions: [],
-            banned: false,
-          },
-          {
-            personId: 4326,
-            name: 'John Jones',
-            dateOfBirth: '1978-05-25',
-            adult: true,
-            relationshipDescription: 'Friend',
-            address: 'Not entered',
-            restrictions: [
-              {
-                restrictionType: 'CLOSED',
-                restrictionTypeDescription: 'Closed',
-                startDate: '2022-01-01',
-              },
-            ],
-            banned: false,
-          },
-        ],
-      }
+    const visitorList: { visitors: VisitorListItem[] } = {
+      visitors: [
+        {
+          personId: 4000,
+          name: 'Keith Daniels',
+          dateOfBirth: '1980-02-28',
+          adult: true,
+          relationshipDescription: 'Brother',
+          address: 'Not entered',
+          restrictions: [
+            {
+              restrictionType: 'BAN',
+              restrictionTypeDescription: 'Banned',
+              startDate: '2022-01-01',
+              expiryDate: '2023-12-14',
+              comment: 'Ban details',
+            },
+          ],
+          banned: false,
+        },
+        {
+          personId: 4321,
+          name: 'Jeanette Smith',
+          dateOfBirth: '1986-07-28',
+          adult: true,
+          relationshipDescription: 'Sister',
+          address:
+            'Premises,<br>Flat 23B,<br>123 The Street,<br>Springfield,<br>Coventry,<br>West Midlands,<br>C1 2AB,<br>England',
+          restrictions: [
+            {
+              restrictionType: 'BAN',
+              restrictionTypeDescription: 'Banned',
+              startDate: '2022-01-01',
+              expiryDate: '2022-07-31',
+              comment: 'Ban details',
+            },
+          ],
+          banned: true,
+        },
+        {
+          personId: 4322,
+          name: 'Bob Smith',
+          dateOfBirth: '1986-07-28',
+          adult: true,
+          relationshipDescription: 'Brother',
+          address: '1st listed address',
+          restrictions: [],
+          banned: false,
+        },
+        {
+          personId: 4323,
+          name: 'Ted Smith',
+          dateOfBirth: '1968-07-28',
+          adult: true,
+          relationshipDescription: 'Father',
+          address: '1st listed address',
+          restrictions: [],
+          banned: false,
+        },
+        {
+          personId: 4324,
+          name: 'Anne Smith',
+          dateOfBirth: '2018-03-02',
+          adult: false,
+          relationshipDescription: 'Niece',
+          address: 'Not entered',
+          restrictions: [],
+          banned: false,
+        },
+        {
+          personId: 4325,
+          name: 'Bill Smith',
+          dateOfBirth: '2018-03-02',
+          adult: false,
+          relationshipDescription: 'Nephew',
+          address: 'Not entered',
+          restrictions: [],
+          banned: false,
+        },
+        {
+          personId: 4326,
+          name: 'John Jones',
+          dateOfBirth: '1978-05-25',
+          adult: true,
+          relationshipDescription: 'Friend',
+          address: 'Not entered',
+          restrictions: [
+            {
+              restrictionType: 'CLOSED',
+              restrictionTypeDescription: 'Closed',
+              startDate: '2022-01-01',
+            },
+          ],
+          banned: false,
+        },
+      ],
+    }
 
+    beforeEach(() => {
       visitSessionData = {
         prisoner: {
           name: 'prisoner name',
@@ -969,26 +975,66 @@ testJourneys.forEach(journey => {
         })
     })
 
-    it('should set validation errors in flash and redirect if more than 10 visitors are selected', () => {
-      const tooManyVisitorIds = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11']
+    describe('Maximum total number of visitors', () => {
+      it('should allow up to the maximum configured number of visitors', () => {
+        const maxTotalVisitors = 2
+        const visitors = ['4322', '4323']
 
-      return request(sessionApp)
-        .post(`${journey.urlPrefix}/select-visitors`)
-        .send(`visitors=${tooManyVisitorIds.join('&visitors=')}`)
-        .expect(302)
-        .expect('location', `${journey.urlPrefix}/select-visitors`)
-        .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('errors', [
-            {
-              location: 'body',
-              msg: 'Select no more than 10 visitors',
-              path: 'visitors',
-              type: 'field',
-              value: tooManyVisitorIds,
-            },
-          ])
-          expect(flashProvider).toHaveBeenCalledWith('formValues', { visitors: tooManyVisitorIds })
+        supportedPrisonsService.getSupportedPrisons.mockResolvedValue(TestData.supportedPrisons())
+        supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors, policyNoticeDaysMin: 2 })
+
+        sessionApp = appWithAllRoutes({
+          services: { prisonerProfileService, prisonerVisitorsService, supportedPrisonsService },
+          sessionData: {
+            adultVisitors,
+            visitorList,
+            visitSessionData,
+          } as SessionData,
         })
+
+        return request(sessionApp)
+          .post(`${journey.urlPrefix}/select-visitors`)
+          .send({ visitors })
+          .expect(302)
+          .expect('location', `${journey.urlPrefix}/select-date-and-time`)
+          .expect(() => {
+            expect(visitSessionData.visitors.length).toEqual(2)
+          })
+      })
+
+      it('should set validation errors in flash and redirect if more than the maximum configured visitors are selected', () => {
+        const maxTotalVisitors = 2
+        const visitors = ['4322', '4323', '4324']
+
+        supportedPrisonsService.getSupportedPrisons.mockResolvedValue(TestData.supportedPrisons())
+        supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors, policyNoticeDaysMin: 2 })
+
+        sessionApp = appWithAllRoutes({
+          services: { prisonerProfileService, prisonerVisitorsService, supportedPrisonsService },
+          sessionData: {
+            adultVisitors,
+            visitorList,
+            visitSessionData,
+          } as SessionData,
+        })
+        return request(sessionApp)
+          .post(`${journey.urlPrefix}/select-visitors`)
+          .send({ visitors })
+          .expect(302)
+          .expect('location', `${journey.urlPrefix}/select-visitors`)
+          .expect(() => {
+            expect(flashProvider).toHaveBeenCalledWith('errors', [
+              {
+                location: 'body',
+                msg: `Select no more than ${maxTotalVisitors} visitors`,
+                path: 'visitors',
+                type: 'field',
+                value: visitors,
+              },
+            ])
+            expect(flashProvider).toHaveBeenCalledWith('formValues', { visitors })
+          })
+      })
     })
   })
 })

--- a/server/routes/visitJourney/selectVisitors.ts
+++ b/server/routes/visitJourney/selectVisitors.ts
@@ -115,8 +115,9 @@ export default class SelectVisitors {
         throw new Error('No visitors selected')
       }
 
-      if (selected.length > 10) {
-        throw new Error('Select no more than 10 visitors')
+      const { maxTotalVisitors } = req.session.selectedEstablishment
+      if (selected.length > maxTotalVisitors) {
+        throw new Error(`Select no more than ${maxTotalVisitors} visitors`)
       }
 
       const selectedAndBanned = req.session.visitorList.visitors.filter((visitor: VisitorListItem) => {

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -182,7 +182,7 @@ describe('clearSession', () => {
     adultVisitors: { adults: [] },
     slotsList: {},
     visitSessionData: { prisoner: undefined },
-    selectedEstablishment: { prisonId: 'HEI', prisonName: 'Hewell (HMP)', policyNoticeDaysMin: 2 },
+    selectedEstablishment: { prisonId: 'HEI', prisonName: 'Hewell (HMP)', maxTotalVisitors: 6, policyNoticeDaysMin: 2 },
   }
 
   req.session = sessionData as Session & SessionData
@@ -194,7 +194,12 @@ describe('clearSession', () => {
       returnTo: '/url',
       nowInMinutes: 123456,
       cookie: undefined,
-      selectedEstablishment: { prisonId: 'HEI', prisonName: 'Hewell (HMP)', policyNoticeDaysMin: 2 },
+      selectedEstablishment: {
+        prisonId: 'HEI',
+        prisonName: 'Hewell (HMP)',
+        maxTotalVisitors: 6,
+        policyNoticeDaysMin: 2,
+      },
     })
   })
 })

--- a/server/services/supportedPrisonsService.test.ts
+++ b/server/services/supportedPrisonsService.test.ts
@@ -58,14 +58,17 @@ describe('Supported prisons service', () => {
     })
   })
 
-  describe('getPolicyNoticeDaysMin', () => {
-    it('should return a number (policyNoticeDaysMin) when called with a prison ID', async () => {
+  describe('getPrisonConfig', () => {
+    it('should return some prison config values (maxTotalVisitors, policyNoticeDaysMin) when called with a prison ID', async () => {
       orchestrationApiClient.getPrison.mockResolvedValue(prisonDto)
 
-      const results = await supportedPrisonsService.getPolicyNoticeDaysMin('user', 'HEI')
+      const results = await supportedPrisonsService.getPrisonConfig('user', 'HEI')
 
-      expect(orchestrationApiClient.getPrison).toHaveBeenCalledTimes(1)
-      expect(results).toStrictEqual(3)
+      expect(orchestrationApiClient.getPrison).toHaveBeenCalledWith('HEI')
+      expect(results).toStrictEqual({
+        maxTotalVisitors: prisonDto.maxTotalVisitors,
+        policyNoticeDaysMin: prisonDto.policyNoticeDaysMin,
+      })
     })
   })
 

--- a/server/services/supportedPrisonsService.ts
+++ b/server/services/supportedPrisonsService.ts
@@ -36,11 +36,14 @@ export default class SupportedPrisonsService {
     return orchestrationApiClient.getSupportedPrisonIds()
   }
 
-  async getPolicyNoticeDaysMin(username: string, prisonCode: string): Promise<number> {
+  async getPrisonConfig(
+    username: string,
+    prisonCode: string,
+  ): Promise<{ maxTotalVisitors: number; policyNoticeDaysMin: number }> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
-    const { policyNoticeDaysMin } = await orchestrationApiClient.getPrison(prisonCode)
-    return policyNoticeDaysMin
+    const { policyNoticeDaysMin, maxTotalVisitors } = await orchestrationApiClient.getPrison(prisonCode)
+    return { maxTotalVisitors, policyNoticeDaysMin }
   }
 
   private async refreshPrisonNames(username: string): Promise<void> {


### PR DESCRIPTION
Replace the hard-coded maximum of 10 visitors that can be selected for a visit with the configurable value that is now available per prison.