### PR TITLE
VB-4957 Add expandable comment component

### DIFF
--- a/assets/js/components/expandableComment.js
+++ b/assets/js/components/expandableComment.js
@@ -1,15 +1,16 @@
 const expandableComments = document.querySelectorAll('.bapv-expandable-comment')
+const FUL_COMMENT_EXPANDED_CLASS = 'bapv-expandable-comment__full-comment--expanded'
 
 expandableComments.forEach(expandableComment => {
-  expandableComment.querySelector('.bapv-expandable-comment__show').addEventListener('click', () => {
-    expandableComment
-      .querySelector('.bapv-expandable-comment__full-comment')
-      .classList.add('bapv-expandable-comment__full-comment--expanded')
+  const showFullCommentButton = expandableComment.querySelector('.bapv-expandable-comment__show')
+  const hideFullCommentButton = expandableComment.querySelector('.bapv-expandable-comment__hide')
+  const fullCommentText = expandableComment.querySelector('.bapv-expandable-comment__full-comment')
+
+  showFullCommentButton.addEventListener('click', () => {
+      fullCommentText.classList.add(FUL_COMMENT_EXPANDED_CLASS)
   })
 
-  expandableComment.querySelector('.bapv-expandable-comment__hide').addEventListener('click', () => {
-    expandableComment
-      .querySelector('.bapv-expandable-comment__full-comment')
-      .classList.remove('bapv-expandable-comment__full-comment--expanded')
+  hideFullCommentButton.addEventListener('click', () => {
+    fullCommentText.classList.remove(FUL_COMMENT_EXPANDED_CLASS)
   })
 })

--- a/assets/js/components/expandableComment.js
+++ b/assets/js/components/expandableComment.js
@@ -1,0 +1,15 @@
+const expandableComments = document.querySelectorAll('.bapv-expandable-comment')
+
+expandableComments.forEach(expandableComment => {
+  expandableComment.querySelector('.bapv-expandable-comment__show').addEventListener('click', () => {
+    expandableComment
+      .querySelector('.bapv-expandable-comment__full-comment')
+      .classList.add('bapv-expandable-comment__full-comment--expanded')
+  })
+
+  expandableComment.querySelector('.bapv-expandable-comment__hide').addEventListener('click', () => {
+    expandableComment
+      .querySelector('.bapv-expandable-comment__full-comment')
+      .classList.remove('bapv-expandable-comment__full-comment--expanded')
+  })
+})

--- a/assets/sass/application.scss
+++ b/assets/sass/application.scss
@@ -11,6 +11,7 @@ $govuk-page-width: $moj-page-width;
 @import 'node_modules/@ministryofjustice/hmpps-connect-dps-components/dist/assets/header-bar';
 
 @import './components/card';
+@import './components/expandableComment';
 @import './components/block-background';
 @import './components/filter';
 @import './components/notificationTypes';

--- a/assets/sass/components/_expandableComment.scss
+++ b/assets/sass/components/_expandableComment.scss
@@ -1,0 +1,19 @@
+.bapv-expandable-comment__full-comment,
+.bapv-expandable-comment__show:has(+ .bapv-expandable-comment__full-comment--expanded),
+.bapv-expandable-comment__hide {
+  display: none;
+}
+
+.bapv-expandable-comment__full-comment {
+  margin-top: 1lh;
+}
+
+.bapv-expandable-comment__full-comment--expanded,
+.bapv-expandable-comment__full-comment--expanded + .bapv-expandable-comment__hide {
+  display: block;
+}
+
+.bapv-expandable-comment__show,
+.bapv-expandable-comment__hide {
+  line-height: 2;
+}

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -275,4 +275,37 @@ describe('Nunjucks Filters', () => {
       })
     })
   })
+
+  describe('splitOnNewline', () => {
+    it('should handle null or undefined', () => {
+      const expectedResult = ['', '']
+
+      expect(njkEnv.getFilter('splitOnNewline')(null)).toStrictEqual(expectedResult)
+      expect(njkEnv.getFilter('splitOnNewline')(undefined)).toStrictEqual(expectedResult)
+    })
+
+    it('should handle a string with no newline', () => {
+      const input = 'a string with no newline '
+      const expectedResult = ['a string with no newline', '']
+
+      const result = njkEnv.getFilter('splitOnNewline')(input)
+      expect(result).toStrictEqual(expectedResult)
+    })
+
+    it('should trim and ignore leading or trailing newlines or whitespace', () => {
+      const input = ' \r\n a string with leading and trailing whitespace\n '
+      const expectedResult = ['a string with leading and trailing whitespace', '']
+
+      const result = njkEnv.getFilter('splitOnNewline')(input)
+      expect(result).toStrictEqual(expectedResult)
+    })
+
+    it('should split on first non-leading newline and keep subsequent newlines', () => {
+      const input = ' \n line one\n\nline two\n\nline three \n\n '
+      const expectedResult = ['line one', 'line two\n\nline three']
+
+      const result = njkEnv.getFilter('splitOnNewline')(input)
+      expect(result).toStrictEqual(expectedResult)
+    })
+  })
 })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -131,5 +131,17 @@ export function registerNunjucks(app?: express.Express): Environment {
 
   njkEnv.addFilter('pluralise', (word, count, plural = `${word}s`) => (count === 1 ? word : plural))
 
+  // split string on first newline (if present), returning trimmed [firstLine, remainingText]
+  njkEnv.addFilter('splitOnNewline', (rawComment: string): [string, string] => {
+    if (typeof rawComment !== 'string') {
+      return ['', '']
+    }
+
+    const comment = rawComment.trim()
+    const [firstLine, ...rest] = comment.split(/(\n)/)
+
+    return [firstLine, rest.join('').trim()]
+  })
+
   return njkEnv
 }

