### PR TITLE
VB-4655 Prisoner alerts: render newlines in alert descriptions

### DIFF
--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -223,6 +223,7 @@
 
 .bapv-force-overflow {
  overflow-wrap: anywhere;
+ white-space: pre-line;
 }
 
 .bapv-timetable-dates {


### PR DESCRIPTION
Preserve line spaces when rendering alert descriptions so user formatting is retained.