### PR TITLE
VB-3991 Handle renamed session conflict type

### DIFF
--- a/server/routes/visitJourney/dateAndTime.test.ts
+++ b/server/routes/visitJourney/dateAndTime.test.ts
@@ -4,7 +4,7 @@ import { SessionData } from 'express-session'
 import * as cheerio from 'cheerio'
 import { FlashData, VisitSessionData, VisitSlot, VisitSlotList } from '../../@types/bapv'
 import { appWithAllRoutes, flashProvider } from '../testutils/appSetup'
-import { ApplicationDto } from '../../data/orchestrationApiTypes'
+import { ApplicationDto, VisitSession } from '../../data/orchestrationApiTypes'
 import {
   createMockAuditService,
   createMockVisitService,
@@ -91,7 +91,7 @@ testJourneys.forEach(journey => {
                 capacity: 30,
                 visitRoom: 'room name',
                 // representing a pre-existing visit that is BOOKED
-                sessionConflicts: ['DOUBLE_BOOKED'],
+                sessionConflicts: ['DOUBLE_BOOKING_OR_RESERVATION'] as unknown as VisitSession['sessionConflicts'], // TODO remove cast when VB-3956 released
                 visitRestriction: 'OPEN',
               },
               {
@@ -117,7 +117,7 @@ testJourneys.forEach(journey => {
                 capacity: 30,
                 visitRoom: 'room name',
                 // representing the RESERVED visit being handled in this session
-                sessionConflicts: ['DOUBLE_BOOKED'],
+                sessionConflicts: ['DOUBLE_BOOKED'], // TODO update to DOUBLE_BOOKING_OR_RESERVATION when VB-3956 released
                 visitRestriction: 'OPEN',
               },
             ],
@@ -421,7 +421,7 @@ testJourneys.forEach(journey => {
               capacity: 30,
               visitRoom: 'room name',
               // representing the visit application visit being handled in this session
-              sessionConflicts: ['DOUBLE_BOOKED'],
+              sessionConflicts: ['DOUBLE_BOOKED'], // TODO update to DOUBLE_BOOKING_OR_RESERVATION when VB-3956 released
               visitRestriction: 'OPEN',
             })
 

--- a/server/views/pages/bookAVisit/dateAndTime.njk
+++ b/server/views/pages/bookAVisit/dateAndTime.njk
@@ -17,7 +17,8 @@
 {% macro buildSlotsRadioItems(slotsList, radios) %}
   {% for slot in slotsList %}
 
-    {%- set doubleBooked = slot.id != originalVisitSlot.id and (slot.sessionConflicts and "DOUBLE_BOOKED" in slot.sessionConflicts) %}
+    {# // TODO remove DOUBLE_BOOKED when VB-3956 released #}
+    {%- set doubleBooked = slot.id != originalVisitSlot.id and (slot.sessionConflicts and ("DOUBLE_BOOKED" in slot.sessionConflicts or "DOUBLE_BOOKING_OR_RESERVATION" in slot.sessionConflicts)) %}
     {%- set checked = true if formValues['visit-date-and-time'] and formValues['visit-date-and-time'] == slot.id else false %}
 
     {%- set tableText %}

--- a/server/views/pages/bookAVisit/dateAndTime.test.ts
+++ b/server/views/pages/bookAVisit/dateAndTime.test.ts
@@ -3,6 +3,7 @@ import * as cheerio from 'cheerio'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../utils/nunjucksSetup'
 import { VisitSlot, VisitSlotList } from '../../../@types/bapv'
+import { VisitSession } from '../../../data/orchestrationApiTypes'
 
 const template = fs.readFileSync('server/views/pages/bookAVisit/dateAndTime.njk')
 
@@ -76,7 +77,7 @@ describe('Views - Date and time of visit', () => {
                   capacity: 30,
                   visitRoom: 'room name',
                   // representing a pre-existing visit that is BOOKED
-                  sessionConflicts: ['DOUBLE_BOOKED'],
+                  sessionConflicts: ['DOUBLE_BOOKING_OR_RESERVATION'] as unknown as VisitSession['sessionConflicts'], // TODO remove cast when VB-3956 released
                   visitRestriction: 'OPEN',
                 },
               ],
@@ -101,7 +102,7 @@ describe('Views - Date and time of visit', () => {
                   capacity: 30,
                   visitRoom: 'room name',
                   // representing the RESERVED visit being handled in this session
-                  sessionConflicts: ['DOUBLE_BOOKED'],
+                  sessionConflicts: ['DOUBLE_BOOKED'], // TODO update to DOUBLE_BOOKING_OR_RESERVATION when VB-3956 released
                   visitRestriction: 'OPEN',
                 },
               ],


### PR DESCRIPTION
Handle both existing (`DOUBLE_BOOKED`) and forthcoming change to (`DOUBLE_BOOKING_OR_RESERVATION`) value for session conflicts.

`DOUBLE_BOOKED` can be removed once API changes have been released.