--- a/server/views/components/expandableComment/expandableComment.test.ts
+++ b/server/views/components/expandableComment/expandableComment.test.ts
@@ -1,0 +1,46 @@
+import nunjucks, { Template } from 'nunjucks'
+import * as cheerio from 'cheerio'
+import { registerNunjucks } from '../../../utils/nunjucksSetup'
+
+describe('Expandable comment component', () => {
+  const njkEnv = registerNunjucks()
+  const templateString = `
+{%- from "components/expandableComment/macro.njk" import bapvExpandableComment -%}
+{{- bapvExpandableComment(comment) -}}`
+
+  let compiledTemplate: Template
+  let viewContext: Record<string, unknown>
+
+  beforeEach(() => {
+    viewContext = {}
+  })
+
+  it('should handle missing input', () => {
+    compiledTemplate = nunjucks.compile(templateString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+    expect($('body').html()).toBe('')
+  })
+
+  it('should trim input and not render additional markup if no newline within the text', () => {
+    viewContext = {
+      comment: { text: ' \na string with no newline in the text \r\n' },
+    }
+    compiledTemplate = nunjucks.compile(templateString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+    expect($('body').html().trim()).toBe('a string with no newline in the text')
+  })
+
+  it('should split on first newline and add expandable comment markup', () => {
+    viewContext = {
+      comment: { text: 'line one\nline two\nline three' },
+    }
+    compiledTemplate = nunjucks.compile(templateString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('.bapv-expandable-comment').length).toBe(1)
+    expect($('.bapv-expandable-comment__first-line').text()).toBe('line one')
+    expect($('.bapv-expandable-comment__show').length).toBe(1)
+    expect($('.bapv-expandable-comment__full-comment').text()).toBe('line two\nline three')
+    expect($('.bapv-expandable-comment__hide').length).toBe(1)
+  })
+})

--- a/server/views/components/expandableComment/macro.njk
+++ b/server/views/components/expandableComment/macro.njk
@@ -1,0 +1,3 @@
+{% macro bapvExpandableComment(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/expandableComment/template.njk
+++ b/server/views/components/expandableComment/template.njk
@@ -1,0 +1,33 @@
+{%- from "govuk/components/button/macro.njk" import govukButton -%}
+
+{% set splitText = params.text | splitOnNewline %}
+{% set firstLine = splitText[0] %}
+{% set remainingText = splitText[1] %}
+
+{% if remainingText | length %}
+  <div class="bapv-expandable-comment">
+    <div class="bapv-force-overflow bapv-expandable-comment__first-line">
+      {{- firstLine -}}
+    </div>
+
+    {{ govukButton({
+      text: "See full comment",
+      classes: "bapv-link-button bapv-expandable-comment__show",
+      type: "button",
+      attributes: { "data-test": "show-full-comment" }
+    }) }}
+
+    <div class="bapv-force-overflow bapv-expandable-comment__full-comment">
+      {{- remainingText -}}
+    </div>
+
+    {{ govukButton({
+      text: "Close full comment",
+      classes: "bapv-link-button bapv-expandable-comment__hide",
+      type: "button",
+      attributes: { "data-test": "close-full-comment" }
+    }) }}
+  </div>
+{% else %}
+  {{- params.text -}}
+{% endif %}

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 {% from "components/visitors.njk" import visitorDateOfBirth, visitorRestrictions %}
+{%- from "components/expandableComment/macro.njk" import bapvExpandableComment -%}
 
 {% set pageHeaderTitle = "Select visitors from the prisoner’s approved visitor list" %}
 {% set pageTitle %}
@@ -94,8 +95,8 @@
               html: '<span class="test-alert-type' + loop.index + ' govuk-tag alert-tag alert-tag--' + alert.alertType + '">' + alert.alertTypeDescription + '</span>'
             },
             {
-              text: alert.comment,
-              classes: "bapv-force-overflow test-alert-comment" + loop.index
+              html: bapvExpandableComment({ text: alert.comment }),
+              classes: "test-alert-comment" + loop.index
             },
             {
               text: alertExpiryDate,
@@ -238,4 +239,8 @@
     {% endif %}
     </div>
   </div>
+{% endblock %}
+
+{% block pageScripts %}
+  <script src="/assets/components/expandableComment.js"></script>
 {% endblock %}


### PR DESCRIPTION
Add a component to show a block of text (e.g. text comments on a prisoner alert) up to its **first newline character**. 

A link-styled button to see the full comment is rendered:
<img width="172" alt="Screenshot 2024-12-18 at 19 44 23" src="https://github.com/user-attachments/assets/fddace0b-8cc0-4a9e-90a6-2977b6386744" />

When the full comment is shown, there is a link-styled button to hide the full comment.
<img width="550" alt="Screenshot 2024-12-18 at 19 45 18" src="https://github.com/user-attachments/assets/96aecd96-46ad-4a74-8578-5b6f1cc26445" />

To use the component, call the macro. E.g. to use this when rendering a table cell:
```
  {
    html: bapvExpandableComment({ text: alert.comment }),
    attributes: { "data-test": "tab-alerts-comment" }
  },
```
 Also necessary to add the JavaScript include to the appropriate page template at the bottom, e.g.:
```
{% block pageScripts %}
  <script src="/assets/components/expandableComment.js"></script>
{% endblock %}
```

Show/hide functionality could be tested in Cypress integration tests.