### PR TITLE
VB-4787, deal with booker lead visit cancellation

### DIFF
--- a/integration_tests/e2e/cancelVisit.cy.ts
+++ b/integration_tests/e2e/cancelVisit.cy.ts
@@ -48,6 +48,7 @@ context('Cancel visit journey', () => {
       },
       applicationMethodType: 'NOT_APPLICABLE',
       actionedBy: 'USER1',
+      userType: 'STAFF',
     }
 
     cy.visit('/visit/ab-cd-ef-gh')
@@ -78,6 +79,7 @@ context('Cancel visit journey', () => {
       },
       applicationMethodType: 'WEBSITE',
       actionedBy: 'USER1',
+      userType: 'STAFF',
     }
 
     cy.visit('/visit/ab-cd-ef-gh')

--- a/integration_tests/e2e/visitDetails.cy.ts
+++ b/integration_tests/e2e/visitDetails.cy.ts
@@ -50,7 +50,7 @@ context('Visit details page', () => {
 
     visitDetailsPage.visitReference().contains('ab-cd-ef-gh')
 
-    visitDetailsPage.cancellationType().contains('This visit was cancelled by the visitor.')
+    visitDetailsPage.cancellationType().contains('This visit was cancelled by a visitor.')
 
     visitDetailsPage.updateBooking().should('have.length', 0)
     visitDetailsPage.cancelBooking().should('have.length', 0)

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -74,6 +74,7 @@ export default {
               },
               applicationMethodType: cancelVisitDto.applicationMethodType,
               actionedBy: cancelVisitDto.actionedBy,
+              userType: cancelVisitDto.userType,
             },
             ignoreArrayOrder: true,
           },

--- a/integration_tests/pages/visitCancelled.ts
+++ b/integration_tests/pages/visitCancelled.ts
@@ -7,5 +7,5 @@ export default class VisitCancelledPage extends Page {
 
   visitDetails = (): PageElement => cy.get('[data-test="visit-details"]')
 
-  homeButton = (): PageElement => cy.get('[data-test="go-to-start"]')
+  homeButton = (): PageElement => cy.get('[data-test="go-to-home"]')
 }

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -770,6 +770,12 @@ export interface components {
         | 'BY_PRISONER'
       /** @description Username for user who actioned this request */
       actionedBy: string
+      /**
+       * @description User type
+       * @example STAFF
+       * @enum {string}
+       */
+      userType: 'STAFF' | 'PUBLIC' | 'SYSTEM'
     }
     /**
      * @description Contact Phone Number
@@ -1329,10 +1335,10 @@ export interface components {
       sort?: components['schemas']['SortObject'][]
       /** Format: int32 */
       pageSize?: number
+      unpaged?: boolean
       paged?: boolean
       /** Format: int32 */
       pageNumber?: number
