### PR TITLE
VB-3894: Handle unexpected notification group event types

### DIFF
--- a/server/services/visitNotificationsService.ts
+++ b/server/services/visitNotificationsService.ts
@@ -69,7 +69,9 @@ export default class VisitNotificationsService {
     notificationGroups.forEach(notificationGroup =>
       type.set(notificationGroup.type, notificationTypes[notificationGroup.type]),
     )
-    type.forEach((label, value) => typeFilterItems.push({ label, value, checked: appliedFilters.type.includes(value) }))
+    type.forEach((label, value) =>
+      typeFilterItems.push({ label: label ?? value, value, checked: appliedFilters.type.includes(value) }),
+    )
     typeFilterItems.sort((a, b) => a.label.localeCompare(b.label))
 
     return [

--- a/server/views/pages/review/visitsReviewListing.njk
+++ b/server/views/pages/review/visitsReviewListing.njk
@@ -65,7 +65,7 @@
             {
               attributes: { "data-test": "type-" + loop.index },
               html: govukTag({
-                text: notificationTypes[listItem.type],
+                text: notificationTypes[listItem.type] | default(listItem.type),
                 classes: 'notification-tag notification-tag--' + listItem.type | lower
               })
             },

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -84,7 +84,7 @@
           {% set visitNotificationBannerHtml %}
             {{ govukWarningText({
               classes: "govuk-!-margin-bottom-0 govuk-!-padding-left-4",
-              html: '<span data-test="visit-notification">' + notificationTypeWarnings[notification] + "</span>",
+              html: '<span data-test="visit-notification">' + (notificationTypeWarnings[notification] | default(notification)) + "</span>",
               iconFallbackText: "Warning"
             }) }}
           {% endset %}


### PR DESCRIPTION
Fixes a crash that could occur on the visits review listing page if a visit notification came through from the API with an unexpected type.

In this case now, the raw value of the type is rendered in the review listing and on the booking summary page.