### PR TITLE
Overbooking feature - update journey - display at end of journey

### DIFF
--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -5,7 +5,7 @@ import AuditService from '../../services/auditService'
 import { getFlashFormValues, getSelectedSlot, getSlotByTimeAndRestriction } from '../visitorUtils'
 import getUrlPrefix from './visitJourneyUtils'
 import { VisitService, VisitSessionsService } from '../../services'
-import { isOriginalVisitSlot } from '../../utils/utils'
+import { isSameVisitSlot } from '../../utils/utils'
 
 export default class DateAndTime {
   constructor(
@@ -135,7 +135,7 @@ export default class DateAndTime {
     visitSessionData.visitSlot = getSelectedSlot(req.session.slotsList, req.body['visit-date-and-time'])
 
     const isOriginalSlot = isUpdate
-      ? isOriginalVisitSlot(visitSessionData.visitSlot, visitSessionData.originalVisitSlot)
+      ? isSameVisitSlot(visitSessionData.visitSlot, visitSessionData.originalVisitSlot)
       : false
 
     // If 'available tables is less than or equal to zero

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -5,6 +5,7 @@ import AuditService from '../../services/auditService'
 import { getFlashFormValues, getSelectedSlot, getSlotByTimeAndRestriction } from '../visitorUtils'
 import getUrlPrefix from './visitJourneyUtils'
 import { VisitService, VisitSessionsService } from '../../services'
+import { isOriginalVisitSlot } from '../../utils/utils'
 
 export default class DateAndTime {
   constructor(
@@ -133,10 +134,17 @@ export default class DateAndTime {
 
     visitSessionData.visitSlot = getSelectedSlot(req.session.slotsList, req.body['visit-date-and-time'])
 
+    const isOriginalSlot = isUpdate
+      ? isOriginalVisitSlot(visitSessionData.visitSlot, visitSessionData.originalVisitSlot)
+      : false
+
     // If 'available tables is less than or equal to zero
-    // Then no capacity was originally displayed, so show overbooking page
     if (visitSessionData.visitSlot.availableTables <= 0) {
-      return res.redirect(`${urlPrefix}/select-date-and-time/overbooking`)
+      // If on update journey, and not the original slot OR is not update journey
+      if ((isUpdate && !isOriginalSlot) || !isUpdate) {
+        // show overbooking page
+        return res.redirect(`${urlPrefix}/select-date-and-time/overbooking`)
+      }
     }
 
     await this.reserveOrChangeApplication(req, res)

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -9,8 +9,10 @@ import {
   safeReturnUrl,
   getParsedDateFromQueryString,
   getWeekOfDatesStartingMonday,
+  isOriginalVisitSlot,
 } from './utils'
 import getResultsPagingLinksTestData from './utils.testData'
+import TestData from '../routes/testutils/testData'
 
 describe('Convert to title case', () => {
   it('null string', () => {
@@ -168,6 +170,75 @@ describe('getWeekOfDatesStartingMonday', () => {
       weekOfDates: [],
       previousWeek: '',
       nextWeek: '',
+    })
+  })
+})
+
+describe('isOriginalVisitSlot', () => {
+  ;[
+    {
+      // Matches
+      sessionSlot: {
+        sessionTemplateReference: 'ab-cd-ef-gh',
+        startTimestamp: '2020-01-01T10:00:00',
+      },
+      originalVisitSlot: {
+        sessionTemplateReference: 'ab-cd-ef-gh',
+        startTimestamp: '2020-01-01T10:00:00',
+      },
+      expected: true,
+    },
+    {
+      // Incorrect sessionTemplateReference
+      sessionSlot: {
+        sessionTemplateReference: 'gh-ef-cd-ab',
+        startTimestamp: '2020-01-01T10:00:00',
+      },
+      originalVisitSlot: {
+        sessionTemplateReference: 'ab-cd-ef-gh',
+        startTimestamp: '2020-01-01T10:00:00',
+      },
+      expected: false,
+    },
+    {
+      // Incorrect startTimestamp(time)
+      sessionSlot: {
+        sessionTemplateReference: 'ab-cd-ef-gh',
+        startTimestamp: '2020-01-01T14:00:00',
+      },
+      originalVisitSlot: {
+        sessionTemplateReference: 'ab-cd-ef-gh',
+        startTimestamp: '2020-01-01T10:00:00',
+      },
+      expected: false,
+    },
+    {
+      // Incorrect startTimestamp(date)
+      sessionSlot: {
+        sessionTemplateReference: 'ab-cd-ef-gh',
+        startTimestamp: '2021-01-01T10:00:00',
+      },
+      originalVisitSlot: {
+        sessionTemplateReference: 'ab-cd-ef-gh',
+        startTimestamp: '2020-01-01T10:00:00',
+      },
+      expected: false,
+    },
+    {
+      // Incorrect sessionTemplateReference and startTimestamp
+      sessionSlot: {
+        sessionTemplateReference: 'gh-ef-cd-ab',
+        startTimestamp: '2021-01-01T10:00:00',
+      },
+      originalVisitSlot: {
+        sessionTemplateReference: 'ab-cd-ef-gh',
+        startTimestamp: '2020-01-01T10:00:00',
+      },
+      expected: false,
+    },
+  ].forEach(testData => {
+    it(`should output ${testData.expected} when supplied with ${testData.sessionSlot.sessionTemplateReference} ${testData.sessionSlot.startTimestamp} and ${testData.originalVisitSlot.sessionTemplateReference} ${testData.originalVisitSlot.startTimestamp}`, () => {
+      expect(isOriginalVisitSlot(testData.sessionSlot, testData.originalVisitSlot)).toBe(testData.expected)
     })
   })
 })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -9,9 +9,10 @@ import {
   safeReturnUrl,
   getParsedDateFromQueryString,
   getWeekOfDatesStartingMonday,
-  isOriginalVisitSlot,
+  isSameVisitSlot,
 } from './utils'
 import getResultsPagingLinksTestData from './utils.testData'
+import { VisitSlot } from '../@types/bapv'
 
 describe('Convert to title case', () => {
   it('null string', () => {
@@ -173,7 +174,7 @@ describe('getWeekOfDatesStartingMonday', () => {
   })
 })
 
-describe('isOriginalVisitSlot', () => {
+describe('isSameVisitSlot', () => {
   ;[
     {
       // Matches
@@ -237,7 +238,9 @@ describe('isOriginalVisitSlot', () => {
     },
   ].forEach(testData => {
     it(`should output ${testData.expected} when supplied with ${testData.sessionSlot.sessionTemplateReference} ${testData.sessionSlot.startTimestamp} and ${testData.originalVisitSlot.sessionTemplateReference} ${testData.originalVisitSlot.startTimestamp}`, () => {
-      expect(isOriginalVisitSlot(testData.sessionSlot, testData.originalVisitSlot)).toBe(testData.expected)
+      expect(isSameVisitSlot(testData.sessionSlot as VisitSlot, testData.originalVisitSlot as VisitSlot)).toBe(
+        testData.expected,
+      )
     })
   })
 })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -12,7 +12,6 @@ import {
   isOriginalVisitSlot,
 } from './utils'
 import getResultsPagingLinksTestData from './utils.testData'
-import TestData from '../routes/testutils/testData'
 
 describe('Convert to title case', () => {
   it('null string', () => {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -10,7 +10,7 @@ import {
   addWeeks,
   subWeeks,
 } from 'date-fns'
-import { VisitSessionData, VisitSlot } from '../@types/bapv'
+import { VisitSlot } from '../@types/bapv'
 
 export const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -10,6 +10,7 @@ import {
   addWeeks,
   subWeeks,
 } from 'date-fns'
+import { VisitSessionData, VisitSlot } from '../@types/bapv'
 
 export const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
@@ -156,4 +157,12 @@ export const getWeekOfDatesStartingMonday = (
   const nextWeek = format(addWeeks(weekStartDate, 1), dateFormat)
 
   return { weekOfDates, previousWeek, nextWeek }
+}
+
+export const isOriginalVisitSlot = (visitSlot: Partial<VisitSlot>, originalVisitSlot: Partial<VisitSlot>): boolean => {
+  const isMatchingTemplateReference = visitSlot.sessionTemplateReference === originalVisitSlot.sessionTemplateReference
+
+  const isMatchingStartTimestamp = visitSlot.startTimestamp === originalVisitSlot.startTimestamp
+
+  return isMatchingTemplateReference && isMatchingStartTimestamp
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -159,7 +159,7 @@ export const getWeekOfDatesStartingMonday = (
   return { weekOfDates, previousWeek, nextWeek }
 }
 
-export const isOriginalVisitSlot = (visitSlot: Partial<VisitSlot>, originalVisitSlot: Partial<VisitSlot>): boolean => {
+export const isSameVisitSlot = (visitSlot: VisitSlot, originalVisitSlot: VisitSlot): boolean => {
   const isMatchingTemplateReference = visitSlot.sessionTemplateReference === originalVisitSlot.sessionTemplateReference
 
   const isMatchingStartTimestamp = visitSlot.startTimestamp === originalVisitSlot.startTimestamp


### PR DESCRIPTION
Only display during update journey at end of journey

Fixes raised bug, where a fully booked (not overbooked) session would flag the 'overbooking' page after date and time 