### PR TITLE
VB-3742 Block a new date for visits page

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -13,6 +13,7 @@ declare module 'express-session' {
     slotsList: VisitSlotList
     visitSessionData: VisitSessionData
     selectedEstablishment: Prison
+    visitBlockDate?: string
   }
 }
 

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -10,6 +10,7 @@ import {
   CreateApplicationDto,
   IgnoreVisitNotificationsDto,
   NotificationType,
+  PageVisitDto,
   SessionSchedule,
   Visit,
   VisitRestriction,
@@ -172,6 +173,31 @@ describe('orchestrationApiClient', () => {
       )
 
       expect(output).toStrictEqual(visitPreviews)
+    })
+  })
+
+  describe('getBookedVisitCountByDate', () => {
+    it('should return booked visit count for given prison and date', async () => {
+      const results: PageVisitDto = {
+        totalElements: 2,
+      }
+
+      fakeOrchestrationApi
+        .get(`/visits/search`)
+        .query({
+          prisonId: 'HEI',
+          visitStartDate: '2022-05-23',
+          visitEndDate: '2022-05-23',
+          visitStatus: 'BOOKED',
+          page: '0',
+          size: '1',
+        })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, results)
+
+      const output = await orchestrationApiClient.getBookedVisitCountByDate('HEI', '2022-05-23')
+
+      expect(output).toBe(2)
     })
   })
 

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -11,6 +11,7 @@ import {
   NotificationCount,
   NotificationGroup,
   NotificationType,
+  PageVisitDto,
   PrisonDto,
   PrisonerProfile,
   SessionCapacity,
@@ -80,6 +81,21 @@ export default class OrchestrationApiClient {
         ...(visitRestrictions && { visitRestrictions }),
       }).toString(),
     })
+  }
+
+  async getBookedVisitCountByDate(prisonId: string, date: string): Promise<number> {
+    const visits = await this.restClient.get<PageVisitDto>({
+      path: `/visits/search`,
+      query: new URLSearchParams({
+        prisonId,
+        visitStartDate: date,
+        visitEndDate: date,
+        visitStatus: 'BOOKED',
+        page: '0',
+        size: '1',
+      }).toString(),
+    })
+    return visits.totalElements ?? 0
   }
 
   //  orchestration-applications-controller

--- a/server/routes/blockVisitDates/blockNewDateController.test.ts
+++ b/server/routes/blockVisitDates/blockNewDateController.test.ts
@@ -1,0 +1,97 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import * as cheerio from 'cheerio'
+import { SessionData } from 'express-session'
+import { appWithAllRoutes } from '../testutils/appSetup'
+import { createMockVisitService } from '../../services/testutils/mocks'
+import config from '../../config'
+
+let app: Express
+let sessionData: SessionData
+
+const visitService = createMockVisitService()
+
+const url = '/block-visit-dates/block-new-date'
+
+beforeEach(() => {
+  jest.replaceProperty(config, 'features', { sessionManagement: true })
+
+  sessionData = {} as SessionData
+  app = appWithAllRoutes({ services: { visitService }, sessionData })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Feature flag', () => {
+  it('should return a 404 if feature not enabled', () => {
+    jest.replaceProperty(config, 'features', { sessionManagement: false })
+    app = appWithAllRoutes({})
+    return request(app).get(url).expect(404)
+  })
+})
+
+describe('Block new visit date', () => {
+  describe(`GET ${url}`, () => {
+    it('should redirect to blocked dates listing page if no new block date in session', () => {
+      return request(app).get(url).expect(302).expect('location', '/block-visit-dates')
+    })
+
+    it('should display block new date page - with one existing booking', () => {
+      sessionData.visitBlockDate = '2024-09-06'
+      visitService.getBookedVisitCountByDate.mockResolvedValue(1)
+
+      return request(app)
+        .get(url)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('.govuk-back-link').attr('href')).toBe('/block-visit-dates')
+          expect($('h1').text()).toBe('Are you sure you want to block visits on Friday 6 September 2024?')
+
+          expect($('[data-test=existing-bookings]').text().trim()).toBe('There is 1 existing booking for this date.')
+          expect($('[data-test=no-existing-bookings]').length).toBe(0)
+
+          expect($('input[name=confirmBlockDate]').length).toBe(2)
+          expect($('input[name=confirmBlockDate]:checked').length).toBe(0)
+
+          expect($('[data-test=submit]').text().trim()).toBe('Continue')
+
+          expect(visitService.getBookedVisitCountByDate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId: 'HEI',
+            date: sessionData.visitBlockDate,
+          })
+        })
+    })
+
+    it('should display block new date page - with multiple existing bookings', () => {
+      sessionData.visitBlockDate = '2024-09-06'
+      visitService.getBookedVisitCountByDate.mockResolvedValue(2)
+
+      return request(app)
+        .get(url)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test=existing-bookings]').text().trim()).toBe('There are 2 existing bookings for this date.')
+          expect($('[data-test=no-existing-bookings]').length).toBe(0)
+        })
+    })
+
+    it('should display block new date page - with no existing bookings', () => {
+      sessionData.visitBlockDate = '2024-09-06'
+      visitService.getBookedVisitCountByDate.mockResolvedValue(0)
+
+      return request(app)
+        .get(url)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test=existing-bookings]').length).toBe(0)
+          expect($('[data-test=no-existing-bookings]').text()).toBe('There are no existing bookings for this date.')
+        })
+    })
+  })
+})

