### PR TITLE
VB-4400 Refactor for Prison / PrisonDto

### DIFF
--- a/integration_tests/integration/changeEstablishment.cy.ts
+++ b/integration_tests/integration/changeEstablishment.cy.ts
@@ -29,7 +29,7 @@ context('Change establishment', () => {
 
     const changeEstablishmentPage = Page.verifyOnPage(ChangeEstablishmentPage)
     changeEstablishmentPage.selectEstablishment('BLI')
-    cy.task('stubGetPrison', TestData.prisonDto({ code: 'BLI' }))
+    cy.task('stubGetPrison', TestData.prisonDto({ code: 'BLI', prisonName: 'Bristol (HMP & YOI)' }))
     changeEstablishmentPage.continueButton().click()
 
     homePage = Page.verifyOnPage(HomePage)

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -1,8 +1,8 @@
 import { OffenderRestriction } from '../data/prisonApiTypes'
-import { PrisonName } from '../data/prisonRegisterApiTypes'
 import {
   ApplicationMethodType,
   NotificationType,
+  PrisonDto,
   PrisonerProfile,
   Visit,
   VisitorSupport,
@@ -156,9 +156,8 @@ export type VisitsReviewListItem = {
   visitDates: string[]
 }
 
-export interface Prison extends PrisonName {
-  policyNoticeDaysMin: number
-  maxTotalVisitors: number
+export interface Prison extends Omit<PrisonDto, 'code'> {
+  prisonId: string
 }
 
 export type FilterField = { id: string; label: string; items: { label: string; value: string; checked: boolean }[] }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,4 +1,4 @@
-import { VisitorListItem, VisitSessionData, Prison } from '../bapv'
+import { Prison, VisitorListItem, VisitSessionData } from '../bapv'
 import { UserDetails } from '../../services/userService'
 
 export default {}

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -11,12 +11,13 @@ import {
   IgnoreVisitNotificationsDto,
   NotificationType,
   PageVisitDto,
+  PrisonDto,
   PrisonExcludeDateDto,
   SessionSchedule,
   Visit,
   VisitRestriction,
 } from './orchestrationApiTypes'
-import { VisitSessionData } from '../@types/bapv'
+import { Prison, VisitSessionData } from '../@types/bapv'
 
 describe('orchestrationApiClient', () => {
   let fakeOrchestrationApi: nock.Scope
@@ -616,17 +617,18 @@ describe('orchestrationApiClient', () => {
   })
 
   describe('getPrison', () => {
-    it('should return a PrisonDto object', async () => {
-      const results = TestData.prisonDto()
+    it('should return a Prison object (mapped from received PrisonDto)', async () => {
+      const receivedPrisonDto = { code: 'HEI', prisonName: 'Hewell (HMP)' } as PrisonDto
+      const expectedPrison = { prisonId: 'HEI', prisonName: 'Hewell (HMP)' } as Prison
 
       fakeOrchestrationApi
         .get(`/config/prisons/prison/${prisonId}`)
         .matchHeader('authorization', `Bearer ${token}`)
-        .reply(200, results)
+        .reply(200, receivedPrisonDto)
 
       const output = await orchestrationApiClient.getPrison(prisonId)
 
-      expect(output).toEqual(results)
+      expect(output).toStrictEqual(expectedPrison)
     })
   })
 })

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -24,7 +24,7 @@ import {
   VisitRestriction,
   VisitSession,
 } from './orchestrationApiTypes'
-import { VisitSessionData } from '../@types/bapv'
+import { Prison, VisitSessionData } from '../@types/bapv'
 
 export default class OrchestrationApiClient {
   private restClient: RestClient
@@ -271,10 +271,12 @@ export default class OrchestrationApiClient {
     })
   }
 
-  async getPrison(prisonId: string): Promise<PrisonDto> {
-    return this.restClient.get({
-      path: `/config/prisons/prison/${prisonId}`,
+  async getPrison(id: string): Promise<Prison> {
+    // rename 'code' to 'prisonId' for consistency
+    const { code: prisonId, ...prisonDto } = await this.restClient.get<PrisonDto>({
+      path: `/config/prisons/prison/${id}`,
     })
+    return { prisonId, ...prisonDto }
   }
 
   private convertMainContactToVisitContact(mainContact: VisitSessionData['mainContact']): {

--- a/server/middleware/populateSelectedEstablishment.test.ts
+++ b/server/middleware/populateSelectedEstablishment.test.ts
@@ -1,15 +1,11 @@
 import { Request, Response } from 'express'
-import { Cookie } from 'express-session'
 import TestData from '../routes/testutils/testData'
 import { createMockSupportedPrisonsService } from '../services/testutils/mocks'
 import populateSelectedEstablishment from './populateSelectedEstablishment'
-import { Prison } from '../@types/bapv'
 
 const supportedPrisonsService = createMockSupportedPrisonsService()
 
 const supportedPrisons = TestData.supportedPrisons()
-supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
-supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors: 6, policyNoticeDaysMin: 2 })
 
 let req: Request
 const res = {
@@ -20,48 +16,33 @@ const next = jest.fn()
 
 describe('populateSelectedEstablishment', () => {
   beforeEach(() => {
-    req = {
-      path: '/',
-      session: {
-        regenerate: jest.fn(),
-        destroy: jest.fn(),
-        reload: jest.fn(),
-        id: 'sessionId',
-        resetMaxAge: jest.fn(),
-        save: jest.fn(),
-        touch: jest.fn(),
-        cookie: new Cookie(),
-      },
-    } as unknown as Request
+    req = { session: {} } as unknown as Request
 
     res.locals = {
-      selectedEstablishment: <Prison>undefined,
+      selectedEstablishment: undefined,
       user: <Express.User>{ activeCaseLoadId: 'HEI', username: 'user1' },
     }
+
+    supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
   })
 
   afterEach(() => {
-    jest.clearAllMocks()
+    jest.resetAllMocks()
   })
 
   describe('when establishment not already set in session', () => {
     it('should set establishment in session and populate res.locals if active caseload is a supported prison', async () => {
       res.locals.user.activeCaseLoadId = 'BLI'
-
-      const expectedEstablishment: Prison = {
-        prisonId: 'BLI',
-        prisonName: supportedPrisons.BLI,
-        maxTotalVisitors: 6,
-        policyNoticeDaysMin: 2,
-      }
+      const prison = TestData.prison({ prisonId: 'BLI', prisonName: 'Bristol (HMP)' })
+      supportedPrisonsService.getPrison.mockResolvedValue(prison)
 
       await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
       await new Promise(process.nextTick)
 
       expect(supportedPrisonsService.getSupportedPrisons).toHaveBeenCalledWith('user1')
-      expect(supportedPrisonsService.getPrisonConfig).toHaveBeenCalledWith('user1', 'BLI')
-      expect(req.session.selectedEstablishment).toStrictEqual(expectedEstablishment)
-      expect(res.locals.selectedEstablishment).toStrictEqual(expectedEstablishment)
+      expect(supportedPrisonsService.getPrison).toHaveBeenCalledWith('user1', 'BLI')
+      expect(req.session.selectedEstablishment).toStrictEqual(prison)
+      expect(res.locals.selectedEstablishment).toStrictEqual(prison)
       expect(next).toHaveBeenCalled()
     })
 
@@ -104,12 +85,7 @@ describe('populateSelectedEstablishment', () => {
 
   describe('when establishment already set in session', () => {
     it('should populate res.locals with selected establishment without prisons lookup', async () => {
-      req.session.selectedEstablishment = {
-        prisonId: 'HEI',
-        prisonName: supportedPrisons.HEI,
-        maxTotalVisitors: 6,
-        policyNoticeDaysMin: 2,
-      }
+      req.session.selectedEstablishment = TestData.prison()
 
       await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
 
@@ -120,12 +96,7 @@ describe('populateSelectedEstablishment', () => {
 
     it('should populate res.locals with already selected establishment without prisons lookup if active caseload changes', async () => {
       res.locals.user.activeCaseLoadId = 'BLI'
-      req.session.selectedEstablishment = {
-        prisonId: 'HEI',
-        prisonName: supportedPrisons.HEI,
-        maxTotalVisitors: 6,
-        policyNoticeDaysMin: 2,
-      }
+      req.session.selectedEstablishment = TestData.prison({ prisonId: 'BLI', prisonName: 'Bristol (HMP)' })
 
       await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
 
@@ -137,12 +108,7 @@ describe('populateSelectedEstablishment', () => {
     it('should make no changes and not redirect if request path is /change-establishment', async () => {
       ;(req.path as string) = '/change-establishment'
       res.locals.user.activeCaseLoadId = 'BLI'
-      req.session.selectedEstablishment = {
-        prisonId: 'HEI',
-        prisonName: supportedPrisons.HEI,
-        maxTotalVisitors: 6,
-        policyNoticeDaysMin: 2,
-      }
+      req.session.selectedEstablishment = TestData.prison()
 
       await populateSelectedEstablishment(supportedPrisonsService)(req, res, next)
 

--- a/server/middleware/populateSelectedEstablishment.ts
+++ b/server/middleware/populateSelectedEstablishment.ts
@@ -15,17 +15,9 @@ export default function populateSelectedEstablishment(
         return res.redirect('/change-establishment')
       }
 
-      const { maxTotalVisitors, policyNoticeDaysMin } = await supportedPrisonsService.getPrisonConfig(
-        res.locals.user.username,
-        activeCaseLoadId,
-      )
+      const prison = await supportedPrisonsService.getPrison(res.locals.user.username, activeCaseLoadId)
 
-      req.session.selectedEstablishment = {
-        prisonId: activeCaseLoadId,
-        prisonName: supportedPrisons[activeCaseLoadId],
-        maxTotalVisitors,
-        policyNoticeDaysMin,
-      }
+      req.session.selectedEstablishment = prison
     }
     res.locals.selectedEstablishment = req.session.selectedEstablishment
 

--- a/server/middleware/sessionCheckMiddleware.test.ts
+++ b/server/middleware/sessionCheckMiddleware.test.ts
@@ -62,12 +62,7 @@ describe('sessionCheckMiddleware', () => {
         save: jest.fn(),
         touch: jest.fn(),
         cookie: new Cookie(),
-        selectedEstablishment: {
-          prisonId,
-          prisonName: supportedPrisons[prisonId],
-          maxTotalVisitors: 6,
-          policyNoticeDaysMin: 2,
-        },
+        selectedEstablishment: TestData.prison(),
       },
     }
     mockResponse = {
@@ -82,12 +77,10 @@ describe('sessionCheckMiddleware', () => {
   })
 
   it('should redirect to the start page if prisonId in originalVisitSlot (set for update journey) does not match selected establishment', () => {
-    req.session.selectedEstablishment = {
+    req.session.selectedEstablishment = TestData.prison({
       prisonId: 'BLI',
       prisonName: supportedPrisons.BLI,
-      maxTotalVisitors: 6,
-      policyNoticeDaysMin: 2,
-    }
+    })
     req.session.visitSessionData = { originalVisitSlot: visitSlot } as VisitSessionData
 
     sessionCheckMiddleware({ stage: 1 })(req as Request, mockResponse as Response, next)
@@ -252,12 +245,10 @@ describe('sessionCheckMiddleware', () => {
     })
 
     it('should redirect to the start page if prisonId in visitSlot does not match selected establishment', () => {
-      req.session.selectedEstablishment = {
+      req.session.selectedEstablishment = TestData.prison({
         prisonId: 'BLI',
         prisonName: supportedPrisons.BLI,
-        maxTotalVisitors: 6,
-        policyNoticeDaysMin: 2,
-      }
+      })
       req.session.visitSessionData = {
         applicationReference: 'aaa-bbb-ccc',
         prisoner: prisonerData,

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -39,6 +39,7 @@ import type { Services } from '../../services'
 import UserService, { UserDetails } from '../../services/userService'
 import SupportedPrisonsService from '../../services/supportedPrisonsService'
 import TestData from './testData'
+import { Prison } from '../../@types/bapv'
 
 export const user: Express.User = {
   name: 'FIRST LAST',
@@ -86,11 +87,8 @@ class MockSupportedPrisonsService extends SupportedPrisonsService {
     return TestData.supportedPrisons()
   }
 
-  async getPrisonConfig(
-    _username: string,
-    _prisonCode: string,
-  ): Promise<{ maxTotalVisitors: number; policyNoticeDaysMin: number }> {
-    return { maxTotalVisitors: 6, policyNoticeDaysMin: 2 }
+  async getPrison(_username: string, _prisonCode: string): Promise<Prison> {
+    return TestData.prison()
   }
 }
 

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -20,6 +20,7 @@ import { CurrentIncentive, Prisoner } from '../../data/prisonerOffenderSearchTyp
 import { Address, Contact, Restriction } from '../../data/prisonerContactRegistryApiTypes'
 import { ScheduledEvent } from '../../data/whereaboutsApiTypes'
 import { PrisonName } from '../../data/prisonRegisterApiTypes'
+import { Prison } from '../../@types/bapv'
 
 export default class TestData {
   static address = ({
@@ -369,6 +370,29 @@ export default class TestData {
   } = {}): Record<string, string> => prisons
 
   static supportedPrisonIds = ({ prisonIds = ['HEI', 'BLI'] } = {}): string[] => prisonIds
+
+  static prison = ({
+    prisonId = 'HEI',
+    prisonName = 'Hewell (HMP)',
+    active = true,
+    policyNoticeDaysMax = 28,
+    policyNoticeDaysMin = 2,
+    maxTotalVisitors = 6,
+    maxAdultVisitors = 3,
+    maxChildVisitors = 3,
+    adultAgeYears = 18,
+  }: Partial<Prison> = {}): Prison =>
+    ({
+      prisonId,
+      prisonName,
+      active,
+      policyNoticeDaysMax,
+      policyNoticeDaysMin,
+      maxTotalVisitors,
+      maxAdultVisitors,
+      maxChildVisitors,
+      adultAgeYears,
+    }) as Prison
 
   static prisonDto = ({
     code = 'HEI',

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -37,6 +37,7 @@ const visitSessionsService = createMockVisitSessionsService()
 
 let visitSessionData: VisitSessionData
 
+const prison = TestData.prison()
 const supportedPrisons = TestData.supportedPrisons()
 const supportedPrisonIds = TestData.supportedPrisonIds()
 
@@ -125,7 +126,7 @@ describe('/visit/:reference', () => {
     prisonerVisitorsService.getVisitors.mockResolvedValue(visitors)
     supportedPrisonsService.getSupportedPrisonIds.mockResolvedValue(supportedPrisonIds)
     supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
-    supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors: 6, policyNoticeDaysMin: 2 })
+    supportedPrisonsService.getPrison.mockResolvedValue(prison)
 
     visitSessionData = { prisoner: undefined }
 
@@ -363,7 +364,7 @@ describe('/visit/:reference', () => {
       app = appWithAllRoutes({
         services: { auditService, supportedPrisonsService, visitService, visitSessionsService },
         sessionData: {
-          selectedEstablishment: { prisonId: 'BLI', prisonName: supportedPrisons.BLI, policyNoticeDaysMin: 2 },
+          selectedEstablishment: TestData.prison({ prisonId: 'BLI', prisonName: supportedPrisons.BLI }),
         } as SessionData,
       })
 
@@ -708,7 +709,7 @@ describe('/visit/:reference', () => {
       app = appWithAllRoutes({
         services: { auditService, supportedPrisonsService, visitService, visitSessionsService },
         sessionData: {
-          selectedEstablishment: { prisonId: 'BLI', prisonName: supportedPrisons.BLI, policyNoticeDaysMin: 2 },
+          selectedEstablishment: TestData.prison({ prisonId: 'BLI', prisonName: supportedPrisons.BLI }),
         } as SessionData,
       })
 
@@ -727,7 +728,7 @@ describe('/visit/:reference', () => {
           visitSessionsService,
         },
         sessionData: {
-          selectedEstablishment: { prisonId: 'HEI', prisonName: supportedPrisons.HEI, policyNoticeDaysMin: 14 },
+          selectedEstablishment: { ...prison, policyNoticeDaysMin: 14 },
         } as SessionData,
       })
 
@@ -760,7 +761,7 @@ describe('/visit/:reference', () => {
           visitSessionsService,
         },
         sessionData: {
-          selectedEstablishment: { prisonId: 'HEI', prisonName: supportedPrisons.HEI, policyNoticeDaysMin: 4 },
+          selectedEstablishment: { ...prison, policyNoticeDaysMin: 4 },
         } as SessionData,
       })
 
@@ -1027,7 +1028,7 @@ describe('POST /visit/:reference/cancel', () => {
 
     visitService.cancelVisit = jest.fn().mockResolvedValue(cancelledVisit)
     supportedPrisonsService.getSupportedPrisons.mockResolvedValue(supportedPrisons)
-    supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors: 6, policyNoticeDaysMin: 2 })
+    supportedPrisonsService.getPrison.mockResolvedValue(prison)
 
     app = appWithAllRoutes({
       services: {

--- a/server/routes/visitJourney/selectVisitors.test.ts
+++ b/server/routes/visitJourney/selectVisitors.test.ts
@@ -987,7 +987,7 @@ testJourneys.forEach(journey => {
         const visitors = ['4322', '4323']
 
         supportedPrisonsService.getSupportedPrisons.mockResolvedValue(TestData.supportedPrisons())
-        supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors, policyNoticeDaysMin: 2 })
+        supportedPrisonsService.getPrison.mockResolvedValue(TestData.prison({ maxTotalVisitors }))
 
         sessionApp = appWithAllRoutes({
           services: { prisonerProfileService, prisonerVisitorsService, supportedPrisonsService },
@@ -1013,7 +1013,7 @@ testJourneys.forEach(journey => {
         const visitors = ['4322', '4323', '4324']
 
         supportedPrisonsService.getSupportedPrisons.mockResolvedValue(TestData.supportedPrisons())
-        supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors, policyNoticeDaysMin: 2 })
+        supportedPrisonsService.getPrison.mockResolvedValue(TestData.prison({ maxTotalVisitors }))
 
         sessionApp = appWithAllRoutes({
           services: { prisonerProfileService, prisonerVisitorsService, supportedPrisonsService },

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -2,6 +2,7 @@ import { Request } from 'express'
 import { Session, SessionData } from 'express-session'
 import { VisitSlot, VisitSlotList } from '../@types/bapv'
 import { clearSession, getFlashFormValues, getSelectedSlot, getSlotByTimeAndRestriction } from './visitorUtils'
+import TestData from './testutils/testData'
 
 const prisonId = 'HEI'
 
@@ -182,7 +183,7 @@ describe('clearSession', () => {
     adultVisitors: { adults: [] },
     slotsList: {},
     visitSessionData: { prisoner: undefined },
-    selectedEstablishment: { prisonId: 'HEI', prisonName: 'Hewell (HMP)', maxTotalVisitors: 6, policyNoticeDaysMin: 2 },
+    selectedEstablishment: TestData.prison(),
   }
 
   req.session = sessionData as Session & SessionData
@@ -194,12 +195,7 @@ describe('clearSession', () => {
       returnTo: '/url',
       nowInMinutes: 123456,
       cookie: undefined,
-      selectedEstablishment: {
-        prisonId: 'HEI',
-        prisonName: 'Hewell (HMP)',
-        maxTotalVisitors: 6,
-        policyNoticeDaysMin: 2,
-      },
+      selectedEstablishment: TestData.prison(),
     })
   })
 })

--- a/server/routes/visits.test.ts
+++ b/server/routes/visits.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
   })
 
   supportedPrisonsService.getSupportedPrisons.mockResolvedValue(TestData.supportedPrisons())
-  supportedPrisonsService.getPrisonConfig.mockResolvedValue({ maxTotalVisitors: 6, policyNoticeDaysMin: 2 })
+  supportedPrisonsService.getPrison.mockResolvedValue(TestData.prison())
   blockedDatesService.isBlockedDate.mockResolvedValue(false)
   visitNotificationsService.dateHasNotifications.mockResolvedValue(false)
 

--- a/server/services/supportedPrisonsService.test.ts
+++ b/server/services/supportedPrisonsService.test.ts
@@ -21,7 +21,6 @@ describe('Supported prisons service', () => {
   const prisonNames = TestData.prisonNames()
   const supportedPrisons = TestData.supportedPrisons()
   const supportedPrisonIds = TestData.supportedPrisonIds()
-  const prisonDto = TestData.prisonDto()
 
   beforeEach(() => {
     OrchestrationApiClientFactory.mockReturnValue(orchestrationApiClient)
@@ -70,17 +69,16 @@ describe('Supported prisons service', () => {
     })
   })
 
-  describe('getPrisonConfig', () => {
-    it('should return some prison config values (maxTotalVisitors, policyNoticeDaysMin) when called with a prison ID', async () => {
-      orchestrationApiClient.getPrison.mockResolvedValue(prisonDto)
+  describe('getPrison', () => {
+    const prison = TestData.prison()
 
-      const results = await supportedPrisonsService.getPrisonConfig('user', 'HEI')
+    it('should return a Prison for given prison ID', async () => {
+      orchestrationApiClient.getPrison.mockResolvedValue(prison)
+
+      const results = await supportedPrisonsService.getPrison('user', 'HEI')
 
       expect(orchestrationApiClient.getPrison).toHaveBeenCalledWith('HEI')
-      expect(results).toStrictEqual({
-        maxTotalVisitors: prisonDto.maxTotalVisitors,
-        policyNoticeDaysMin: prisonDto.policyNoticeDaysMin,
-      })
+      expect(results).toStrictEqual(prison)
     })
   })
 

--- a/server/services/supportedPrisonsService.ts
+++ b/server/services/supportedPrisonsService.ts
@@ -1,3 +1,4 @@
+import { Prison } from '../@types/bapv'
 import { HmppsAuthClient, OrchestrationApiClient, PrisonRegisterApiClient, RestClientBuilder } from '../data'
 import { PrisonName } from '../data/prisonRegisterApiTypes'
 
@@ -40,14 +41,10 @@ export default class SupportedPrisonsService {
     return orchestrationApiClient.getSupportedPrisonIds()
   }
 
-  async getPrisonConfig(
-    username: string,
-    prisonCode: string,
-  ): Promise<{ maxTotalVisitors: number; policyNoticeDaysMin: number }> {
+  async getPrison(username: string, prisonId: string): Promise<Prison> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
-    const { policyNoticeDaysMin, maxTotalVisitors } = await orchestrationApiClient.getPrison(prisonCode)
-    return { maxTotalVisitors, policyNoticeDaysMin }
+    return orchestrationApiClient.getPrison(prisonId)
   }
 
   private async refreshPrisonNames(username: string): Promise<void> {


### PR DESCRIPTION
Refactor `getPrisonConfig()` in `SupportedPrisonsService` to be `getPrison()` so all prison config values are available.

Define new `Prison` type to use instead of `PrisonDto` in order to have `prisonId` rather than `code` for consistency.