### PR TITLE
VB-3955 Move call to update visit application to earlier in booking journey

### DIFF
--- a/integration_tests/integration/bookAVisit.cy.ts
+++ b/integration_tests/integration/bookAVisit.cy.ts
@@ -162,6 +162,19 @@ context('Book a visit', () => {
     mainContactPage.getFirstContact().check()
     mainContactPage.phoneNumberTrueRadio().click()
     mainContactPage.enterPhoneNumber('01234 567890')
+    cy.task(
+      'stubChangeVisitApplication',
+      TestData.application({
+        startTimestamp: visitSessions[0].startTimestamp,
+        endTimestamp: visitSessions[0].endTimestamp,
+        visitors: [
+          { nomisPersonId: contacts[0].personId, visitContact: true },
+          { nomisPersonId: contacts[1].personId, visitContact: false },
+        ],
+        visitorSupport: { description: 'Wheelchair ramp, Some extra help!' },
+        sessionTemplateReference: visitSessions[0].sessionTemplateReference,
+      }),
+    )
 
     // Request method
     mainContactPage.continueButton().click()
@@ -184,19 +197,6 @@ context('Book a visit', () => {
     checkYourBookingPage.requestMethod().contains('Phone call')
 
     // Confirmation
-    cy.task(
-      'stubChangeVisitApplication',
-      TestData.application({
-        startTimestamp: visitSessions[0].startTimestamp,
-        endTimestamp: visitSessions[0].endTimestamp,
-        visitors: [
-          { nomisPersonId: contacts[0].personId, visitContact: true },
-          { nomisPersonId: contacts[1].personId, visitContact: false },
-        ],
-        visitorSupport: { description: 'Wheelchair ramp, Some extra help!' },
-        sessionTemplateReference: visitSessions[0].sessionTemplateReference,
-      }),
-    )
     cy.task('stubBookVisit', {
       visit: TestData.visit({
         visitStatus: 'BOOKED',

--- a/integration_tests/integration/checkYourBooking.cy.ts
+++ b/integration_tests/integration/checkYourBooking.cy.ts
@@ -105,6 +105,17 @@ context('Check visit details page', () => {
     mainContactPage.getFirstContact().check()
     mainContactPage.phoneNumberTrueRadio().click()
     mainContactPage.enterPhoneNumber('01234 567890')
+    cy.task(
+      'stubChangeVisitApplication',
+      TestData.application({
+        startTimestamp: visitSessions[0].startTimestamp,
+        endTimestamp: visitSessions[0].endTimestamp,
+        visitContact: { name: 'Jeanette Smith', telephone: '01234 567890' },
+        visitors: [{ nomisPersonId: contacts[0].personId, visitContact: true }],
+        visitorSupport: { description: '' },
+        sessionTemplateReference: visitSessions[0].sessionTemplateReference,
+      }),
+    )
 
     // Request method
     mainContactPage.continueButton().click()
@@ -183,6 +194,20 @@ context('Check visit details page', () => {
     additionalSupportPage.additionalSupportRequired().check()
     additionalSupportPage.enterSupportDetails('Wheelchair ramp')
     additionalSupportPage.continueButton().click()
+    cy.task(
+      'stubChangeVisitApplication',
+      TestData.application({
+        startTimestamp: visitSessions[1].startTimestamp,
+        endTimestamp: visitSessions[1].endTimestamp,
+        visitContact: { name: 'Jeanette Smith', telephone: '01234 567890' },
+        visitors: [
+          { nomisPersonId: contacts[0].personId, visitContact: true },
+          { nomisPersonId: contacts[1].personId, visitContact: false },
+        ],
+        visitorSupport: { description: 'Wheelchair ramp' },
+        sessionTemplateReference: visitSessions[1].sessionTemplateReference,
+      }),
+    )
     mainContactPage.continueButton().click()
     requestMethodPage.continueButton().click()
     checkYourBookingPage.additionalSupport().contains('Wheelchair ramp')
@@ -190,18 +215,6 @@ context('Check visit details page', () => {
     // Check details - change main contact number - then proceed through journey
     checkYourBookingPage.changeMainContact().click()
     mainContactPage.enterPhoneNumber('09876 543 321')
-    mainContactPage.continueButton().click()
-    requestMethodPage.continueButton().click()
-    checkYourBookingPage.mainContactNumber().contains('09876 543 321')
-
-    // Check details - change request method - then proceed through journey
-    checkYourBookingPage.changeRequestMethod().click()
-    requestMethodPage.getRequestLabelByValue('WEBSITE').contains('GOV.UK')
-    requestMethodPage.getRequestMethodByValue('WEBSITE').check()
-    requestMethodPage.continueButton().click()
-    checkYourBookingPage.requestMethod().contains('GOV.UK')
-
-    // Confirmation
     cy.task(
       'stubChangeVisitApplication',
       TestData.application({
@@ -216,6 +229,18 @@ context('Check visit details page', () => {
         sessionTemplateReference: visitSessions[1].sessionTemplateReference,
       }),
     )
+    mainContactPage.continueButton().click()
+    requestMethodPage.continueButton().click()
+    checkYourBookingPage.mainContactNumber().contains('09876 543 321')
+
+    // Check details - change request method - then proceed through journey
+    checkYourBookingPage.changeRequestMethod().click()
+    requestMethodPage.getRequestLabelByValue('WEBSITE').contains('GOV.UK')
+    requestMethodPage.getRequestMethodByValue('WEBSITE').check()
+    requestMethodPage.continueButton().click()
+    checkYourBookingPage.requestMethod().contains('GOV.UK')
+
+    // Confirmation
     cy.task('stubBookVisit', {
       visit: TestData.visit({
         visitStatus: 'BOOKED',

--- a/integration_tests/integration/updateAVisit.cy.ts
+++ b/integration_tests/integration/updateAVisit.cy.ts
@@ -133,6 +133,20 @@ context('Update a visit', () => {
     mainContactPage.getFirstContact().should('be.checked')
     mainContactPage.getPhoneNumber().should('have.value', originalVisit.visitContact.telephone)
     mainContactPage.enterPhoneNumber('09876 543 321')
+    cy.task(
+      'stubChangeVisitApplication',
+      TestData.application({
+        startTimestamp: visitSessions[1].startTimestamp,
+        endTimestamp: visitSessions[1].endTimestamp,
+        visitContact: { name: 'Jeanette Smith', telephone: '09876 543 321' },
+        visitors: [
+          { nomisPersonId: contacts[0].personId, visitContact: true },
+          { nomisPersonId: contacts[1].personId, visitContact: false },
+        ],
+        visitorSupport: { description: 'Wheelchair ramp, Some extra help!' },
+        sessionTemplateReference: visitSessions[1].sessionTemplateReference,
+      }),
+    )
     mainContactPage.continueButton().click()
 
     // Request method
@@ -154,20 +168,6 @@ context('Update a visit', () => {
     checkYourBookingPage.requestMethod().contains('Phone call')
 
     // Submit booking
-    cy.task(
-      'stubChangeVisitApplication',
-      TestData.application({
-        startTimestamp: visitSessions[1].startTimestamp,
-        endTimestamp: visitSessions[1].endTimestamp,
-        visitContact: { name: 'Jeanette Smith', telephone: '09876 543 321' },
-        visitors: [
-          { nomisPersonId: contacts[0].personId, visitContact: true },
-          { nomisPersonId: contacts[1].personId, visitContact: false },
-        ],
-        visitorSupport: { description: 'Wheelchair ramp, Some extra help!' },
-        sessionTemplateReference: visitSessions[1].sessionTemplateReference,
-      }),
-    )
     cy.task('stubBookVisit', {
       visit: TestData.visit({
         visitStatus: 'BOOKED',

--- a/server/routes/bookAVisit.ts
+++ b/server/routes/bookAVisit.ts
@@ -36,7 +36,7 @@ export default function routes({
   const visitType = new VisitType('book', auditService)
   const additionalSupport = new AdditionalSupport('book')
   const dateAndTime = new DateAndTime('book', visitService, visitSessionsService, auditService)
-  const mainContact = new MainContact('book')
+  const mainContact = new MainContact('book', visitService)
   const requestMethod = new RequestMethod('book')
   const checkYourBooking = new CheckYourBooking('book', auditService, visitService)
   const confirmation = new Confirmation('book')

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -263,7 +263,7 @@ export default function routes({
   const visitType = new VisitType('update', auditService)
   const dateAndTime = new DateAndTime('update', visitService, visitSessionsService, auditService)
   const additionalSupport = new AdditionalSupport('update')
-  const mainContact = new MainContact('update')
+  const mainContact = new MainContact('update', visitService)
   const requestMethod = new RequestMethod('update')
   const checkYourBooking = new CheckYourBooking('update', auditService, visitService)
   const confirmation = new Confirmation('update')

--- a/server/routes/visitJourney/checkYourBooking.test.ts
+++ b/server/routes/visitJourney/checkYourBooking.test.ts
@@ -4,7 +4,7 @@ import { SessionData } from 'express-session'
 import * as cheerio from 'cheerio'
 import { FlashData, VisitSessionData } from '../../@types/bapv'
 import { appWithAllRoutes, flashProvider } from '../testutils/appSetup'
-import { ApplicationDto, Visit } from '../../data/orchestrationApiTypes'
+import { Visit } from '../../data/orchestrationApiTypes'
 import { createMockAuditService, createMockVisitService } from '../../services/testutils/mocks'
 
 let sessionApp: Express
@@ -158,16 +158,12 @@ testJourneys.forEach(journey => {
       const visitService = createMockVisitService()
 
       beforeEach(() => {
-        const application: Partial<ApplicationDto> = {
-          reference: visitSessionData.applicationReference,
-        }
         const bookedVisit: Partial<Visit> = {
           applicationReference: visitSessionData.applicationReference,
           reference: 'ab-cd-ef-gh',
           visitStatus: 'BOOKED',
         }
 
-        visitService.changeVisitApplication = jest.fn().mockResolvedValue(application)
         visitService.bookVisit = jest.fn().mockResolvedValue(bookedVisit)
 
         sessionApp = appWithAllRoutes({
@@ -184,7 +180,6 @@ testJourneys.forEach(journey => {
           .expect(302)
           .expect('location', `${journey.urlPrefix}/confirmation`)
           .expect(() => {
-            expect(visitService.changeVisitApplication).toHaveBeenCalledWith({ username: 'user1', visitSessionData })
             expect(visitService.bookVisit).toHaveBeenCalledWith({
               username: 'user1',
               applicationReference: visitSessionData.applicationReference,
@@ -227,7 +222,6 @@ testJourneys.forEach(journey => {
             expect($('.test-visit-type').text()).toContain('Open')
             expect($('form').prop('action')).toBe(`${journey.urlPrefix}/check-your-booking`)
 
-            expect(visitService.changeVisitApplication).toHaveBeenCalledWith({ username: 'user1', visitSessionData })
             expect(visitService.bookVisit).toHaveBeenCalledWith({
               username: 'user1',
               applicationReference: visitSessionData.applicationReference,

--- a/server/routes/visitJourney/checkYourBooking.ts
+++ b/server/routes/visitJourney/checkYourBooking.ts
@@ -40,11 +40,6 @@ export default class CheckYourBooking {
     const { offenderNo } = visitSessionData.prisoner
 
     try {
-      // change visit application to have the latest data
-      await this.visitService.changeVisitApplication({
-        username: res.locals.user.username,
-        visitSessionData,
-      })
       // 'book' the visit: complete the visit application and get BOOKED visit
       const bookedVisit = await this.visitService.bookVisit({
         username: res.locals.user.username,

--- a/server/routes/visitJourney/mainContact.ts
+++ b/server/routes/visitJourney/mainContact.ts
@@ -3,9 +3,13 @@ import { body, ValidationChain, validationResult } from 'express-validator'
 import { VisitorListItem } from '../../@types/bapv'
 import { getFlashFormValues } from '../visitorUtils'
 import getUrlPrefix from './visitJourneyUtils'
+import { VisitService } from '../../services'
 
 export default class MainContact {
-  constructor(private readonly mode: string) {}
+  constructor(
+    private readonly mode: string,
+    private readonly visitService: VisitService,
+  ) {}
 
   async get(req: Request, res: Response): Promise<void> {
     const isUpdate = this.mode === 'update'
@@ -53,6 +57,12 @@ export default class MainContact {
       phoneNumber: req.body.phoneNumber === 'hasPhoneNumber' ? req.body.phoneNumberInput : undefined,
       contactName: selectedContact === undefined ? req.body.someoneElseName : undefined,
     }
+
+    // update visit application to have the latest data
+    await this.visitService.changeVisitApplication({
+      username: res.locals.user.username,
+      visitSessionData,
+    })
 
     return res.redirect(`${urlPrefix}/request-method`)
   }


### PR DESCRIPTION
Move the call to `/visits/application/{reference}/slot/change` that updates the visit application with accumulated data so that it happens when the 'Main contact' page is submitted instead of the 'Check your answers' page. 

This means that:
* the application is updated as soon as all the required information is available
* the 'Check your details' page now only needs to make a single call (to `/visits/{applicationReference}/book`) so any latency is less likely to result in a user re-trying and ending up making a duplicate request