### PR TITLE
VB-4397 Respond with 503 on /info endpoint if error retrieving data

### DIFF
--- a/integration_tests/integration/health.cy.ts
+++ b/integration_tests/integration/health.cy.ts
@@ -14,7 +14,6 @@ context('Healthcheck', () => {
       cy.task('stubOrchestrationPing')
 
       cy.task('stubAuthToken')
-      cy.task('stubSupportedPrisonIds')
     })
 
     it('Health check page is visible', () => {
@@ -25,11 +24,9 @@ context('Healthcheck', () => {
       cy.request('/ping').its('body.status').should('equal', 'UP')
     })
 
-    it('Info is visible', () => {
-      cy.request('/info').its('body').should('exist')
-    })
+    it('Info is visible and should contain activeAgencies', () => {
+      cy.task('stubSupportedPrisonIds')
 
-    it('Info contains activeAgencies array', () => {
       cy.request('/info')
         .its('body.activeAgencies')
         .should('be.an', 'array')
@@ -38,6 +35,15 @@ context('Healthcheck', () => {
           cy.wrap(activeAgencies).its(0).should('equal', 'HEI')
           cy.wrap(activeAgencies).its(1).should('equal', 'BLI')
         })
+    })
+
+    it('Info returns 503 Service unavailable if there is an error getting activeAgencies', () => {
+      cy.task('stubSupportedPrisonIdsError')
+
+      cy.request({ url: '/info', method: 'GET', failOnStatusCode: false }).then(response => {
+        expect(response.status).to.equal(503)
+        expect(response.body).to.equal('')
+      })
     })
   })
 

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -586,6 +586,18 @@ export default {
       },
     })
   },
+  stubSupportedPrisonIdsError: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        url: '/orchestration/config/prisons/user-type/STAFF/supported',
+      },
+      response: {
+        status: 500,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      },
+    })
+  },
   stubGetPrison: (prison: PrisonDto = TestData.prisonDto()): SuperAgentRequest => {
     return stubFor({
       request: {

--- a/server/middleware/setUpHealthChecks.ts
+++ b/server/middleware/setUpHealthChecks.ts
@@ -3,7 +3,6 @@ import express, { Router } from 'express'
 import healthcheck from '../services/healthCheck'
 import type { ApplicationInfo } from '../applicationInfo'
 import { SupportedPrisonsService } from '../services'
-import logger from '../../logger'
 
 export default function setUpHealthChecks(
   applicationInfo: ApplicationInfo,
@@ -27,26 +26,24 @@ export default function setUpHealthChecks(
   )
 
   router.get('/info', async (req, res) => {
-    let activeAgencies: string[]
     try {
-      activeAgencies = await supportedPrisonsService.getActiveAgencies()
-    } catch (error) {
-      logger.error(error, 'Error retrieving activeAgencies')
-      activeAgencies = []
-    }
+      const activeAgencies = await supportedPrisonsService.getActiveAgencies()
 
-    res.json({
-      git: {
-        branch: applicationInfo.branchName,
-      },
-      build: {
-        artifact: applicationInfo.applicationName,
-        version: applicationInfo.buildNumber,
-        name: applicationInfo.applicationName,
-      },
-      productId: applicationInfo.productId,
-      activeAgencies,
-    })
+      res.json({
+        git: {
+          branch: applicationInfo.branchName,
+        },
+        build: {
+          artifact: applicationInfo.applicationName,
+          version: applicationInfo.buildNumber,
+          name: applicationInfo.applicationName,
+        },
+        productId: applicationInfo.productId,
+        activeAgencies,
+      })
+    } catch {
+      res.status(503).send()
+    }
   })
 
   return router


### PR DESCRIPTION
If there is an error calling the API to get the `activeAgencies` for the `/info` endpoint return an `HTTP 503` response instead of returning normally with `activeAgencies: []`.

Aim is to avoid causing calling services to this endpoint caching incorrect data about the service.