-      unpaged?: boolean
     }
     SortObject: {
       direction?: string

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -802,6 +802,7 @@ export interface components {
         | 'VISIT_ORDER_CANCELLED'
         | 'SUPERSEDED_CANCELLATION'
         | 'DETAILS_CHANGED_AFTER_BOOKING'
+        | 'BOOKER_CANCELLED'
       /**
        * @description Outcome text
        * @example Because he got covid
@@ -904,6 +905,7 @@ export interface components {
         | 'VISIT_ORDER_CANCELLED'
         | 'SUPERSEDED_CANCELLATION'
         | 'DETAILS_CHANGED_AFTER_BOOKING'
+        | 'BOOKER_CANCELLED'
       /**
        * @description Visit Restriction
        * @example OPEN
@@ -1308,6 +1310,8 @@ export interface components {
       totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitDto'][]
@@ -1317,20 +1321,18 @@ export interface components {
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
-      first?: boolean
-      last?: boolean
       empty?: boolean
     }
     PageableObject: {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject'][]
-      unpaged?: boolean
+      /** Format: int32 */
+      pageSize?: number
       paged?: boolean
       /** Format: int32 */
       pageNumber?: number
-      /** Format: int32 */
-      pageSize?: number
+      unpaged?: boolean
     }
     SortObject: {
       direction?: string
@@ -1582,6 +1584,16 @@ export interface components {
        */
       prisonerId: string
       /**
+       * @description Prisoner first name
+       * @example James
+       */
+      prisonerFirstName?: string
+      /**
+       * @description Prisoner last name
+       * @example Smith
+       */
+      prisonerLastName?: string
+      /**
        * @description Prison Id
        * @example MDI
        */
@@ -1618,6 +1630,7 @@ export interface components {
         | 'VISIT_ORDER_CANCELLED'
         | 'SUPERSEDED_CANCELLATION'
         | 'DETAILS_CHANGED_AFTER_BOOKING'
+        | 'BOOKER_CANCELLED'
       /**
        * Format: date-time
        * @description The date and time of the visit

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -81,6 +81,7 @@ describe('orchestrationApiClient', () => {
         },
         applicationMethodType: 'NOT_KNOWN',
         actionedBy: 'user1',
+        userType: 'STAFF',
       }
 
       const result: Visit = TestData.visit()

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -1282,7 +1282,7 @@ describe('GET /visit/cancelled', () => {
         const $ = cheerio.load(res.text)
         expect($('h1').text().trim()).toBe('Booking cancelled')
         expect($('[data-test="visit-details"]').text().trim()).toBe('10:15am to 11am on Wednesday 9 February 2022')
-        expect($('[data-test="go-to-start"]').length).toBe(1)
+        expect($('[data-test="go-to-home"]').length).toBe(1)
 
         expect(clearSession).toHaveBeenCalledTimes(1)
       })

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -613,9 +613,9 @@ describe('/visit/:reference', () => {
         visitHistoryDetails.eventsAudit = [
           {
             type: 'CANCELLED_VISIT',
-            applicationMethodType: 'NOT_APPLICABLE',
-            actionedByFullName: 'User Three',
-            userType: 'STAFF',
+            applicationMethodType: 'WEBSITE',
+            actionedByFullName: 'aaaa-bbbb-cccc', // booker reference - this is displayed
+            userType: 'PUBLIC',
             createTimestamp: '2022-01-01T11:00:00',
           },
         ]
@@ -625,8 +625,10 @@ describe('/visit/:reference', () => {
           .expect('Content-Type', /html/)
           .expect(res => {
             const $ = cheerio.load(res.text)
+            expect($('[data-test="visit-actioned-by-1"]').text()).toContain('by aaaa-bbbb-cccc')
             expect($('[data-test="visit-cancelled-type"]').text()).toBe('This visit was cancelled by the visitor.')
-            expect($('[data-test="visit-cancelled-reason-1"]').text()).toBe('')
+            expect($('[data-test="visit-cancelled-reason-1"]').text()).toBe('') // no cancelled reason given on public cancellations
+            expect($('[data-test="visit-cancelled-request-method-1"]').text()).toBe('Method: GOV.UK cancellation')
           })
       })
 

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -626,7 +626,7 @@ describe('/visit/:reference', () => {
           .expect(res => {
             const $ = cheerio.load(res.text)
             expect($('[data-test="visit-actioned-by-1"]').text()).toContain('by aaaa-bbbb-cccc')
-            expect($('[data-test="visit-cancelled-type"]').text()).toBe('This visit was cancelled by the visitor.')
+            expect($('[data-test="visit-cancelled-type"]').text()).toBe('This visit was cancelled by a visitor.')
             expect($('[data-test="visit-cancelled-reason-1"]').text()).toBe('') // no cancelled reason given on public cancellations
             expect($('[data-test="visit-cancelled-request-method-1"]').text()).toBe('Method: GOV.UK cancellation')
           })
@@ -684,7 +684,7 @@ describe('/visit/:reference', () => {
           .expect('Content-Type', /html/)
           .expect(res => {
             const $ = cheerio.load(res.text)
-            expect($('[data-test="visit-cancelled-type"]').text()).toBe('This visit was cancelled by the visitor.')
+            expect($('[data-test="visit-cancelled-type"]').text()).toBe('This visit was cancelled by a visitor.')
             expect($('[data-test="visit-event-1"]').text().trim().replace(/\s+/g, ' ')).toBe('Cancelled')
             expect($('[data-test="visit-actioned-by-1"]').text().trim().replace(/\s+/g, ' ')).toBe('by User Three')
             expect($('[data-test="visit-event-date-time-1"]').text().trim().replace(/\s+/g, ' ')).toBe(

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -606,6 +606,30 @@ describe('/visit/:reference', () => {
           })
       })
 
+      it('should display cancelled message - booker cancelled', () => {
+        visit.visitStatus = 'CANCELLED'
+        visit.outcomeStatus = 'BOOKER_CANCELLED'
+        visit.visitNotes = [] // empty visit notes, as no comment from a booker lead cancellation
+        visitHistoryDetails.eventsAudit = [
+          {
+            type: 'CANCELLED_VISIT',
+            applicationMethodType: 'NOT_APPLICABLE',
+            actionedByFullName: 'User Three',
+            userType: 'STAFF',
+            createTimestamp: '2022-01-01T11:00:00',
+          },
+        ]
+        return request(app)
+          .get('/visit/ab-cd-ef-gh')
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            const $ = cheerio.load(res.text)
+            expect($('[data-test="visit-cancelled-type"]').text()).toBe('This visit was cancelled by the visitor.')
+            expect($('[data-test="visit-cancelled-reason-1"]').text()).toBe('')
+          })
+      })
+
       it('should display cancelled message - details changed after booking', () => {
         visit.visitStatus = 'CANCELLED'
         visit.outcomeStatus = 'DETAILS_CHANGED_AFTER_BOOKING'

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -1145,6 +1145,7 @@ describe('POST /visit/:reference/cancel', () => {
             },
             applicationMethodType: 'NOT_APPLICABLE',
             actionedBy: 'user1',
+            userType: 'STAFF',
           },
         })
         expect(flashProvider).toHaveBeenCalledWith('startTimestamp', cancelledVisit.startTimestamp)
@@ -1181,6 +1182,7 @@ describe('POST /visit/:reference/cancel', () => {
             },
             applicationMethodType: 'EMAIL',
             actionedBy: 'user1',
+            userType: 'STAFF',
           },
         })
       })

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -493,6 +493,7 @@ export default function routes({
         },
         applicationMethodType,
         actionedBy: res.locals.user.username,
+        userType: 'STAFF',
       }
 
       const visit = await visitService.cancelVisit({

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -119,6 +119,7 @@ describe('Visit service', () => {
           },
           applicationMethodType: 'NOT_KNOWN',
           actionedBy: 'user1',
+          userType: 'STAFF',
         }
 
         orchestrationApiClient.cancelVisit.mockResolvedValue(expectedResult)

--- a/server/views/pages/visit/cancelConfirmation.njk
+++ b/server/views/pages/visit/cancelConfirmation.njk
@@ -27,7 +27,7 @@
       text: "Go to manage prison visits",
       classes: "govuk-!-margin-top-3",
       href: "/",
-      attributes: { "data-test": "go-to-start" },
+      attributes: { "data-test": "go-to-home" },
       preventDoubleClick: true
     }) }}
   </div>

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -47,35 +47,37 @@
     {% set cancelledVisitReason = '' %}
 
       {% if visit.visitStatus === "CANCELLED" %}
-
+      
         {% set status = visit.outcomeStatus.split("_") %}
+
+        {% set cancelledBy %}
+          {% if status[0] === 'ADMINISTRATIVE' %}
+            {{- 'This visit was cancelled due to an administrative error with the booking.' -}}
+          {% elseif status[0] === 'DETAILS' %}
+            {{- 'This visit was cancelled as the details changed after booking.' -}}
+          {% elseif status[0] === 'BOOKER' %}
+            {{- 'This visit was cancelled by the visitor.' -}}
+          {% else %}
+            {{- 'This visit was cancelled by the ' + status[0] | lower + '.' -}}
+          {% endif %}
+        {% endset %}
+
+        {% set cancelledVisitBannerHtml %}
+          {{ govukWarningText({
+            classes: "govuk-!-margin-bottom-0 govuk-!-padding-left-4",
+            html: '<span data-test="visit-cancelled-type">' + cancelledBy + '</span>',
+            iconFallbackText: "Warning"
+          }) }}
+        {% endset %}
+
+        {{ mojBanner({
+          classes: "govuk-!-padding-left-4",
+          html: cancelledVisitBannerHtml
+        }) }}
+
         {%- for visitNote in visit.visitNotes %}
           {% if visitNote.type == "VISIT_OUTCOMES" %}
-          {% set cancelledVisitReason = visitNote.text %}
-            
-            {% set cancelledBy %}
-              {% if status[0] === 'ADMINISTRATIVE' %}
-                {{- 'This visit was cancelled due to an administrative error with the booking.' -}}
-              {% elseif status[0] === 'DETAILS' %}
-                {{- 'This visit was cancelled as the details changed after booking.' -}}
-              {% else %}
-                {{- 'This visit was cancelled by the ' + status[0] | lower + '.' -}}
-              {% endif %}
-            {% endset %}
-
-            {% set cancelledVisitBannerHtml %}
-              {{ govukWarningText({
-                classes: "govuk-!-margin-bottom-0 govuk-!-padding-left-4",
-                html: '<span data-test="visit-cancelled-type">' + cancelledBy + '</span>',
-                iconFallbackText: "Warning"
-              }) }}
-            {% endset %}
-
-            {{ mojBanner({
-              classes: "govuk-!-padding-left-4",
-              html: cancelledVisitBannerHtml
-            }) }}
-
+            {% set cancelledVisitReason = visitNote.text %}
           {% endif %}
         {% endfor %}
       {% endif %}
@@ -288,7 +290,9 @@
                   {% elseif event.type === 'UPDATED_VISIT' or event.type === 'MIGRATED_VISIT' %}
                     <p data-test="visit-request-method-{{ loop.index }}">{{ requestMethodDescriptions[event.applicationMethodType] }}</p>
                   {% elseif event.type === 'CANCELLED_VISIT' %}
-                    <p data-test="visit-cancelled-reason-{{ loop.index }}">Reason: {{ cancelledVisitReason }}</p>
+                    {% if cancelledVisitReason !== '' %}
+                      <p data-test="visit-cancelled-reason-{{ loop.index }}">Reason: {{ cancelledVisitReason }}</p>
+                    {% endif %}
                     {% if event.applicationMethodType !== 'NOT_KNOWN' and event.applicationMethodType !== 'NOT_APPLICABLE' %}
                       <p data-test="visit-cancelled-request-method-{{ loop.index }}">{{ requestMethodDescriptions[event.applicationMethodType] }}</p>
                     {% endif %}

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -55,8 +55,8 @@
             {{- 'This visit was cancelled due to an administrative error with the booking.' -}}
           {% elseif status[0] === 'DETAILS' %}
             {{- 'This visit was cancelled as the details changed after booking.' -}}
-          {% elseif status[0] === 'BOOKER' %}
-            {{- 'This visit was cancelled by the visitor.' -}}
+          {% elseif status[0] === 'BOOKER' or status[0] === 'VISITOR' %}
+            {{- 'This visit was cancelled by a visitor.' -}}
           {% else %}
             {{- 'This visit was cancelled by the ' + status[0] | lower + '.' -}}
           {% endif %}

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -47,7 +47,7 @@
     {% set cancelledVisitReason = '' %}
 
       {% if visit.visitStatus === "CANCELLED" %}
-      
+
         {% set status = visit.outcomeStatus.split("_") %}
 
         {% set cancelledBy %}

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -294,7 +294,11 @@
                       <p data-test="visit-cancelled-reason-{{ loop.index }}">Reason: {{ cancelledVisitReason }}</p>
                     {% endif %}
                     {% if event.applicationMethodType !== 'NOT_KNOWN' and event.applicationMethodType !== 'NOT_APPLICABLE' %}
-                      <p data-test="visit-cancelled-request-method-{{ loop.index }}">{{ requestMethodDescriptions[event.applicationMethodType] }}</p>
+                      {% if event.userType ==='PUBLIC' and event.applicationMethodType === 'WEBSITE' %}
+                        <p data-test="visit-cancelled-request-method-{{ loop.index }}">Method: GOV.UK cancellation</p>
+                      {% else %}
+                        <p data-test="visit-cancelled-request-method-{{ loop.index }}">{{ requestMethodDescriptions[event.applicationMethodType] }}</p>
+                      {% endif %}
                     {% endif %}
                   {% elseif event.type === 'IGNORE_VISIT_NOTIFICATIONS_EVENT' %}
                     <p data-test="visit-needs-review-description-{{ loop.index }}">Reason: {{ event.text }}</p>


### PR DESCRIPTION
Change logic surrounding how the visit history tab gets the 'visit notes' - as booker cancellations don't have notes

Make booker lead cancellations displayed 'cancelled by the visitor' with no reason 