### PR TITLE
VB-4331 Handle main contact email address

### DIFF
--- a/integration_tests/e2e/updateAVisit.cy.ts
+++ b/integration_tests/e2e/updateAVisit.cy.ts
@@ -111,6 +111,7 @@ context('Update a visit', () => {
       ],
       visitorSupport: { description: '' },
     })
+    updatedApplication.visitContact.email = 'visitor@example.com' // (may be present if visit originated in public servivce)
     cy.task('stubCreateVisitApplicationFromVisit', {
       visitReference: visitHistoryDetails.visit.reference,
       application: updatedApplication,
@@ -136,7 +137,7 @@ context('Update a visit', () => {
       TestData.application({
         startTimestamp: visitSessions[1].startTimestamp,
         endTimestamp: visitSessions[1].endTimestamp,
-        visitContact: { name: 'Jeanette Smith', telephone: '09876 543 321' },
+        visitContact: { name: 'Jeanette Smith', telephone: '09876 543 321', email: 'visitor@example.com' },
         visitors: [
           { nomisPersonId: contacts[0].personId, visitContact: true },
           { nomisPersonId: contacts[1].personId, visitContact: false },

--- a/integration_tests/e2e/visitDetails.cy.ts
+++ b/integration_tests/e2e/visitDetails.cy.ts
@@ -67,6 +67,7 @@ context('Visit details page', () => {
     visitDetailsPage.visitType().contains('Open')
     visitDetailsPage.visitContact().contains('Smith, Jeanette')
     visitDetailsPage.visitPhone().contains('01234 567890')
+    visitDetailsPage.visitEmail().contains('visitor@example.com')
   })
 
   it('should show update and cancel buttons, and notifications for future visit (date blocked)', () => {

--- a/integration_tests/pages/visitDetails.ts
+++ b/integration_tests/pages/visitDetails.ts
@@ -44,6 +44,8 @@ export default class VisitDetailsPage extends Page {
 
   visitPhone = (): PageElement => cy.get('[data-test="visit-phone"]')
 
+  visitEmail = (): PageElement => cy.get('[data-test="visit-email"]')
+
   // Visitor Details-1
   visitorName1 = (): PageElement => cy.get('[data-test="test-visitor-name1"]')
 

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -112,6 +112,7 @@ export type VisitSessionData = {
   mainContact?: {
     contact?: VisitorListItem
     phoneNumber?: string
+    email?: string
     contactName?: string
   }
   applicationReference?: string

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -935,6 +935,11 @@ export interface components {
        * @example 01234 567890
        */
       telephone?: string
+      /**
+       * @description Contact Email Address
+       * @example email@example.com
+       */
+      email?: string
     }
     /** @description Visit */
     VisitDto: {

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -218,6 +218,7 @@ describe('orchestrationApiClient', () => {
         visitorSupport: { description: '' },
         mainContact: {
           phoneNumber: '01234 567890',
+          email: 'visitor@example.com',
           contactName: 'John Smith',
         },
       }
@@ -234,6 +235,7 @@ describe('orchestrationApiClient', () => {
           visitContact: {
             name: visitSessionData.mainContact.contactName,
             telephone: visitSessionData.mainContact.phoneNumber,
+            email: visitSessionData.mainContact.email,
           },
           visitors: visitSessionData.visitors.map(visitor => {
             return {
@@ -268,6 +270,7 @@ describe('orchestrationApiClient', () => {
         visitorSupport: { description: '' },
         mainContact: {
           phoneNumber: '01234 567890',
+          email: 'visitor@example.com',
           contactName: 'John Smith',
         },
         visitReference: 'ab-cd-ef-gh',
@@ -286,6 +289,7 @@ describe('orchestrationApiClient', () => {
           visitContact: {
             name: visitSessionData.mainContact.contactName,
             telephone: visitSessionData.mainContact.phoneNumber,
+            email: visitSessionData.mainContact.email,
           },
           visitors: visitSessionData.visitors.map(visitor => {
             return {

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -302,6 +302,7 @@ export default class OrchestrationApiClient {
     const visitContact = mainContact
       ? {
           ...(mainContact.phoneNumber && { telephone: mainContact.phoneNumber }),
+          ...(mainContact.email && { email: mainContact.email }),
           name: mainContact.contactName ? mainContact.contactName : mainContact.contact.name,
         }
       : undefined

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -86,6 +86,7 @@ export default class TestData {
     visitContact = {
       name: 'Jeanette Smith',
       telephone: '01234 567890',
+      email: 'visitor@example.com',
     },
     visitors = [
       {
@@ -412,6 +413,7 @@ export default class TestData {
     visitContact = {
       name: 'Jeanette Smith',
       telephone: '01234 567890',
+      email: 'visitor@example.com',
     },
     visitors = [
       {

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -86,7 +86,6 @@ export default class TestData {
     visitContact = {
       name: 'Jeanette Smith',
       telephone: '01234 567890',
-      email: 'visitor@example.com',
     },
     visitors = [
       {

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -164,6 +164,7 @@ describe('/visit/:reference', () => {
           expect($('[data-test="visit-type"]').text()).toBe('Open')
           expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
           expect($('[data-test="visit-phone"]').text()).toBe('01234 567890')
+          expect($('[data-test="visit-email"]').text()).toBe('visitor@example.com')
           expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
           expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
           // prisoner details
@@ -211,15 +212,9 @@ describe('/visit/:reference', () => {
         })
     })
 
-    it('should render full booking summary page with visit information and prisoner tab selected, with default back link, formatting unknown contact telephone correctly', () => {
-      visitHistoryDetails.visit.visitContact.telephone = 'UNKNOWN'
-      prisonerSearchService.getPrisonerById.mockResolvedValue(prisoner)
-      visitService.getFullVisitDetails.mockResolvedValue({
-        visitHistoryDetails,
-        visitors,
-        notifications,
-        additionalSupport,
-      })
+    it('should render full booking summary page and show no contact details message', () => {
+      visit.visitContact.telephone = undefined
+      visit.visitContact.email = undefined
 
       return request(app)
         .get('/visit/ab-cd-ef-gh')
@@ -227,25 +222,9 @@ describe('/visit/:reference', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('h1').text()).toBe('Visit booking details')
-          expect($('.govuk-back-link').attr('href')).toBe('/prisoner/A1234BC')
-          expect($('[data-test="reference"]').text()).toBe('ab-cd-ef-gh')
-          // prisoner details
-          expect($('[data-test="prisoner-name"]').text()).toBe('Smith, John')
-          // visit details
-          expect($('[data-test="visit-contact"]').text()).toBe('Smith, Jeanette')
-          expect($('[data-test="visit-phone"]').text()).toBe('No phone number provided')
-          expect($('[data-test="cancel-visit"]').attr('href')).toBe('/visit/ab-cd-ef-gh/cancel')
-          expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh')
-
-          expect(auditService.viewedVisitDetails).toHaveBeenCalledTimes(1)
-          expect(auditService.viewedVisitDetails).toHaveBeenCalledWith({
-            visitReference: 'ab-cd-ef-gh',
-            prisonerId: 'A1234BC',
-            prisonId: 'HEI',
-            username: 'user1',
-            operationId: undefined,
-          })
+          expect($('[data-test="visit-phone"]').length).toBe(0)
+          expect($('[data-test="visit-email"]').length).toBe(0)
+          expect($('[data-test="visit-no-contact-details"]').text()).toBe('No contact details provided')
         })
     })
 

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -745,7 +745,12 @@ describe('/visit/:reference', () => {
               },
             ],
             visitorSupport: { description: 'Wheelchair ramp, Portable induction loop for people with hearing aids' },
-            mainContact: { contact: visitors[0], phoneNumber: '01234 567890', contactName: 'Jeanette Smith' },
+            mainContact: {
+              contact: visitors[0],
+              phoneNumber: '01234 567890',
+              email: 'visitor@example.com',
+              contactName: 'Jeanette Smith',
+            },
             visitReference: 'ab-cd-ef-gh',
           })
         })

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -195,6 +195,7 @@ export default function routes({
       mainContact: {
         contact: mainContact,
         phoneNumber: visit.visitContact.telephone,
+        email: visit.visitContact.email,
         contactName: visit.visitContact.name,
       },
       visitReference: visit.reference,

--- a/server/routes/visitJourney/mainContact.test.ts
+++ b/server/routes/visitJourney/mainContact.test.ts
@@ -274,6 +274,7 @@ testJourneys.forEach(journey => {
               banned: false,
             })
             expect(visitSessionData.mainContact.phoneNumber).toBe('0114 1234 567')
+            expect(visitSessionData.mainContact.email).toBeUndefined()
             expect(visitSessionData.mainContact.contactName).toBe(undefined)
 
             expect(visitService.changeVisitApplication).toHaveBeenCalledWith({ username: 'user1', visitSessionData })
@@ -292,6 +293,7 @@ testJourneys.forEach(journey => {
           .expect(() => {
             expect(visitSessionData.mainContact.contact).toBe(undefined)
             expect(visitSessionData.mainContact.contactName).toBe('another person')
+            expect(visitSessionData.mainContact.email).toBeUndefined()
             expect(visitSessionData.mainContact.phoneNumber).toBe('0114 7654 321')
 
             expect(visitService.changeVisitApplication).toHaveBeenCalledWith({ username: 'user1', visitSessionData })
@@ -309,6 +311,7 @@ testJourneys.forEach(journey => {
             banned: false,
           },
           phoneNumber: '0114 1234 567',
+          email: 'visitor@example.com',
           contactName: undefined,
         }
         return request(sessionApp)
@@ -323,6 +326,7 @@ testJourneys.forEach(journey => {
             expect(visitSessionData.mainContact.contact).toBe(undefined)
             expect(visitSessionData.mainContact.contactName).toBe('another person')
             expect(visitSessionData.mainContact.phoneNumber).toBe('0114 7654 321')
+            expect(visitSessionData.mainContact.email).toBe('visitor@example.com')
 
             expect(visitService.changeVisitApplication).toHaveBeenCalledWith({ username: 'user1', visitSessionData })
           })

--- a/server/routes/visitJourney/mainContact.ts
+++ b/server/routes/visitJourney/mainContact.ts
@@ -52,9 +52,13 @@ export default class MainContact {
       (visitor: VisitorListItem) => req.body.contact === visitor.personId.toString(),
     )
 
+    // email not collected in this service but need to preserve it as it may have been entered in public service
+    const email = visitSessionData.mainContact?.email
+
     visitSessionData.mainContact = {
       contact: selectedContact,
       phoneNumber: req.body.phoneNumber === 'hasPhoneNumber' ? req.body.phoneNumberInput : undefined,
+      email,
       contactName: selectedContact === undefined ? req.body.someoneElseName : undefined,
     }
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -129,10 +129,6 @@ export function registerNunjucks(app?: express.Express): Environment {
     }
   })
 
-  njkEnv.addFilter('formatTelephone', (telephoneNumber: string) => {
-    return telephoneNumber === 'UNKNOWN' || telephoneNumber === undefined ? 'No phone number provided' : telephoneNumber
-  })
-
   njkEnv.addFilter('pluralise', (word, count, plural = `${word}s`) => (count === 1 ? word : plural))
 
   return njkEnv

--- a/server/views/pages/bookAVisit/checkYourBooking.njk
+++ b/server/views/pages/bookAVisit/checkYourBooking.njk
@@ -143,7 +143,7 @@
                 },
                 value: {
                     html: '<p><span class="test-main-contact-name">' + contactName + '</span><br><span class="test-main-contact-number">' +
-                        mainContact.phoneNumber | formatTelephone + "</span></p>"
+                        mainContact.phoneNumber | d("No phone number provided", true) | escape + "</span></p>"
                 },
                 actions: {
                     items: [

--- a/server/views/pages/bookAVisit/confirmation.njk
+++ b/server/views/pages/bookAVisit/confirmation.njk
@@ -161,7 +161,7 @@
         },
         value: {
             html: '<p class="test-main-contact-name">' + contactName + '</p><p class="test-main-contact-number">' +
-                mainContact.phoneNumber | formatTelephone + '</p>'
+                mainContact.phoneNumber | d("No phone number provided", true) | escape + '</p>'
         }
     }
 ), displayRows) %}

--- a/server/views/pages/visit/summary.njk
+++ b/server/views/pages/visit/summary.njk
@@ -112,10 +112,24 @@
           <strong>Main contact</strong>
           <span data-test="visit-contact">{{ visit.visitContact.name | formatLastNameFirst(false) }}</span>
         </li>
-        <li>
-          <strong>Phone number</strong>
-          <span data-test="visit-phone">{{ visit.visitContact.telephone | formatTelephone }}</span>
-        </li>
+        {% if visit.visitContact.telephone %}
+          <li>
+            <strong>Phone number</strong>
+            <span data-test="visit-phone">{{ visit.visitContact.telephone }}</span>
+          </li>
+        {% endif %}
+        {% if visit.visitContact.email %}
+          <li>
+            <strong>Email address</strong>
+            <span data-test="visit-email">{{ visit.visitContact.email }}</span>
+          </li>
+        {% endif %}
+        {% if not visit.visitContact.telephone and not visit.visitContact.email %}
+          <li>
+            <strong>Contact details</strong>
+            <span data-test="visit-no-contact-details">No contact details provided</span>
+          </li>
+        {% endif %}
       </ul>
 
       <div class="govuk-button-group">


### PR DESCRIPTION
Add support for visits originating in the public service which have a main contact email address.

* Booking details page: show main contact email/phone - or a message if no contact details
* Update journey: although email isn't collected in the staff booking journey, ensure it is retained if a visit originating in the public service is updated