### PR TITLE
VB-3741 Link block visits list page to add new block page

### DIFF
--- a/integration_tests/integration/blockDates.cy.ts
+++ b/integration_tests/integration/blockDates.cy.ts
@@ -21,7 +21,7 @@ context('Block dates', () => {
     cy.task('stubSetActiveCaseLoad', 'HEI')
     cy.task('stubGetNotificationCount', { prisonId: 'HEI' })
 
-    cy.task('stubGetFutureExcludeDates', { prisonId: 'HEI' })
+    cy.task('stubGetFutureBlockedDates', { prisonId: 'HEI' })
 
     const homePage = Page.verifyOnPage(HomePage)
 

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -476,7 +476,7 @@ export default {
       },
     })
   },
-  stubGetFutureExcludeDates: ({
+  stubGetFutureBlockedDates: ({
     prisonId,
     prisonExcludeDates = [TestData.prisonExcludeDateDto()],
   }: {

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -13,7 +13,7 @@ declare module 'express-session' {
     slotsList: VisitSlotList
     visitSessionData: VisitSessionData
     selectedEstablishment: Prison
-    visitBlockDate?: string
+    visitBlockDate?: string // format YYYY-MM-DD
   }
 }
 
@@ -31,6 +31,8 @@ export declare global {
 
       flash(type: 'errors'): ValidationError[]
       flash(type: 'errors', message: ValidationError[]): number
+      flash(type: 'formValues'): Record<string, string | string[] | number[]>[]
+      flash(type: 'formValues', message: Record<string, string | string[] | number[]>): number
     }
 
     interface Locals {

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -436,8 +436,8 @@ describe('orchestrationApiClient', () => {
     })
   })
 
-  describe('getFutureExcludeDates', () => {
-    it('should return future exclude dates for given prison', async () => {
+  describe('getFutureBlockedDates', () => {
+    it('should return future blocked dates for given prison', async () => {
       const results = [TestData.prisonExcludeDateDto()]
 
       fakeOrchestrationApi
@@ -445,7 +445,7 @@ describe('orchestrationApiClient', () => {
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, results)
 
-      const output = await orchestrationApiClient.getFutureExcludeDates(prisonId)
+      const output = await orchestrationApiClient.getFutureBlockedDates(prisonId)
 
       expect(output).toStrictEqual(results)
     })

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -193,7 +193,7 @@ export default class OrchestrationApiClient {
     })
   }
 
-  async getFutureExcludeDates(prisonId: string): Promise<PrisonExcludeDateDto[]> {
+  async getFutureBlockedDates(prisonId: string): Promise<PrisonExcludeDateDto[]> {
     return this.restClient.get({ path: `/config/prisons/prison/${prisonId}/exclude-date/future` })
   }
 

--- a/server/routes/blockVisitDates/blockVisitDatesController.test.ts
+++ b/server/routes/blockVisitDates/blockVisitDatesController.test.ts
@@ -9,14 +9,14 @@ import config from '../../config'
 let app: Express
 
 const blockedDatesService = createMockBlockedDatesService()
-const prisonExcludeDate = TestData.prisonExcludeDateDto()
+const prisonExcludeDateDto = TestData.prisonExcludeDateDto()
 const url = '/block-visit-dates'
 
 beforeEach(() => {
   config.features.sessionManagement = true
   app = appWithAllRoutes({ services: { blockedDatesService } })
 
-  blockedDatesService.getFutureExcludeDates.mockResolvedValue([prisonExcludeDate])
+  blockedDatesService.getFutureBlockedDates.mockResolvedValue([prisonExcludeDateDto])
 })
 
 afterEach(() => {

--- a/server/routes/blockVisitDates/blockVisitDatesController.test.ts
+++ b/server/routes/blockVisitDates/blockVisitDatesController.test.ts
@@ -1,22 +1,25 @@
 import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
-import { appWithAllRoutes } from '../testutils/appSetup'
+import { SessionData } from 'express-session'
+import { FieldValidationError } from 'express-validator'
+import { addDays, format, startOfYesterday, subDays } from 'date-fns'
+import { appWithAllRoutes, flashProvider } from '../testutils/appSetup'
 import { createMockBlockedDatesService } from '../../services/testutils/mocks'
 import TestData from '../testutils/testData'
 import config from '../../config'
+import { FlashData } from '../../@types/bapv'
 
 let app: Express
+let flashData: FlashData
+let sessionData: SessionData
 
 const blockedDatesService = createMockBlockedDatesService()
-const prisonExcludeDateDto = TestData.prisonExcludeDateDto()
 const url = '/block-visit-dates'
 
 beforeEach(() => {
-  config.features.sessionManagement = true
+  jest.replaceProperty(config, 'features', { sessionManagement: true })
   app = appWithAllRoutes({ services: { blockedDatesService } })
-
-  blockedDatesService.getFutureBlockedDates.mockResolvedValue([prisonExcludeDateDto])
 })
 
 afterEach(() => {
@@ -33,7 +36,20 @@ describe('Feature flag', () => {
 
 describe('Block visit dates listing page', () => {
   describe(`GET ${url}`, () => {
-    it('should display block visit dates page', () => {
+    beforeEach(() => {
+      flashData = {}
+      flashProvider.mockImplementation((key: keyof FlashData) => flashData[key])
+    })
+
+    it('should display block visit dates page with a blocked dates listed', () => {
+      const today = new Date()
+      const yesterday = subDays(today, 1)
+      const tomorrow = addDays(today, 1)
+      const blockedDate1 = TestData.prisonExcludeDateDto({ excludeDate: format(today, 'yyyy-MM-dd') })
+      const blockedDate2 = TestData.prisonExcludeDateDto({ excludeDate: format(tomorrow, 'yyyy-MM-dd') })
+
+      blockedDatesService.getFutureBlockedDates.mockResolvedValue([blockedDate1, blockedDate2])
+
       return request(app)
         .get(url)
         .expect('Content-Type', /html/)
@@ -41,9 +57,195 @@ describe('Block visit dates listing page', () => {
           const $ = cheerio.load(res.text)
           expect($('.govuk-back-link').attr('href')).toBe('/')
           expect($('h1').text()).toBe('Block visit dates')
-          expect($('[data-test="blocked-date-1"]').text()).toBe(`Thursday 12 December 2024`)
+
+          expect($('.moj-datepicker').attr('data-min-date')).toBe(format(yesterday, 'dd/MM/yyyy'))
+          expect($('.moj-datepicker').attr('data-excluded-dates')).toBe(
+            `${format(today, 'dd/MM/yyyy')} ${format(tomorrow, 'dd/MM/yyyy')}`,
+          )
+          expect($('input[name=date]').val()).toBeFalsy()
+
+          expect($('[data-test="blocked-date-1"]').text()).toBe(format(blockedDate1.excludeDate, 'EEEE d MMMM yyyy'))
           expect($('[data-test="blocked-by-1"]').text()).toBe(`User one`)
           expect($('[data-test="unblock-date-1"] a').attr('href')).toBe(`/unblock`)
+          expect($('[data-test="blocked-date-2"]').text()).toBe(format(blockedDate2.excludeDate, 'EEEE d MMMM yyyy'))
+          expect($('[data-test="blocked-by-2"]').text()).toBe(`User one`)
+          expect($('[data-test="unblock-date-2"] a').attr('href')).toBe(`/unblock`)
+
+          expect($('[data-test=no-blocked-dates]').length).toBe(0)
+        })
+    })
+
+    it('should display block visit dates page with no blocked dates listed', () => {
+      blockedDatesService.getFutureBlockedDates.mockResolvedValue([])
+
+      return request(app)
+        .get(url)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('.govuk-back-link').attr('href')).toBe('/')
+          expect($('h1').text()).toBe('Block visit dates')
+
+          expect($('[data-test=blocked-dates-table]').length).toBe(0)
+          expect($('[data-test=no-blocked-dates]').length).toBe(1)
+        })
+    })
+
+    it('should render validation errors and pre-populate with formValues', () => {
+      const validationError: FieldValidationError = {
+        type: 'field',
+        location: 'body',
+        path: 'date',
+        value: '2000-02-01',
+        msg: 'The date must be in the future',
+      }
+      const formValues = { date: '2000-02-01' }
+      flashData = { errors: [validationError], formValues: [formValues] }
+
+      blockedDatesService.getFutureBlockedDates.mockResolvedValue([])
+
+      return request(app)
+        .get(url)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('.govuk-back-link').attr('href')).toBe('/')
+          expect($('h1').text()).toBe('Block visit dates')
+
+          expect($('.govuk-error-summary a[href="#date-error"]').text()).toBe(validationError.msg)
+          expect($('#date-error').text()).toContain(validationError.msg)
+          expect($('input[name=date]').val()).toBe('1/2/2000')
+        })
+    })
+  })
+
+  describe(`POST ${url}`, () => {
+    const datePickerDateFormat = 'd/M/yyyy'
+    const expectedDateFormat = 'yyyy-MM-dd'
+    const today = new Date()
+
+    beforeEach(() => {
+      flashData = { errors: [], formValues: [] }
+
+      sessionData = {} as SessionData
+      blockedDatesService.getFutureBlockedDates.mockResolvedValue([])
+
+      app = appWithAllRoutes({ services: { blockedDatesService }, sessionData })
+    })
+
+    it('should set date to block in session and redirect to confirmation page for a valid date', () => {
+      const inputDate = format(today, datePickerDateFormat)
+      const expectedOutputDate = format(today, expectedDateFormat)
+
+      return request(app)
+        .post(url)
+        .send({ date: inputDate })
+        .expect(302)
+        .expect('location', '/block-visit-dates/block-new-date')
+        .expect(() => {
+          expect(blockedDatesService.getFutureBlockedDates).toHaveBeenCalledWith('HEI', 'user1')
+          expect(sessionData.visitBlockDate).toBe(expectedOutputDate)
+          expect(flashProvider).not.toHaveBeenCalled()
+        })
+    })
+
+    it('should set error and redirect back to listing page when no date entered', () => {
+      const expectedValidationError: FieldValidationError = {
+        location: 'body',
+        msg: 'Enter a valid date',
+        path: 'date',
+        type: 'field',
+        value: undefined,
+      }
+
+      return request(app)
+        .post(url)
+        .expect(302)
+        .expect('location', '/block-visit-dates')
+        .expect(() => {
+          expect(blockedDatesService.getFutureBlockedDates).not.toHaveBeenCalled()
+          expect(sessionData.visitBlockDate).toBe(undefined)
+          expect(flashProvider).toHaveBeenCalledWith('errors', [expectedValidationError])
+          expect(flashProvider).toHaveBeenCalledWith('formValues', { date: undefined })
+        })
+    })
+
+    it('should set error and redirect back to listing page when an invalid date entered', () => {
+      const inputDate = 'INVALID'
+
+      const expectedValidationError: FieldValidationError = {
+        location: 'body',
+        msg: 'Enter a valid date',
+        path: 'date',
+        type: 'field',
+        value: null,
+      }
+
+      return request(app)
+        .post(url)
+        .send({ date: inputDate })
+        .expect(302)
+        .expect('location', '/block-visit-dates')
+        .expect(() => {
+          expect(blockedDatesService.getFutureBlockedDates).not.toHaveBeenCalled()
+          expect(sessionData.visitBlockDate).toBe(undefined)
+          expect(flashProvider).toHaveBeenCalledWith('errors', [expectedValidationError])
+          expect(flashProvider).toHaveBeenCalledWith('formValues', { date: null })
+        })
+    })
+
+    it('should set error and redirect back to listing page when a date in the past is entered', () => {
+      const yesterday = startOfYesterday()
+      const inputDate = format(yesterday, datePickerDateFormat)
+      const expectedOutputDate = format(yesterday, expectedDateFormat)
+
+      const expectedValidationError: FieldValidationError = {
+        location: 'body',
+        msg: 'The date must be in the future',
+        path: 'date',
+        type: 'field',
+        value: expectedOutputDate,
+      }
+
+      return request(app)
+        .post(url)
+        .send({ date: inputDate })
+        .expect(302)
+        .expect('location', '/block-visit-dates')
+        .expect(() => {
+          expect(blockedDatesService.getFutureBlockedDates).not.toHaveBeenCalled()
+          expect(sessionData.visitBlockDate).toBe(undefined)
+          expect(flashProvider).toHaveBeenCalledWith('errors', [expectedValidationError])
+          expect(flashProvider).toHaveBeenCalledWith('formValues', { date: expectedOutputDate })
+        })
+    })
+
+    it('should set error and redirect back to listing page when an already-blocked date is entered', () => {
+      const inputDate = format(today, datePickerDateFormat)
+      const expectedOutputDate = format(today, expectedDateFormat)
+
+      blockedDatesService.getFutureBlockedDates.mockResolvedValue([
+        TestData.prisonExcludeDateDto({ excludeDate: expectedOutputDate }),
+      ])
+
+      const expectedValidationError: FieldValidationError = {
+        location: 'body',
+        msg: 'The date entered is already blocked',
+        path: 'date',
+        type: 'field',
+        value: expectedOutputDate,
+      }
+
+      return request(app)
+        .post(url)
+        .send({ date: inputDate })
+        .expect(302)
+        .expect('location', '/block-visit-dates')
+        .expect(() => {
+          expect(blockedDatesService.getFutureBlockedDates).toHaveBeenCalledWith('HEI', 'user1')
+          expect(sessionData.visitBlockDate).toBe(undefined)
+          expect(flashProvider).toHaveBeenCalledWith('errors', [expectedValidationError])
+          expect(flashProvider).toHaveBeenCalledWith('formValues', { date: expectedOutputDate })
         })
     })
   })

--- a/server/routes/blockVisitDates/blockVisitDatesController.ts
+++ b/server/routes/blockVisitDates/blockVisitDatesController.ts
@@ -6,7 +6,7 @@ export default class BlockVisitDatesController {
 
   public view(): RequestHandler {
     return async (req, res) => {
-      const blockedDates = await this.blockedDatesService.getFutureExcludeDates(
+      const blockedDates = await this.blockedDatesService.getFutureBlockedDates(
         req.session.selectedEstablishment.prisonId,
         res.locals.user.username,
       )

--- a/server/routes/blockVisitDates/blockVisitDatesController.ts
+++ b/server/routes/blockVisitDates/blockVisitDatesController.ts
@@ -1,4 +1,6 @@
 import { RequestHandler } from 'express'
+import { body, matchedData, Meta, ValidationChain, validationResult } from 'express-validator'
+import { format, startOfYesterday } from 'date-fns'
 import { BlockedDatesService } from '../../services'
 
 export default class BlockVisitDatesController {
@@ -11,10 +13,63 @@ export default class BlockVisitDatesController {
         res.locals.user.username,
       )
 
+      const datePickerMinDate = format(startOfYesterday(), 'dd/MM/yyyy')
+      const datePickerExcludedDates = blockedDates.map(date => format(date.excludeDate, 'dd/MM/yyyy')).join(' ')
+
       res.render('pages/blockVisitDates/blockVisitDates', {
+        errors: req.flash('errors'),
+        formValues: req.flash('formValues')?.[0],
         blockedDates,
+        datePickerMinDate,
+        datePickerExcludedDates,
         showEstablishmentSwitcher: true,
       })
     }
+  }
+
+  public submit(): RequestHandler {
+    return async (req, res) => {
+      const errors = validationResult(req)
+      if (!errors.isEmpty()) {
+        req.flash('errors', errors.array())
+        req.flash('formValues', matchedData(req, { onlyValidData: false }))
+        return res.redirect('/block-visit-dates')
+      }
+
+      const { date } = matchedData<{ date: string }>(req)
+      req.session.visitBlockDate = date
+
+      return res.redirect('/block-visit-dates/block-new-date')
+    }
+  }
+
+  public validate(): ValidationChain[] {
+    return [
+      body('date', 'Enter a valid date')
+        .notEmpty()
+        .bail()
+        // reformat raw input from day/month/year to year-month-day
+        .customSanitizer((date: string) => date.split('/').reverse().join('-'))
+        // convert to a Date
+        .toDate()
+        .isISO8601()
+        .bail()
+        // reformat to date string
+        .customSanitizer((date: Date) => format(date, 'yyyy-MM-dd'))
+        // date cannot be in past
+        .isAfter({ comparisonDate: format(startOfYesterday(), 'yyyy-MM-dd') })
+        .withMessage('The date must be in the future')
+        .bail()
+        // date cannot be an existing blocked date
+        .custom(async (date: string, { req }: Meta & { req: Express.Request }) => {
+          const blockedDates = await this.blockedDatesService.getFutureBlockedDates(
+            req.session.selectedEstablishment.prisonId,
+            req.user.username,
+          )
+          if (blockedDates.some(blockedDate => blockedDate.excludeDate === date)) {
+            throw new Error('The date entered is already blocked')
+          }
+        }),
+    ]
   }
 }

--- a/server/routes/blockVisitDates/index.ts
+++ b/server/routes/blockVisitDates/index.ts
@@ -23,6 +23,7 @@ export default function routes(services: Services): Router {
   }
 
   get('/', blockVisitDatesController.view())
+  postWithValidation('/', blockVisitDatesController.validate(), blockVisitDatesController.submit())
 
   get('/block-new-date', blockNewDateController.view())
   postWithValidation('/block-new-date', blockNewDateController.validate(), blockNewDateController.submit())

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -39,7 +39,6 @@ import type { Services } from '../../services'
 
 import UserService, { UserDetails } from '../../services/userService'
 import SupportedPrisonsService from '../../services/supportedPrisonsService'
-import { VisitorListItem, VisitSlotList, VisitSessionData } from '../../@types/bapv'
 import TestData from './testData'
 
 export const user: Express.User = {

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -18,7 +18,7 @@ jest.mock('../../applicationInfo', () => {
 
 import express, { Express } from 'express'
 import { NotFound } from 'http-errors'
-import { Cookie, SessionData } from 'express-session'
+import { Session, SessionData } from 'express-session'
 
 import indexRoutes from '../index'
 import bookAVisitRoutes from '../bookAVisit'
@@ -100,16 +100,7 @@ function appSetup(
   services: Services,
   production: boolean,
   userSupplier: () => Express.User,
-  sessionData: SessionData = {
-    cookie: new Cookie(),
-    returnTo: '',
-    nowInMinutes: 0,
-    visitorList: { visitors: [] as VisitorListItem[] },
-    adultVisitors: { adults: [] as VisitorListItem[] },
-    slotsList: {} as VisitSlotList,
-    visitSessionData: {} as VisitSessionData,
-    selectedEstablishment: undefined,
-  },
+  sessionData: SessionData,
 ): Express {
   const app = express()
 
@@ -122,16 +113,7 @@ function appSetup(
     res.locals = {
       user: { ...req.user },
     }
-    req.session = {
-      ...sessionData,
-      regenerate: jest.fn(),
-      destroy: jest.fn(),
-      reload: jest.fn(),
-      id: 'sessionId',
-      resetMaxAge: jest.fn(),
-      save: jest.fn(),
-      touch: jest.fn(),
-    }
+    req.session = sessionData as Session & Partial<SessionData>
     next()
   })
   app.use(express.json())
@@ -169,7 +151,7 @@ export function appWithAllRoutes({
   production = false,
   services = {},
   userSupplier = () => user,
-  sessionData,
+  sessionData = {} as SessionData,
 }: {
   production?: boolean
   services?: Partial<Services>

--- a/server/services/blockedDatesService.test.ts
+++ b/server/services/blockedDatesService.test.ts
@@ -36,14 +36,14 @@ describe('Blocked dates service', () => {
     })
   })
 
-  describe('getFutureExcludeDates', () => {
-    it('should return exclude dates count for given prison', async () => {
+  describe('getFutureBlockedDates', () => {
+    it('should return future blocked dates for given prison', async () => {
       const prisonExcludeDateDto = TestData.prisonExcludeDateDto()
-      orchestrationApiClient.getFutureExcludeDates.mockResolvedValue([prisonExcludeDateDto])
+      orchestrationApiClient.getFutureBlockedDates.mockResolvedValue([prisonExcludeDateDto])
 
-      const result = await blockedDatesService.getFutureExcludeDates(prisonId, username)
+      const result = await blockedDatesService.getFutureBlockedDates(prisonId, username)
 
-      expect(orchestrationApiClient.getFutureExcludeDates).toHaveBeenCalledWith(prisonId)
+      expect(orchestrationApiClient.getFutureBlockedDates).toHaveBeenCalledWith(prisonId)
       expect(result).toStrictEqual([prisonExcludeDateDto])
     })
   })

--- a/server/services/blockedDatesService.ts
+++ b/server/services/blockedDatesService.ts
@@ -13,9 +13,9 @@ export default class BlockedDatesService {
     await orchestrationApiClient.blockVisitDate(prisonId, date, username)
   }
 
-  async getFutureExcludeDates(prisonId: string, username: string): Promise<PrisonExcludeDateDto[]> {
+  async getFutureBlockedDates(prisonId: string, username: string): Promise<PrisonExcludeDateDto[]> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
-    return orchestrationApiClient.getFutureExcludeDates(prisonId)
+    return orchestrationApiClient.getFutureBlockedDates(prisonId)
   }
 }

--- a/server/views/pages/blockVisitDates/blockVisitDates.njk
+++ b/server/views/pages/blockVisitDates/blockVisitDates.njk
@@ -25,6 +25,7 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     {# TODO configure date picker for min start date #}
+    {# TODO configure date picker for excluded dates #}
     {{ mojDatePicker({
       id: "date",
       name: "date",

--- a/server/views/pages/blockVisitDates/blockVisitDates.njk
+++ b/server/views/pages/blockVisitDates/blockVisitDates.njk
@@ -4,12 +4,14 @@
 {%- from "govuk/components/button/macro.njk" import govukButton -%}
 
 {% set pageHeaderTitle = "Block visit dates" %}
-{% set pageTitle = applicationName + " - " + pageHeaderTitle %}
+  {% if errors | length %}Error: {% endif %}{{ applicationName }} - {{ pageHeaderTitle }}
 {% set backLinkHref = "/" %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+      {% include "partials/errorSummary.njk" %}
 
       <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
 
@@ -24,8 +26,6 @@
   <form action="/block-visit-dates" method="POST" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-    {# TODO configure date picker for min start date #}
-    {# TODO configure date picker for excluded dates #}
     {{ mojDatePicker({
       id: "date",
       name: "date",
@@ -36,8 +36,10 @@
       hint: {
         text: "For example, 31/3/2024"
       },
-      errorMessage: errors | findError('date'),
-      value: formValues.date
+      value: formValues.date | formatDate('d/M/yyyy'),
+      minDate: datePickerMinDate,
+      excludedDates: datePickerExcludedDates,
+      errorMessage: errors | findError('date')
     }) }}
 
     {{ govukButton({
@@ -68,22 +70,28 @@
         ]), displayRows) %}
       {% endfor %}
 
-      {{ govukTable({
-        caption: "Blocked dates",
-        captionClasses: "govuk-table__caption--m",
-        head: [
-          {
-            text: "Date"
-          },
-          {
-            text: "Blocked by"
-          },
-          {
-            text: "Action"
-          }
-        ],
-        rows: displayRows
-      }) }}
+      {% if blockedDates | length %}
+        {{ govukTable({
+          caption: "Blocked dates",
+          captionClasses: "govuk-table__caption--m",
+          head: [
+            {
+              text: "Date"
+            },
+            {
+              text: "Blocked by"
+            },
+            {
+              text: "Action"
+            }
+          ],
+          rows: displayRows,
+          attributes: { "data-test": "blocked-dates-table" }
+        }) }}
+      {% else %}
+        <h2 class="govuk-heading-m">Blocked dates</h2>
+        <p data-test="no-blocked-dates">There are no upcoming blocked dates for this prison.</p>
+      {% endif %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
* Improve listings page (extra options on date picker to hide already-blocked dates; handle no blocked dates)
* 'Wire-up' date picker to POST to the add new block date confirmation page
* Make naming more consistent

(TODO: coming next is the success message when a date is blocked and making the 'unblock' links work)