### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>ministryofjustice/hmpps-renovate-config:node"],
   "prBodyTemplate": "{{{table}}}{{{notes}}}{{{warnings}}}{{{controls}}}",
-  "prCreation": "immediate",
+  "dependencyDashboard": true,
+  "schedule": ["every weekend"],
   "packageRules": [
     {
       "matchManagers": ["npm"],
@@ -13,7 +14,7 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non major NPM dependencies",
       "groupSlug": "all-npm-minor-patch",
-      "stabilityDays": 5
+      "minimumReleaseAge": "3 days"
     },
     {
       "matchDepTypes": ["engines"],
@@ -22,7 +23,7 @@
     {
       "matchPackageNames": ["typescript", "govuk-frontend"],
       "rangeStrategy": "bump",
-      "stabilityDays": 0
+      "minimumReleaseAge": null
     },
     {
       "matchManagers": ["npm"],
@@ -38,6 +39,6 @@
     }
   ],
   "vulnerabilityAlerts": {
-    "stabilityDays": 0
+    "minimumReleaseAge": null
   }
 }


### PR DESCRIPTION
* Remove `immediate` PR creation and schedule to run at weekends (for vulnerabilities this *should* be overridden - https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts)
* Enable dependency dashboard
* Updated config file (with suggestions from validator `npx --yes --package renovate -- renovate-config-validator`)