### PR TITLE
VB-3760 Hide 'Do not change' button if only notification is a blocked date

### DIFF
--- a/integration_tests/integration/reviewAVisit.cy.ts
+++ b/integration_tests/integration/reviewAVisit.cy.ts
@@ -23,7 +23,7 @@ context('Review a visit', () => {
       createTimestamp: '2024-04-11T09:00:00',
     },
     {
-      type: 'PRISON_VISITS_BLOCKED_FOR_DATE',
+      type: 'NON_ASSOCIATION_EVENT',
       applicationMethodType: 'NOT_APPLICABLE',
       createTimestamp: '2024-04-11T10:00:00',
     },
@@ -56,13 +56,13 @@ context('Review a visit', () => {
     cy.task('stubVisitHistory', visitHistoryDetails)
     cy.task('stubPrisonerSocialContacts', { offenderNo, contacts })
 
-    const notifications: NotificationType[] = ['PRISON_VISITS_BLOCKED_FOR_DATE']
+    const notifications: NotificationType[] = ['NON_ASSOCIATION_EVENT']
     cy.task('stubGetVisitNotifications', { reference: visitHistoryDetails.visit.reference, notifications })
 
     // Start on booking summary page and chose 'Do not change' button
     cy.visit('/visit/ab-cd-ef-gh')
     const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
-    visitDetailsPage.visitNotification().eq(0).contains(notificationTypeWarnings.PRISON_VISITS_BLOCKED_FOR_DATE)
+    visitDetailsPage.visitNotification().eq(0).contains(notificationTypeWarnings.NON_ASSOCIATION_EVENT)
     visitDetailsPage.clearNotifications().click()
 
     // Clear notifications page - select Yes and give a reason

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -452,6 +452,28 @@ describe('/visit/:reference', () => {
           })
       })
 
+      it('should display a single visit notification banner and NOT the do not change button when only a blocked date notification set', () => {
+        visitService.getFullVisitDetails.mockResolvedValue({
+          visitHistoryDetails,
+          visitors,
+          notifications: ['PRISON_VISITS_BLOCKED_FOR_DATE'],
+          additionalSupport,
+        })
+
+        return request(app)
+          .get('/visit/ab-cd-ef-gh')
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            const $ = cheerio.load(res.text)
+            expect($('[data-test="visit-notification"]').length).toBe(1)
+            expect($('[data-test="visit-notification"]').text()).toBe(
+              notificationTypeWarnings.PRISON_VISITS_BLOCKED_FOR_DATE,
+            )
+            expect($('[data-test="clear-notifications"]').length).toBe(0)
+          })
+      })
+
       it('should display a single visit notification banner and do not change button when a single notification type is set', () => {
         visitService.getFullVisitDetails.mockResolvedValue({
           visitHistoryDetails,

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -104,6 +104,11 @@ export default function routes({
     const showUpdate = nowTimestamp < visitStartTimestamp
     const showCancel = nowTimestamp < chosenFutureInterval
 
+    const filteredNotifications = notifications.filter(
+      notification => notification !== 'PRISON_VISITS_BLOCKED_FOR_DATE',
+    )
+    const showDoNotChange = filteredNotifications.length > 0
+
     return res.render('pages/visit/summary', {
       prisoner,
       prisonerLocation,
@@ -117,6 +122,7 @@ export default function routes({
       fromPageQuery,
       showUpdate,
       showCancel,
+      showDoNotChange,
       requestMethodDescriptions,
       eventAuditTypes,
       notificationTypes,

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -136,7 +136,7 @@
                 preventDoubleClick: true
               }) }}
             {% endif %}
-            {% if notifications | length %} 
+            {% if showDoNotChange %} 
               {{ govukButton({
                 text: "Do not change",
                 classes: "govuk-!-margin-top-5 govuk-button--secondary",


### PR DESCRIPTION
If the only visit notification is for a blocked date then do not show the 'Do not change' button on the booking summary page.