--- a/server/routes/blockVisitDates/blockNewDateController.ts
+++ b/server/routes/blockVisitDates/blockNewDateController.ts
@@ -1,0 +1,18 @@
+import { RequestHandler } from 'express'
+
+export default class BlockNewDateController {
+  public constructor() {}
+
+  public view(): RequestHandler {
+    return async (req, res) => {
+      const { visitBlockDate } = req.session
+      if (!visitBlockDate) {
+        return res.redirect('/block-visit-dates')
+      }
+
+      const visitCount = 2
+
+      return res.render('pages/blockVisitDates/blockNewDate', { visitBlockDate, visitCount })
+    }
+  }
+}

--- a/server/routes/blockVisitDates/blockNewDateController.ts
+++ b/server/routes/blockVisitDates/blockNewDateController.ts
@@ -1,7 +1,8 @@
 import { RequestHandler } from 'express'
+import { VisitService } from '../../services'
 
 export default class BlockNewDateController {
-  public constructor() {}
+  public constructor(private readonly visitService: VisitService) {}
 
   public view(): RequestHandler {
     return async (req, res) => {
@@ -10,7 +11,12 @@ export default class BlockNewDateController {
         return res.redirect('/block-visit-dates')
       }
 
-      const visitCount = 2
+      const { prisonId } = req.session.selectedEstablishment
+      const visitCount = await this.visitService.getBookedVisitCountByDate({
+        username: res.locals.user.username,
+        prisonId,
+        date: visitBlockDate,
+      })
 
       return res.render('pages/blockVisitDates/blockNewDate', { visitBlockDate, visitCount })
     }

--- a/server/routes/blockVisitDates/blockVisitDatesController.test.ts
+++ b/server/routes/blockVisitDates/blockVisitDatesController.test.ts
@@ -6,6 +6,8 @@ import config from '../../config'
 
 let app: Express
 
+const url = '/block-visit-dates'
+
 beforeEach(() => {
   jest.replaceProperty(config, 'features', { sessionManagement: true })
   app = appWithAllRoutes({})
@@ -19,15 +21,15 @@ describe('Feature flag', () => {
   it('should return a 404 if feature not enabled', () => {
     jest.replaceProperty(config, 'features', { sessionManagement: false })
     app = appWithAllRoutes({})
-    return request(app).get('/block-visit-dates').expect(404)
+    return request(app).get(url).expect(404)
   })
 })
 
 describe('Block visit dates listing page', () => {
-  describe('GET /block-visit-dates', () => {
+  describe(`GET ${url}`, () => {
     it('should display block visit dates page', () => {
       return request(app)
-        .get('/block-visit-dates')
+        .get(url)
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)

--- a/server/routes/blockVisitDates/index.ts
+++ b/server/routes/blockVisitDates/index.ts
@@ -6,15 +6,13 @@ import BlockVisitDatesController from './blockVisitDatesController'
 import config from '../../config'
 import BlockNewDateController from './blockNewDateController'
 
-// @TODO remove line below when services no longer unused
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes(services: Services): Router {
   const router = Router()
 
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   const blockVisitDatesController = new BlockVisitDatesController()
-  const blockNewDateController = new BlockNewDateController()
+  const blockNewDateController = new BlockNewDateController(services.visitService)
 
   // serve 404 for any route if feature flag not set
   if (!config.features.sessionManagement) {

--- a/server/routes/blockVisitDates/index.ts
+++ b/server/routes/blockVisitDates/index.ts
@@ -4,6 +4,7 @@ import { Services } from '../../services'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import BlockVisitDatesController from './blockVisitDatesController'
 import config from '../../config'
+import BlockNewDateController from './blockNewDateController'
 
 // @TODO remove line below when services no longer unused
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -13,6 +14,7 @@ export default function routes(services: Services): Router {
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   const blockVisitDatesController = new BlockVisitDatesController()
+  const blockNewDateController = new BlockNewDateController()
 
   // serve 404 for any route if feature flag not set
   if (!config.features.sessionManagement) {
@@ -20,6 +22,7 @@ export default function routes(services: Services): Router {
   }
 
   get('/', blockVisitDatesController.view())
+  get('/block-new-date', blockNewDateController.view())
 
   return router
 }

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -336,5 +336,22 @@ describe('Visit service', () => {
         expect(result).toStrictEqual(visitPreviews)
       })
     })
+
+    describe('getBookedVisitCountByDate', () => {
+      it('should return booked visit count for given date', async () => {
+        const date = '2024-01-31'
+
+        orchestrationApiClient.getBookedVisitCountByDate.mockResolvedValue(2)
+
+        const result = await visitService.getBookedVisitCountByDate({
+          username: 'user',
+          prisonId,
+          date,
+        })
+
+        expect(orchestrationApiClient.getBookedVisitCountByDate).toHaveBeenCalledWith(prisonId, date)
+        expect(result).toBe(2)
+      })
+    })
   })
 })

--- a/server/services/visitService.ts
+++ b/server/services/visitService.ts
@@ -175,6 +175,21 @@ export default class VisitService {
     return orchestrationApiClient.getVisitsBySessionTemplate(prisonId, undefined, sessionDate, undefined)
   }
 
+  async getBookedVisitCountByDate({
+    username,
+    prisonId,
+    date,
+  }: {
+    username: string
+    prisonId: string
+    date: string
+  }): Promise<number> {
+    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
+
+    return orchestrationApiClient.getBookedVisitCountByDate(prisonId, date)
+  }
+
   private buildVisitInformation(visit: Visit): VisitInformation {
     const visitTime = `${prisonerTimePretty(visit.startTimestamp)} to ${prisonerTimePretty(visit.endTimestamp)}`
 

--- a/server/views/pages/blockVisitDates/blockNewDate.njk
+++ b/server/views/pages/blockVisitDates/blockNewDate.njk
@@ -1,0 +1,55 @@
+{% extends "layout.njk" %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageHeaderTitle = "Are you sure you want to block visits on " + visitBlockDate | formatDate('EEEE d MMMM yyyy') + "?" %}
+{% set pageTitle %}
+  {% if errors | length %}Error: {% endif %}{{ applicationName }} - {{ pageHeaderTitle }}
+{% endset %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% include "partials/errorSummary.njk" %}
+
+      <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
+
+      {% if visitCount %}
+        <p>
+          There are {{ visitCount }} existing {{ "booking" | pluralise(visitCount) }} for this date.
+        </p>
+        <p>
+          These will be shown on the ‘Need review’ page to be rescheduled or cancelled.
+        </p>
+      {% else %}
+        <p>There are no existing bookings for this date.</p>
+      {% endif %}
+
+      <form action="/block-visit-dates/block-new-date" method="POST" novalidate>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+        {{ govukRadios({
+          name: "confirmBlockDate",
+          items: [
+            {
+              value: "yes",
+              text: "Yes"
+            },
+            {
+              value: "no",
+              text: "No"
+            }
+          ],
+          errorMessage: errors | findError('confirmBlockDate'),
+          attributes: { "data-test": "confirm-block-date" }
+        }) }}
+
+        {{ govukButton({
+          text: "Continue",
+          attributes: { "data-test": "submit" },
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/pages/blockVisitDates/blockNewDate.njk
+++ b/server/views/pages/blockVisitDates/blockNewDate.njk
@@ -16,7 +16,7 @@
 
       {% if visitCount %}
         <p>
-          There are {{ visitCount }} existing {{ "booking" | pluralise(visitCount) }} for this date.
+          There {{ "is" | pluralise(visitCount, "are") }} {{ visitCount }} existing {{ "booking" | pluralise(visitCount) }} for this date.
         </p>
         <p>
           These will be shown on the ‘Need review’ page to be rescheduled or cancelled.

--- a/server/views/pages/blockVisitDates/blockNewDate.njk
+++ b/server/views/pages/blockVisitDates/blockNewDate.njk
@@ -7,6 +7,8 @@
   {% if errors | length %}Error: {% endif %}{{ applicationName }} - {{ pageHeaderTitle }}
 {% endset %}
 
+{% set backLinkHref = '/block-visit-dates' %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -15,14 +17,14 @@
       <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
 
       {% if visitCount %}
-        <p>
+        <p data-test="existing-bookings">
           There {{ "is" | pluralise(visitCount, "are") }} {{ visitCount }} existing {{ "booking" | pluralise(visitCount) }} for this date.
         </p>
         <p>
           These will be shown on the ‘Need review’ page to be rescheduled or cancelled.
         </p>
       {% else %}
-        <p>There are no existing bookings for this date.</p>
+        <p data-test="no-existing-bookings">There are no existing bookings for this date.</p>
       {% endif %}
 
       <form action="/block-visit-dates/block-new-date" method="POST" novalidate>


### PR DESCRIPTION
Render page to block a new visit date (from selected date set in session).

To note:
* actually blocking the date will be in next PR
* date in session will be populated from previous page in journey - being worked on separately