### PR TITLE
VB-4976 Show open and closed visits on the same page

### DIFF
--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -129,10 +129,10 @@ describe('orchestrationApiClient', () => {
   })
 
   describe('getVisitsBySessionTemplate', () => {
-    it('should return visit previews details for given session template reference, date, prison and restriction', async () => {
+    it('should return visit previews details for given session template reference, date, and prison', async () => {
       const sessionTemplateReference = 'v9d.7ed.7u'
       const sessionDate = '2024-01-31'
-      const visitRestrictions: VisitRestriction = 'OPEN'
+      const visitRestrictions: VisitRestriction[] = ['OPEN', 'CLOSED']
       const visitPreviews = [TestData.visitPreview()]
 
       fakeOrchestrationApi
@@ -142,7 +142,7 @@ describe('orchestrationApiClient', () => {
           sessionTemplateReference,
           sessionDate,
           visitStatus: 'BOOKED',
-          visitRestrictions,
+          visitRestrictions: visitRestrictions.join(','),
         })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, visitPreviews)

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -73,7 +73,7 @@ export default class OrchestrationApiClient {
     prisonId: string,
     reference: string,
     sessionDate: string,
-    visitRestrictions: VisitRestriction,
+    visitRestrictions: VisitRestriction[],
   ): Promise<VisitPreview[]> {
     return this.restClient.get({
       path: '/visits/session-template',

--- a/server/routes/visitsByDate.test.ts
+++ b/server/routes/visitsByDate.test.ts
@@ -104,7 +104,7 @@ describe('GET /visits - Visits by date page', () => {
 
           // side-nav
           expect($('.moj-side-navigation h4').eq(0).text()).toBe('Visits hall')
-          expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('1:45pm to 3:45pm')
+          expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('1:45pm to 3:45pm - Visits hall')
           expect($('.moj-side-navigation ul').eq(0).find('a').first().attr('href')).toBe(
             '/visits?sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
           )
@@ -113,16 +113,26 @@ describe('GET /visits - Visits by date page', () => {
           )
 
           // Visits
-          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 1:45pm to 3:45pm')
-          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 of 20 tables booked')
-          expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+          expect($('[data-test=visit-room-caption]').text()).toBe('Visits hall')
+          expect($('h2').text()).toBe('Visits from 1:45pm to 3:45pm')
 
-          expect($('[data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
-          expect($('[data-test="prisoner-number"]').eq(0).text()).toBe('A1234BC')
-          expect($('[data-test="booked-on"]').eq(0).text()).toBe('1 January at 9am')
-          expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe(
-            '/visit/ab-cd-ef-gh?query=type%3DOPEN%26sessionReference%3D-afe.dcc.0f%26selectedDate%3D2024-02-01%26firstTabDate%3D2024-02-01&from=visits',
+          expect($('[data-test=visit-section-heading-closed]').text().trim()).toBe('Closed visits')
+          expect($('[data-test=visit-tables-booked-closed]').text().trim()).toBe('0 of 5 tables booked')
+          expect($('[data-test=visit-visitors-total-closed]').length).toBe(0)
+          expect($('[data-test=visits-closed]').length).toBe(0)
+
+          expect($('[data-test=visit-section-heading-open]').text().trim()).toBe('Open visits')
+          expect($('[data-test=visit-tables-booked-open]').text().trim()).toBe('1 of 20 tables booked')
+          expect($('[data-test=visit-visitors-total-open]').text()).toBe('2 visitors')
+
+          expect($('[data-test=visits-open] [data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
+          expect($('[data-test=visits-open] [data-test="prisoner-number"]').eq(0).text()).toBe('A1234BC')
+          expect($('[data-test=visits-open] [data-test="booked-on"]').eq(0).text()).toBe('1 January at 9am')
+          expect($('[data-test=visits-open] [data-test="view-visit-link"]').eq(0).attr('href')).toBe(
+            '/visit/ab-cd-ef-gh?query=sessionReference%3D-afe.dcc.0f%26selectedDate%3D2024-02-01%26firstTabDate%3D2024-02-01&from=visits',
           )
+
+          expect($('[data-test=visit-section-heading-unknown]').length).toBe(0)
 
           expect($('[data-test="no-visits-message"]').length).toBe(0)
 
@@ -138,7 +148,6 @@ describe('GET /visits - Visits by date page', () => {
             prisonId,
             reference: sessionSchedule[0].sessionTemplateReference,
             sessionDate: today,
-            visitRestrictions: 'OPEN',
           })
           expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
             username: 'user1',
@@ -173,16 +182,26 @@ describe('GET /visits - Visits by date page', () => {
           )
 
           // Visits
-          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 1:45pm to 3:45pm')
-          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 of 20 tables booked')
-          expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+          expect($('[data-test=visit-room-caption]').text()).toBe('Visits hall')
+          expect($('h2').text()).toBe('Visits from 1:45pm to 3:45pm')
 
-          expect($('[data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
-          expect($('[data-test="prisoner-number"]').eq(0).text()).toBe('A1234BC')
-          expect($('[data-test="booked-on"]').eq(0).text()).toBe('1 January at 9am')
-          expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe(
-            '/visit/ab-cd-ef-gh?query=type%3DOPEN%26sessionReference%3D-afe.dcc.0f%26selectedDate%3D2024-02-02%26firstTabDate%3D2024-02-01&from=visits',
+          expect($('[data-test=visit-section-heading-closed]').text().trim()).toBe('Closed visits')
+          expect($('[data-test=visit-tables-booked-closed]').text().trim()).toBe('0 of 5 tables booked')
+          expect($('[data-test=visit-visitors-total-closed]').length).toBe(0)
+          expect($('[data-test=visits-closed]').length).toBe(0)
+
+          expect($('[data-test=visit-section-heading-open]').text().trim()).toBe('Open visits')
+          expect($('[data-test=visit-tables-booked-open]').text().trim()).toBe('1 of 20 tables booked')
+          expect($('[data-test=visit-visitors-total-open]').text()).toBe('2 visitors')
+
+          expect($('[data-test=visits-open] [data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
+          expect($('[data-test=visits-open] [data-test="prisoner-number"]').eq(0).text()).toBe('A1234BC')
+          expect($('[data-test=visits-open] [data-test="booked-on"]').eq(0).text()).toBe('1 January at 9am')
+          expect($('[data-test=visits-open] [data-test="view-visit-link"]').eq(0).attr('href')).toBe(
+            '/visit/ab-cd-ef-gh?query=sessionReference%3D-afe.dcc.0f%26selectedDate%3D2024-02-02%26firstTabDate%3D2024-02-01&from=visits',
           )
+
+          expect($('[data-test=visit-section-heading-unknown]').length).toBe(0)
 
           expect($('[data-test="no-visits-message"]').length).toBe(0)
 
@@ -198,7 +217,6 @@ describe('GET /visits - Visits by date page', () => {
             prisonId,
             reference: sessionSchedule[0].sessionTemplateReference,
             sessionDate: '2024-02-02',
-            visitRestrictions: 'OPEN',
           })
           expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
             username: 'user1',
@@ -237,9 +255,11 @@ describe('GET /visits - Visits by date page', () => {
           )
 
           // Visits
-          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 1:45pm to 3:45pm')
-          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 of 20 tables booked')
-          expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+          expect($('[data-test=visit-room-caption]').text()).toBe('Visits hall')
+          expect($('h2').text()).toBe('Visits from 1:45pm to 3:45pm')
+          expect($('[data-test=visit-section-heading-open]').text().trim()).toBe('Open visits')
+          expect($('[data-test=visit-tables-booked-open]').text().trim()).toBe('1 of 20 tables booked')
+          expect($('[data-test=visit-visitors-total-open]').text()).toBe('2 visitors')
 
           expect(blockedDatesService.isBlockedDate).not.toHaveBeenCalled()
           expect(visitNotificationsService.dateHasNotifications).not.toHaveBeenCalled()
@@ -253,7 +273,6 @@ describe('GET /visits - Visits by date page', () => {
             prisonId,
             reference: sessionSchedule[0].sessionTemplateReference,
             sessionDate: today,
-            visitRestrictions: 'OPEN',
           })
           expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
             username: 'user1',
@@ -273,147 +292,6 @@ describe('GET /visits - Visits by date page', () => {
   describe('Visits without a session template - UNKNOWN/migrated visits', () => {
     beforeEach(() => {
       visitSessionsService.getSessionSchedule.mockResolvedValue([])
-      visitService.getVisitsBySessionTemplate.mockResolvedValue([])
-      visitService.getVisitsWithoutSessionTemplate.mockResolvedValue(visits)
-    })
-
-    // FIXME
-    it.skip('should render date tabs, side-nav and visits for default date (today)', () => {
-      return request(app)
-        .get('/visits')
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('h1').text()).toBe('View visits by date')
-
-          // date tabs
-          expect($('.moj-sub-navigation__link').length).toBe(3)
-          expect($('.moj-sub-navigation__link').eq(0).text()).toBe('Thursday 1 February 2024')
-          expect($('.moj-sub-navigation__link').eq(0).attr('href')).toBe(
-            '/visits?selectedDate=2024-02-01&firstTabDate=2024-02-01',
-          )
-          expect($('.moj-sub-navigation__link').eq(0).attr('aria-current')).toBe('page')
-
-          expect($('.moj-sub-navigation__link').eq(1).text()).toBe('Friday 2 February 2024')
-          expect($('.moj-sub-navigation__link').eq(1).attr('href')).toBe(
-            '/visits?selectedDate=2024-02-02&firstTabDate=2024-02-01',
-          )
-          expect($('.moj-sub-navigation__link').eq(1).attr('aria-current')).toBe(undefined)
-
-          expect($('.moj-sub-navigation__link').eq(2).text()).toBe('Saturday 3 February 2024')
-          expect($('.moj-sub-navigation__link').eq(2).attr('href')).toBe(
-            '/visits?selectedDate=2024-02-03&firstTabDate=2024-02-01',
-          )
-          expect($('.moj-sub-navigation__link').eq(2).attr('aria-current')).toBe(undefined)
-
-          // side-nav
-          expect($('.moj-side-navigation h4').eq(0).text()).toBe('All visits')
-          expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('1:45pm to 3:45pm')
-          expect($('.moj-side-navigation ul').eq(0).find('a').first().attr('href')).toBe(
-            '/visits?sessionReference=13%3A45-15%3A45&selectedDate=2024-02-01&firstTabDate=2024-02-01',
-          )
-          expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
-            '/visits?sessionReference=13%3A45-15%3A45&selectedDate=2024-02-01&firstTabDate=2024-02-01',
-          )
-
-          // Visits
-          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('All visits, 1:45pm to 3:45pm')
-          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 table booked')
-          expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
-
-          expect($('[data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
-          expect($('[data-test="prisoner-number"]').eq(0).text()).toBe('A1234BC')
-          expect($('[data-test="booked-on"]').eq(0).text()).toBe('1 January at 9am')
-          expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe(
-            '/visit/ab-cd-ef-gh?query=type%3DUNKNOWN%26sessionReference%3D13%253A45-15%253A45%26selectedDate%3D2024-02-01%26firstTabDate%3D2024-02-01&from=visits',
-          )
-
-          expect($('[data-test="no-visits-message"]').length).toBe(0)
-
-          expect(blockedDatesService.isBlockedDate).not.toHaveBeenCalled()
-          expect(visitNotificationsService.dateHasNotifications).not.toHaveBeenCalled()
-          expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
-            username: 'user1',
-            prisonId,
-            date: today,
-          })
-          expect(visitService.getVisitsBySessionTemplate).not.toHaveBeenCalled()
-          expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
-            username: 'user1',
-            prisonId,
-            sessionDate: today,
-          })
-          expect(auditService.viewedVisits).toHaveBeenCalledWith({
-            viewDate: today,
-            prisonId,
-            username: 'user1',
-            operationId: undefined,
-          })
-        })
-    })
-
-    // FIXME
-    it.skip('should render date tabs, side-nav and visits for a specific unknown visits time slot reference', () => {
-      return request(app)
-        .get('/visits?type=UNKNOWN&sessionReference=13%3A45-15%3A45&selectedDate=2024-02-02&firstTabDate=2024-02-01')
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          const $ = cheerio.load(res.text)
-          expect($('h1').text()).toBe('View visits by date')
-
-          // date tabs
-          expect($('.moj-sub-navigation__link').length).toBe(3)
-          expect($('.moj-sub-navigation__link').eq(1).attr('aria-current')).toBe('page')
-
-          // side-nav
-          expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
-            '/visits?type=UNKNOWN&sessionReference=13%3A45-15%3A45&selectedDate=2024-02-02&firstTabDate=2024-02-01',
-          )
-
-          // Visits
-          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('All visits, 1:45pm to 3:45pm')
-          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 table booked')
-          expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
-
-          expect($('[data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
-          expect($('[data-test="prisoner-number"]').eq(0).text()).toBe('A1234BC')
-          expect($('[data-test="booked-on"]').eq(0).text()).toBe('1 January at 9am')
-          expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe(
-            '/visit/ab-cd-ef-gh?query=type%3DUNKNOWN%26sessionReference%3D13%253A45-15%253A45%26selectedDate%3D2024-02-02%26firstTabDate%3D2024-02-01&from=visits',
-          )
-
-          expect($('[data-test="no-visits-message"]').length).toBe(0)
-
-          expect(blockedDatesService.isBlockedDate).not.toHaveBeenCalled()
-          expect(visitNotificationsService.dateHasNotifications).not.toHaveBeenCalled()
-          expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
-            username: 'user1',
-            prisonId,
-            date: '2024-02-02',
-          })
-          expect(visitService.getVisitsBySessionTemplate).not.toHaveBeenCalled()
-          expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
-            prisonId,
-            sessionDate: '2024-02-02',
-            username: 'user1',
-          })
-          expect(auditService.viewedVisits).toHaveBeenCalledWith({
-            viewDate: '2024-02-02',
-            prisonId,
-            username: 'user1',
-            operationId: undefined,
-          })
-        })
-    })
-  })
-
-  // FIXME
-  describe.skip('Visits both with and without a session template', () => {
-    beforeEach(() => {
-      blockedDatesService.isBlockedDate.mockResolvedValue(false)
-      visitSessionsService.getSessionSchedule.mockResolvedValue(sessionSchedule)
       visitService.getVisitsBySessionTemplate.mockResolvedValue([])
       visitService.getVisitsWithoutSessionTemplate.mockResolvedValue(visits)
     })
@@ -448,35 +326,175 @@ describe('GET /visits - Visits by date page', () => {
           expect($('.moj-sub-navigation__link').eq(2).attr('aria-current')).toBe(undefined)
 
           // side-nav
-          expect($('.moj-side-navigation h4').eq(0).text()).toBe('Open visits')
-          expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('1:45pm to 3:45pm')
+          expect($('.moj-side-navigation h4').eq(0).text()).toBe('All visits')
+          expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('1:45pm to 3:45pm - All visits')
           expect($('.moj-side-navigation ul').eq(0).find('a').first().attr('href')).toBe(
-            '/visits?type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+            '/visits?sessionReference=13%3A45-15%3A45&selectedDate=2024-02-01&firstTabDate=2024-02-01',
           )
           expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
-            '/visits?type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
-          )
-
-          expect($('.moj-side-navigation h4').eq(1).text()).toBe('Closed visits')
-          expect($('.moj-side-navigation ul').eq(1).find('a').text()).toBe('1:45pm to 3:45pm')
-          expect($('.moj-side-navigation ul').eq(1).find('a').first().attr('href')).toBe(
-            '/visits?type=CLOSED&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
-          )
-
-          expect($('.moj-side-navigation h4').eq(2).text()).toBe('All visits')
-          expect($('.moj-side-navigation ul').eq(2).find('a').text()).toBe('1:45pm to 3:45pm')
-          expect($('.moj-side-navigation ul').eq(2).find('a').first().attr('href')).toBe(
-            '/visits?type=UNKNOWN&sessionReference=13%3A45-15%3A45&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+            '/visits?sessionReference=13%3A45-15%3A45&selectedDate=2024-02-01&firstTabDate=2024-02-01',
           )
 
           // Visits
-          expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 1:45pm to 3:45pm')
-          expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('0 of 20 tables booked')
-          expect($('[data-test="visit-visitors-total"]').length).toBe(0)
+          expect($('[data-test=visit-room-caption]').length).toBe(0)
+          expect($('h2').text()).toBe('Visits from 1:45pm to 3:45pm')
+
+          expect($('[data-test=visit-section-heading-closed]').length).toBe(0)
+          expect($('[data-test=visit-section-heading-open]').length).toBe(0)
+
+          expect($('[data-test=visit-section-heading-unknown]').text().trim()).toBe('All visits')
+          expect($('[data-test=visit-tables-booked-unknown]').text().trim()).toBe('1 table booked')
+          expect($('[data-test=visit-visitors-total-unknown]').text()).toBe('2 visitors')
+
+          expect($('[data-test=visits-unknown] [data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
+          expect($('[data-test=visits-unknown] [data-test="prisoner-number"]').eq(0).text()).toBe('A1234BC')
+          expect($('[data-test=visits-unknown] [data-test="booked-on"]').eq(0).text()).toBe('1 January at 9am')
+          expect($('[data-test=visits-unknown] [data-test="view-visit-link"]').eq(0).attr('href')).toBe(
+            '/visit/ab-cd-ef-gh?query=sessionReference%3D13%253A45-15%253A45%26selectedDate%3D2024-02-01%26firstTabDate%3D2024-02-01&from=visits',
+          )
 
           expect($('[data-test="no-visits-message"]').length).toBe(0)
 
-          expect(blockedDatesService.isBlockedDate).toHaveBeenCalledWith('HEI', '2024-02-01', 'user1')
+          expect(blockedDatesService.isBlockedDate).not.toHaveBeenCalled()
+          expect(visitNotificationsService.dateHasNotifications).not.toHaveBeenCalled()
+          expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            date: today,
+          })
+          expect(visitService.getVisitsBySessionTemplate).not.toHaveBeenCalled()
+          expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            sessionDate: today,
+          })
+          expect(auditService.viewedVisits).toHaveBeenCalledWith({
+            viewDate: today,
+            prisonId,
+            username: 'user1',
+            operationId: undefined,
+          })
+        })
+    })
+
+    it('should render date tabs, side-nav and visits for a specific unknown visits time slot reference', () => {
+      return request(app)
+        .get('/visits?type=UNKNOWN&sessionReference=13%3A45-15%3A45&selectedDate=2024-02-02&firstTabDate=2024-02-01')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('View visits by date')
+
+          // date tabs
+          expect($('.moj-sub-navigation__link').length).toBe(3)
+          expect($('.moj-sub-navigation__link').eq(1).attr('aria-current')).toBe('page')
+
+          // side-nav
+          expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
+            '/visits?sessionReference=13%3A45-15%3A45&selectedDate=2024-02-02&firstTabDate=2024-02-01',
+          )
+
+          // Visits
+          expect($('[data-test=visit-room-caption]').length).toBe(0)
+          expect($('h2').text()).toBe('Visits from 1:45pm to 3:45pm')
+
+          expect($('[data-test=visit-section-heading-closed]').length).toBe(0)
+          expect($('[data-test=visit-section-heading-open]').length).toBe(0)
+
+          expect($('[data-test=visit-section-heading-unknown]').text().trim()).toBe('All visits')
+          expect($('[data-test=visit-tables-booked-unknown]').text().trim()).toBe('1 table booked')
+          expect($('[data-test=visit-visitors-total-unknown]').text()).toBe('2 visitors')
+
+          expect($('[data-test=visits-unknown] [data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
+          expect($('[data-test=visits-unknown] [data-test="prisoner-number"]').eq(0).text()).toBe('A1234BC')
+          expect($('[data-test=visits-unknown] [data-test="booked-on"]').eq(0).text()).toBe('1 January at 9am')
+          expect($('[data-test=visits-unknown] [data-test="view-visit-link"]').eq(0).attr('href')).toBe(
+            '/visit/ab-cd-ef-gh?query=sessionReference%3D13%253A45-15%253A45%26selectedDate%3D2024-02-02%26firstTabDate%3D2024-02-01&from=visits',
+          )
+
+          expect($('[data-test="no-visits-message"]').length).toBe(0)
+
+          expect(blockedDatesService.isBlockedDate).not.toHaveBeenCalled()
+          expect(visitNotificationsService.dateHasNotifications).not.toHaveBeenCalled()
+          expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
+            username: 'user1',
+            prisonId,
+            date: '2024-02-02',
+          })
+          expect(visitService.getVisitsBySessionTemplate).not.toHaveBeenCalled()
+          expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
+            prisonId,
+            sessionDate: '2024-02-02',
+            username: 'user1',
+          })
+          expect(auditService.viewedVisits).toHaveBeenCalledWith({
+            viewDate: '2024-02-02',
+            prisonId,
+            username: 'user1',
+            operationId: undefined,
+          })
+        })
+    })
+  })
+
+  describe('Visits both with and without a session template', () => {
+    beforeEach(() => {
+      blockedDatesService.isBlockedDate.mockResolvedValue(false)
+      visitSessionsService.getSessionSchedule.mockResolvedValue(sessionSchedule)
+      visitService.getVisitsBySessionTemplate.mockResolvedValue(visits)
+      visitService.getVisitsWithoutSessionTemplate.mockResolvedValue(visits)
+    })
+
+    it('should render date tabs, side-nav and visits for default date (today)', () => {
+      return request(app)
+        .get('/visits')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('View visits by date')
+
+          // date tabs
+          expect($('.moj-sub-navigation__link').length).toBe(3)
+          expect($('.moj-sub-navigation__link').eq(2).attr('aria-current')).toBe(undefined)
+
+          // side-nav
+          expect($('.moj-side-navigation h4').eq(0).text()).toBe('Visits hall')
+          expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('1:45pm to 3:45pm - Visits hall')
+          expect($('.moj-side-navigation ul').eq(0).find('a').first().attr('href')).toBe(
+            '/visits?sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+          expect($('.moj-side-navigation__item--active a').attr('href')).toBe(
+            '/visits?sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+
+          expect($('.moj-side-navigation h4').eq(1).text()).toBe('All visits')
+          expect($('.moj-side-navigation ul').eq(1).find('a').text()).toBe('1:45pm to 3:45pm - All visits')
+          expect($('.moj-side-navigation ul').eq(1).find('a').first().attr('href')).toBe(
+            '/visits?sessionReference=13%3A45-15%3A45&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+          )
+
+          // Visits
+          expect($('[data-test=visit-room-caption]').text()).toBe('Visits hall')
+          expect($('h2').text()).toBe('Visits from 1:45pm to 3:45pm')
+
+          expect($('[data-test=visit-section-heading-closed]').text().trim()).toBe('Closed visits')
+          expect($('[data-test=visit-tables-booked-closed]').text().trim()).toBe('0 of 5 tables booked')
+          expect($('[data-test=visit-visitors-total-closed]').length).toBe(0)
+          expect($('[data-test=visits-closed]').length).toBe(0)
+
+          expect($('[data-test=visit-section-heading-open]').text().trim()).toBe('Open visits')
+          expect($('[data-test=visit-tables-booked-open]').text().trim()).toBe('1 of 20 tables booked')
+          expect($('[data-test=visit-visitors-total-open]').text()).toBe('2 visitors')
+
+          expect($('[data-test=visits-open] [data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
+
+          expect($('[data-test=visit-section-heading-unknown]').length).toBe(0)
+
+          expect($('[data-test="no-visits-message"]').length).toBe(0)
+
+          expect(blockedDatesService.isBlockedDate).not.toHaveBeenCalled()
           expect(visitNotificationsService.dateHasNotifications).not.toHaveBeenCalled()
           expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
             username: 'user1',
@@ -488,7 +506,6 @@ describe('GET /visits - Visits by date page', () => {
             prisonId,
             reference: sessionSchedule[0].sessionTemplateReference,
             sessionDate: today,
-            visitRestrictions: 'OPEN',
           })
           expect(visitService.getVisitsWithoutSessionTemplate).toHaveBeenCalledWith({
             username: 'user1',

--- a/server/routes/visitsByDate.ts
+++ b/server/routes/visitsByDate.ts
@@ -52,7 +52,11 @@ export default function routes({
     ])
 
     // identify if a session schedule has been selected or can be defaulted
-    const sessionSchedule = getSelectedOrDefaultSessionSchedule(sessionSchedulesForDay, selectedSessionReference)
+    const sessionSchedule = getSelectedOrDefaultSessionSchedule(
+      sessionSchedulesForDay,
+      selectedSessionReference,
+      unknownVisits,
+    )
 
     // side nav comprises sessions in schedule and those derived from 'unknown' visits
     const sessionsSideNav = getSessionsSideNav(
@@ -60,7 +64,7 @@ export default function routes({
       unknownVisits,
       selectedDateString,
       firstTabDateString,
-      selectedSessionReference || sessionSchedule?.sessionTemplateReference,
+      sessionSchedule?.sessionTemplateReference || selectedSessionReference,
     )
 
     // data structure for any possible set of visits

--- a/server/routes/visitsUtils.test.ts
+++ b/server/routes/visitsUtils.test.ts
@@ -113,28 +113,56 @@ describe('getSelectedOrDefaultSessionSchedule', () => {
       capacity: { open: 10, closed: 3 },
     }),
   ]
+  describe('with unknown visits not present', () => {
+    it('should return null if session schedule empty', () => {
+      const result = getSelectedOrDefaultSessionSchedule([], '', [])
+      expect(result).toBe(null)
+    })
 
-  it('should return null if session schedule empty', () => {
-    const result = getSelectedOrDefaultSessionSchedule([], '')
-    expect(result).toBe(null)
+    it('should default to the first session schedule', () => {
+      const sessionReference: string = undefined
+      const result = getSelectedOrDefaultSessionSchedule(sessionSchedule, sessionReference, [])
+      expect(result).toStrictEqual(sessionSchedule[0])
+    })
+
+    it('should return selected session schedule if present', () => {
+      const sessionReference: string = sessionSchedule[1].sessionTemplateReference
+      const result = getSelectedOrDefaultSessionSchedule(sessionSchedule, sessionReference, [])
+      expect(result).toStrictEqual(sessionSchedule[1])
+    })
+
+    it('should return default if invalid session reference given', () => {
+      const sessionReference: string = 'invalid reference'
+      const result = getSelectedOrDefaultSessionSchedule(sessionSchedule, sessionReference, [])
+      expect(result).toStrictEqual(sessionSchedule[0])
+    })
   })
 
-  it('should default to the first session schedule', () => {
-    const sessionReference: string = undefined
-    const result = getSelectedOrDefaultSessionSchedule(sessionSchedule, sessionReference)
-    expect(result).toStrictEqual(sessionSchedule[0])
-  })
+  describe('with unknown visits present', () => {
+    const unknownVisits = [
+      TestData.visitPreview({ visitTimeSlot: { startTime: '09:00', endTime: '10:00' } }),
+      TestData.visitPreview({ visitTimeSlot: { startTime: '10:00', endTime: '11:00' } }),
+    ]
 
-  it('should return selected session schedule if present', () => {
-    const sessionReference: string = sessionSchedule[1].sessionTemplateReference
-    const result = getSelectedOrDefaultSessionSchedule(sessionSchedule, sessionReference)
-    expect(result).toStrictEqual(sessionSchedule[1])
-  })
+    it('should return null if reference matches an unknown visit time slot - empty session schedule', () => {
+      const result = getSelectedOrDefaultSessionSchedule([], '09:00-10:00', unknownVisits)
+      expect(result).toBe(null)
+    })
 
-  it('should return default if invalid session reference given', () => {
-    const sessionReference: string = 'invalid reference'
-    const result = getSelectedOrDefaultSessionSchedule(sessionSchedule, sessionReference)
-    expect(result).toStrictEqual(sessionSchedule[0])
+    it('should return null if reference does not match an unknown visit time slot - empty session schedule', () => {
+      const result = getSelectedOrDefaultSessionSchedule([], 'invalid-time-slot', unknownVisits)
+      expect(result).toBe(null)
+    })
+
+    it('should return null if reference matches an unknown visit time slot - with a session schedule', () => {
+      const result = getSelectedOrDefaultSessionSchedule(sessionSchedule, '09:00-10:00', unknownVisits)
+      expect(result).toBe(null)
+    })
+
+    it('should return to default of first session schedule if reference does not match an unknown visit time slot - with a session schedule', () => {
+      const result = getSelectedOrDefaultSessionSchedule(sessionSchedule, 'invalid-time-slot', unknownVisits)
+      expect(result).toStrictEqual(sessionSchedule[0])
+    })
   })
 })
 

--- a/server/routes/visitsUtils.ts
+++ b/server/routes/visitsUtils.ts
@@ -39,8 +39,13 @@ export const getDateTabs = (
 export function getSelectedOrDefaultSessionSchedule(
   sessionSchedule: SessionSchedule[],
   sessionReference: string,
+  unknownVisits: VisitPreview[],
 ): SessionSchedule {
-  if (!sessionSchedule.length) {
+  const isValidUnknownVisitTimeSlot = unknownVisits.some(
+    visit => `${visit.visitTimeSlot.startTime}-${visit.visitTimeSlot.endTime}` === sessionReference,
+  )
+
+  if (!sessionSchedule.length || isValidUnknownVisitTimeSlot) {
     return null
   }
 

--- a/server/routes/visitsUtils.ts
+++ b/server/routes/visitsUtils.ts
@@ -1,7 +1,7 @@
 import { format, parse, add } from 'date-fns'
 import { VisitsPageSideNav, VisitsPageSideNavItem } from '../@types/bapv'
 import { getParsedDateFromQueryString, prisonerTimePretty } from '../utils/utils'
-import { SessionSchedule, VisitPreview, VisitRestriction } from '../data/orchestrationApiTypes'
+import { SessionSchedule, VisitPreview } from '../data/orchestrationApiTypes'
 
 export const getDateTabs = (
   selectedDate: string,
@@ -36,54 +36,17 @@ export const getDateTabs = (
   return tabs
 }
 
-export function getSelectedOrDefaultSessionTemplate(
+export function getSelectedOrDefaultSessionSchedule(
   sessionSchedule: SessionSchedule[],
   sessionReference: string,
-  type: VisitRestriction,
-): { sessionReference: string; type: VisitRestriction; times: string; capacity: number } | null {
-  if (type === 'UNKNOWN') {
+): SessionSchedule {
+  if (!sessionSchedule.length) {
     return null
   }
 
-  // it's the selected session if reference, type (open/closed) match and a capacity is set
-  const selectedSession = sessionSchedule.find(
-    schedule =>
-      schedule.sessionTemplateReference === sessionReference &&
-      schedule.capacity[<Lowercase<typeof type>>type.toLowerCase()] > 0,
-  )
-  if (selectedSession) {
-    return {
-      sessionReference: selectedSession.sessionTemplateReference,
-      type,
-      times: sessionTimeSlotToString(selectedSession.sessionTimeSlot),
-      capacity: selectedSession.capacity[<Lowercase<typeof type>>type.toLowerCase()],
-    }
-  }
+  const selectedSessionSchedule = sessionSchedule.find(session => session.sessionTemplateReference === sessionReference)
 
-  // default session is first open one in schedule with capacity...
-  const defaultOpenSession = sessionSchedule.find(schedule => schedule.capacity.open > 0)
-  if (defaultOpenSession) {
-    return {
-      sessionReference: defaultOpenSession.sessionTemplateReference,
-      type: 'OPEN',
-      times: sessionTimeSlotToString(defaultOpenSession.sessionTimeSlot),
-      capacity: defaultOpenSession.capacity.open,
-    }
-  }
-
-  // ...or else the first closed with capacity
-  const defaultClosedSession = sessionSchedule.find(schedule => schedule.capacity.closed > 0)
-  if (defaultClosedSession) {
-    return {
-      sessionReference: defaultClosedSession.sessionTemplateReference,
-      type: 'CLOSED',
-      times: sessionTimeSlotToString(defaultClosedSession.sessionTimeSlot),
-      capacity: defaultClosedSession.capacity.closed,
-    }
-  }
-
-  // there are no sessions
-  return null
+  return selectedSessionSchedule ?? sessionSchedule[0]
 }
 
 export function getSessionsSideNav(

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -303,7 +303,7 @@ describe('Visit service', () => {
       it('should return visit previews for given session template reference, date, prison and restriction', async () => {
         const reference = 'v9d.7ed.7u'
         const sessionDate = '2024-01-31'
-        const visitRestrictions: VisitRestriction = 'OPEN'
+        const visitRestrictions: VisitRestriction[] = ['OPEN', 'CLOSED']
         const visitPreviews = [TestData.visitPreview()]
 
         orchestrationApiClient.getVisitsBySessionTemplate.mockResolvedValue(visitPreviews)
@@ -313,7 +313,6 @@ describe('Visit service', () => {
           prisonId,
           reference,
           sessionDate,
-          visitRestrictions,
         })
 
         expect(orchestrationApiClient.getVisitsBySessionTemplate).toHaveBeenCalledWith(

--- a/server/services/visitService.ts
+++ b/server/services/visitService.ts
@@ -8,7 +8,6 @@ import {
   Visit,
   VisitHistoryDetails,
   VisitPreview,
-  VisitRestriction,
 } from '../data/orchestrationApiTypes'
 import { buildVisitorListItem } from '../utils/visitorUtils'
 import { HmppsAuthClient, OrchestrationApiClient, PrisonerContactRegistryApiClient, RestClientBuilder } from '../data'
@@ -153,18 +152,16 @@ export default class VisitService {
     prisonId,
     reference,
     sessionDate,
-    visitRestrictions,
   }: {
     username: string
     prisonId: string
     reference: string
     sessionDate: string
-    visitRestrictions: VisitRestriction
   }): Promise<VisitPreview[]> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
-    return orchestrationApiClient.getVisitsBySessionTemplate(prisonId, reference, sessionDate, visitRestrictions)
+    return orchestrationApiClient.getVisitsBySessionTemplate(prisonId, reference, sessionDate, ['OPEN', 'CLOSED'])
   }
 
   async getVisitsWithoutSessionTemplate({

--- a/server/views/pages/visitsByDate/visitsByDate.njk
+++ b/server/views/pages/visitsByDate/visitsByDate.njk
@@ -13,10 +13,86 @@
   {{ breadcrumbs() }}
 {% endblock %}
 
+{% macro renderVisitsSection(visitsSection, type) %}
+  {% if visitsSection.capacity %}
+    <h3 class="govuk-heading-m">{{ "all" if type == "unknown" else type | capitalize }} visits</h3>
+    <p data-test="visit-tables-booked-{{ type}}">
+      {{ visitsSection.visits | length }}{{ (" of " + visitsSection.capacity) if visitsSection.capacity }} {{ "table" | pluralise(visitsSection.capacity or visitsSection.visits | length)}} booked
+    </p>
+
+    {% if visitsSection.visits | length %}
+      <p data-test="visit-visitors-total-{{ type}}">
+        {{ visitsSection.numVisitors }} {{ "visitor" | pluralise(visitsSection.numVisitors) }}
+      </p>
+
+      {% set visitsRows = [] %}
+      {% for visit in visitsSection.visits %}
+        {% set visitsRows = (visitsRows.push([
+          {
+            text: visit.lastName | capitalize + ", " + visit.firstName | capitalize,
+            attributes: { "data-test": "prisoner-name" }
+          },
+          {
+            text: visit.prisonerId,
+            attributes: { "data-test": "prisoner-number" }
+          },
+          {
+            text: visit.firstBookedDateTime | formatDate("d MMMM") +
+              " at " + visit.firstBookedDateTime | formatTime,
+            attributes: {
+              "data-test": "booked-on",
+              "data-sort-value": visit.firstBookedDateTime | formatDate("t")
+            }
+          },
+          {
+            classes: "govuk-!-text-align-right",
+            html: '<a href="/visit/' + visit.visitReference + '?' + queryParamsForBackLink +
+              '" class="govuk-link--no-visited-state" data-test="view-visit-link">View</a>'
+          }
+        ]), visitsRows) %}
+      {% endfor %}
+
+        {{ govukTable({
+          attributes: {
+            "data-module": "moj-sortable-table",
+            "data-test": type + "-visits"
+          },
+          classes: "bapv-table govuk-!-margin-top-3",
+          head: [
+            {
+              text: "Prisoner name",
+              attributes: {
+                "aria-sort": "none"
+              }
+            },
+            {
+              text: "Prison number",
+              attributes: {
+                "aria-sort": "none"
+              }
+            },
+            {
+              text: "Booked on",
+              attributes: {
+                "aria-sort": "descending",
+                "data-test": "header-booked-on"
+              }
+            },
+            {
+              text: "Action",
+              classes: "govuk-!-text-align-right"
+            }
+          ],
+          rows: visitsRows
+        }) }}
+    {% endif %}
+  {% endif %}
+{% endmacro %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
+      <h1 class="govuk-heading-xl">{{ pageHeaderTitle }}</h1>
       {% include "partials/errorSummary.njk" %}
     </div>
   </div>
@@ -78,11 +154,11 @@
           {% set sectionItems = [] %}
           {% for item in items %}
             {% set sectionItems = (sectionItems.push({
-                text: item.times,
+                html: item.times + '<span class="govuk-visually-hidden"> - ' + heading | escape + '</span>',
                 href: "/visits?" + item.queryParams,
                 active: item.active
               }), sectionItems) %}
-              {% set selectedTimeSlotLabel = item.times if item.active else selectedTimeSlotLabel %}
+            {% set selectedTimeSlotLabel = item.times if item.active else selectedTimeSlotLabel %}
           {% endfor %}
           {% set sessionSideNavSections = (sessionSideNavSections.push({
             heading: {
@@ -102,15 +178,16 @@
     {% endif %}
 
     <div class="govuk-grid-column-three-quarters">
-
       {% if sessionsSideNav | length %}
-        <h2 class="govuk-heading-m" data-test="visit-session-heading">
-          {{ (selectedSessionTemplate.type or "all") | capitalize }} visits, {{ selectedTimeSlotLabel }}
-        </h2>
+        {% if selectedSessionSchedule %}
+          <span class="govuk-caption-l">{{ selectedSessionSchedule.visitRoom }}</span>
+        {% endif %}
+        <h2 class="govuk-heading-l">Visits from {{ selectedTimeSlotLabel }}</h2>
 
-        <p data-test="visit-tables-booked">
-          {{ visits | length }}{{ (" of " + selectedSessionTemplate.capacity) if selectedSessionTemplate.capacity }} {{ "table" | pluralise(selectedSessionTemplate.capacity or visits | length)}} booked
-        </p>
+        {{ renderVisitsSection(visits.CLOSED, 'closed') }}
+        {{ renderVisitsSection(visits.OPEN, 'open') }}
+        {{ renderVisitsSection(visits.UNKNOWN, 'unknown') }}
+
       {% else %}
         <p class="govuk-!-margin-top-0" data-test="no-visits-message">
           {% if isAnExcludeDateWithVisitNotifications %}
@@ -121,71 +198,6 @@
             No visit sessions on this day.
           {% endif %}
         </p>
-      {% endif %}
-
-      {% if visits | length %}
-        <p data-test="visit-visitors-total">
-          {{ visitorsTotal }} {{ "visitor" | pluralise(visitorsTotal) }}
-        </p>
-
-        {% set visitsRows = [] %}
-        {% for visit in visits %}
-          {% set visitsRows = (visitsRows.push([
-            {
-              text: visit.lastName | capitalize + ", " + visit.firstName | capitalize,
-              attributes: { "data-test": "prisoner-name" }
-            },
-            {
-              text: visit.prisonerId,
-              attributes: { "data-test": "prisoner-number" }
-            },
-            {
-              text: visit.firstBookedDateTime | formatDate("d MMMM") +
-                " at " + visit.firstBookedDateTime | formatTime,
-              attributes: {
-                "data-test": "booked-on",
-                "data-sort-value": visit.firstBookedDateTime | formatDate("t")
-              }
-            },
-            {
-              classes: "govuk-!-text-align-right",
-              html: '<a href="/visit/' + visit.visitReference + '?' + queryParamsForBackLink +
-                '" class="govuk-link--no-visited-state" data-test="view-visit-link">View</a>'
-            }
-          ]), visitsRows) %}
-        {% endfor %}
-        {{ govukTable({
-          attributes: {
-            "data-module": "moj-sortable-table"
-          },
-          classes: "bapv-table govuk-!-margin-top-3",
-          head: [
-            {
-              text: "Prisoner name",
-              attributes: {
-                "aria-sort": "none"
-              }
-            },
-            {
-              text: "Prison number",
-              attributes: {
-                "aria-sort": "none"
-              }
-            },
-            {
-              text: "Booked on",
-              attributes: {
-                "aria-sort": "descending",
-                "data-test": "header-booked-on"
-              }
-            },
-            {
-              text: "Action",
-              classes: "govuk-!-text-align-right"
-            }
-          ],
-          rows: visitsRows
-        }) }}
       {% endif %}
     </div>
   </div>

--- a/server/views/pages/visitsByDate/visitsByDate.njk
+++ b/server/views/pages/visitsByDate/visitsByDate.njk
@@ -18,14 +18,17 @@
   {% set capacity = sessionSchedule.capacity[type] %}
 
   {% if capacity or (visitsSection.visits | length) %}
-    <h3 class="govuk-heading-m govuk-!-margin-top-7">{{ ("all" if type == "unknown" else type) | capitalize }} visits</h3>
+    <h3 class="govuk-heading-m govuk-!-margin-top-7" data-test="visit-section-heading-{{ type }}">
+      {{- ("all" if type == "unknown" else type) | capitalize }} visits
+    </h3>
+
     <p data-test="visit-tables-booked-{{ type}}">
       {{ visitsSection.visits | length }}{{ (" of " + capacity) if capacity }} {{ "table" | pluralise(capacity or visitsSection.visits | length)}} booked
     </p>
 
     {% if visitsSection.visits | length %}
       <p data-test="visit-visitors-total-{{ type}}">
-        {{ visitsSection.numVisitors }} {{ "visitor" | pluralise(visitsSection.numVisitors) }}
+        {{- visitsSection.numVisitors }} {{ "visitor" | pluralise(visitsSection.numVisitors) -}}
       </p>
 
       {% set visitsRows = [] %}
@@ -58,7 +61,7 @@
         {{ govukTable({
           attributes: {
             "data-module": "moj-sortable-table",
-            "data-test": type + "-visits"
+            "data-test": "visits-" + type
           },
           classes: "bapv-table govuk-!-margin-top-3 govuk-!-margin-bottom-9",
           head: [

--- a/server/views/pages/visitsByDate/visitsByDate.njk
+++ b/server/views/pages/visitsByDate/visitsByDate.njk
@@ -13,11 +13,14 @@
   {{ breadcrumbs() }}
 {% endblock %}
 
-{% macro renderVisitsSection(visitsSection, type) %}
-  {% if visitsSection.capacity %}
-    <h3 class="govuk-heading-m">{{ "all" if type == "unknown" else type | capitalize }} visits</h3>
+{% macro renderVisitsSection(type) %}
+  {% set visitsSection = visits[type | upper] %}
+  {% set capacity = sessionSchedule.capacity[type] %}
+
+  {% if capacity or (visitsSection.visits | length) %}
+    <h3 class="govuk-heading-m govuk-!-margin-top-7">{{ ("all" if type == "unknown" else type) | capitalize }} visits</h3>
     <p data-test="visit-tables-booked-{{ type}}">
-      {{ visitsSection.visits | length }}{{ (" of " + visitsSection.capacity) if visitsSection.capacity }} {{ "table" | pluralise(visitsSection.capacity or visitsSection.visits | length)}} booked
+      {{ visitsSection.visits | length }}{{ (" of " + capacity) if capacity }} {{ "table" | pluralise(capacity or visitsSection.visits | length)}} booked
     </p>
 
     {% if visitsSection.visits | length %}
@@ -57,7 +60,7 @@
             "data-module": "moj-sortable-table",
             "data-test": type + "-visits"
           },
-          classes: "bapv-table govuk-!-margin-top-3",
+          classes: "bapv-table govuk-!-margin-top-3 govuk-!-margin-bottom-9",
           head: [
             {
               text: "Prisoner name",
@@ -179,14 +182,14 @@
 
     <div class="govuk-grid-column-three-quarters">
       {% if sessionsSideNav | length %}
-        {% if selectedSessionSchedule %}
-          <span class="govuk-caption-l">{{ selectedSessionSchedule.visitRoom }}</span>
+        {% if sessionSchedule %}
+          <span class="govuk-caption-l" data-test="visit-room-caption">{{ sessionSchedule.visitRoom }}</span>
         {% endif %}
         <h2 class="govuk-heading-l">Visits from {{ selectedTimeSlotLabel }}</h2>
 
-        {{ renderVisitsSection(visits.CLOSED, 'closed') }}
-        {{ renderVisitsSection(visits.OPEN, 'open') }}
-        {{ renderVisitsSection(visits.UNKNOWN, 'unknown') }}
+        {{ renderVisitsSection('closed') }}
+        {{ renderVisitsSection('open') }}
+        {{ renderVisitsSection('unknown') }}
 
       {% else %}
         <p class="govuk-!-margin-top-0" data-test="no-visits-message">

--- a/server/views/pages/visitsByDate/visitsByDate.test.ts
+++ b/server/views/pages/visitsByDate/visitsByDate.test.ts
@@ -5,7 +5,7 @@ import { registerNunjucks } from '../../../utils/nunjucksSetup'
 import TestData from '../../../routes/testutils/testData'
 import { VisitsPageSideNav } from '../../../@types/bapv'
 import { VisitPreview } from '../../../data/orchestrationApiTypes'
-import { type getSelectedOrDefaultSessionTemplate } from '../../../routes/visitsUtils'
+import { type getSelectedOrDefaultSessionSchedule } from '../../../routes/visitsUtils'
 
 const template = fs.readFileSync('server/views/pages/visitsByDate/visitsByDate.njk')
 
@@ -95,7 +95,7 @@ describe('Views - Visits by date', () => {
       ],
     ])
 
-    const selectedSessionTemplate: ReturnType<typeof getSelectedOrDefaultSessionTemplate> = {
+    const selectedSessionTemplate: ReturnType<typeof getSelectedOrDefaultSessionSchedule> = {
       sessionReference: 'ref-1',
       type: 'OPEN',
       times: '10am to 11am',
@@ -177,7 +177,7 @@ describe('Views - Visits by date', () => {
       ],
     ])
 
-    const selectedSessionTemplate: ReturnType<typeof getSelectedOrDefaultSessionTemplate> = {
+    const selectedSessionTemplate: ReturnType<typeof getSelectedOrDefaultSessionSchedule> = {
       sessionReference: 'ref-1',
       type: 'OPEN',
       times: '10am to 11am',

--- a/server/views/pages/visitsByDate/visitsByDate.test.ts
+++ b/server/views/pages/visitsByDate/visitsByDate.test.ts
@@ -4,8 +4,7 @@ import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../utils/nunjucksSetup'
 import TestData from '../../../routes/testutils/testData'
 import { VisitsPageSideNav } from '../../../@types/bapv'
-import { VisitPreview } from '../../../data/orchestrationApiTypes'
-import { type getSelectedOrDefaultSessionSchedule } from '../../../routes/visitsUtils'
+import { VisitPreview, VisitRestriction } from '../../../data/orchestrationApiTypes'
 
 const template = fs.readFileSync('server/views/pages/visitsByDate/visitsByDate.njk')
 
@@ -67,15 +66,14 @@ describe('Views - Visits by date', () => {
     expect($('.bapv-table').length).toBe(0)
   })
 
-  it('should display side-nav and session heading when session schedule set but no visits', () => {
+  it('should display side-nav and session headings when session schedule set but no visits', () => {
     const sessionsSideNav: VisitsPageSideNav = new Map([
       [
         'Visits hall',
         [
           {
-            times: '10am to 11am',
             reference: 'ref-1',
-            capacity: 20,
+            times: '10am to 11am',
             queryParams: 'query-1',
             active: true,
           },
@@ -85,9 +83,8 @@ describe('Views - Visits by date', () => {
         'Visits hall 2',
         [
           {
-            times: '2pm to 3pm',
             reference: 'ref-2',
-            capacity: 10,
+            times: '2pm to 3pm',
             queryParams: 'query-2',
             active: false,
           },
@@ -95,44 +92,50 @@ describe('Views - Visits by date', () => {
       ],
     ])
 
-    const selectedSessionTemplate: ReturnType<typeof getSelectedOrDefaultSessionSchedule> = {
-      sessionReference: 'ref-1',
-      type: 'OPEN',
-      times: '10am to 11am',
-      capacity: 20,
-    }
+    const sessionSchedule = TestData.sessionSchedule({
+      sessionTemplateReference: 'ref-1',
+      sessionTimeSlot: { startTime: '10:00', endTime: '11:00' },
+      capacity: { open: 20, closed: 5 },
+    })
     const queryParamsForBackLink = 'back-link-query'
-    const visits: VisitPreview[] = []
-    const visitorsTotal = 0
+    const visits: Record<VisitRestriction, { numVisitors: number; visits: VisitPreview[] }> = {
+      CLOSED: { numVisitors: 0, visits: [] },
+      OPEN: { numVisitors: 0, visits: [] },
+      UNKNOWN: { numVisitors: 0, visits: [] },
+    }
 
     viewContext = {
-      selectedSessionTemplate,
+      sessionSchedule,
       sessionsSideNav,
       queryParamsForBackLink,
       visits,
-      visitorsTotal,
     }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
     expect($('.moj-side-navigation h4').eq(0).text()).toBe('Visits hall')
-    expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('10am to 11am')
+    expect($('.moj-side-navigation ul').eq(0).find('a').text()).toBe('10am to 11am - Visits hall')
     expect($('.moj-side-navigation ul').eq(0).find('a').first().attr('href')).toBe('/visits?query-1')
     expect($('.moj-side-navigation__item--active a').attr('href')).toBe('/visits?query-1')
 
     expect($('.moj-side-navigation h4').eq(1).text()).toBe('Visits hall 2')
-    expect($('.moj-side-navigation ul').eq(1).find('a').first().text()).toBe('2pm to 3pm')
+    expect($('.moj-side-navigation ul').eq(1).find('a').first().text()).toBe('2pm to 3pm - Visits hall 2')
     expect($('.moj-side-navigation ul').eq(1).find('a').first().attr('href')).toBe('/visits?query-2')
 
-    expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 10am to 11am')
-    expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('0 of 20 tables booked')
-    expect($('[data-test="visit-visitors-total"]').length).toBe(0)
+    expect($('[data-test=visit-room-caption]').text()).toBe('Visits hall')
+    expect($('h2').text()).toBe('Visits from 10am to 11am')
+    expect($('[data-test=visit-section-heading-closed]').text().trim()).toBe('Closed visits')
+    expect($('[data-test=visit-tables-booked-closed]').text().trim()).toBe('0 of 5 tables booked')
+    expect($('[data-test=visit-visitors-total-closed]').length).toBe(0)
+    expect($('[data-test=visit-section-heading-open]').text().trim()).toBe('Open visits')
+    expect($('[data-test=visit-tables-booked-open]').text().trim()).toBe('0 of 20 tables booked')
+    expect($('[data-test=visit-visitors-total-open]').length).toBe(0)
 
     expect($('[data-test="no-visits-message"]').length).toBe(0)
   })
 
   it('should display appropriate message for an exclude date with no visits', () => {
-    viewContext = { visits: [], isAnExcludeDate: true, isAnExcludeDateWithVisitNotifications: false }
+    viewContext = { visits: {}, isAnExcludeDate: true, isAnExcludeDateWithVisitNotifications: false }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
@@ -146,7 +149,7 @@ describe('Views - Visits by date', () => {
   it('should display appropriate message for an exclude date with visits that need review', () => {
     viewContext = {
       queryParamsForBackLink: 'back-link-params',
-      visits: [],
+      visits: {},
       isAnExcludeDate: true,
       isAnExcludeDateWithVisitNotifications: true,
     }
@@ -167,9 +170,8 @@ describe('Views - Visits by date', () => {
         'Visits hall',
         [
           {
-            times: '10am to 11am',
             reference: 'ref-1',
-            capacity: 20,
+            times: '10am to 11am',
             queryParams: 'query-1',
             active: true,
           },
@@ -177,28 +179,31 @@ describe('Views - Visits by date', () => {
       ],
     ])
 
-    const selectedSessionTemplate: ReturnType<typeof getSelectedOrDefaultSessionSchedule> = {
-      sessionReference: 'ref-1',
-      type: 'OPEN',
-      times: '10am to 11am',
-      capacity: 20,
-    }
+    const sessionSchedule = TestData.sessionSchedule({
+      sessionTemplateReference: 'ref-1',
+      sessionTimeSlot: { startTime: '10:00', endTime: '11:00' },
+    })
     const queryParamsForBackLink = 'back-link-query'
-    const visits = [TestData.visitPreview()]
-    const visitorsTotal = 2
+    const visits: Record<VisitRestriction, { numVisitors: number; visits: VisitPreview[] }> = {
+      CLOSED: { numVisitors: 0, visits: [] },
+      OPEN: { numVisitors: 2, visits: [TestData.visitPreview()] },
+      UNKNOWN: { numVisitors: 0, visits: [] },
+    }
 
-    viewContext = { selectedSessionTemplate, sessionsSideNav, queryParamsForBackLink, visits, visitorsTotal }
+    viewContext = { sessionSchedule, sessionsSideNav, queryParamsForBackLink, visits }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('[data-test="visit-session-heading"]').text().trim()).toBe('Open visits, 10am to 11am')
-    expect($('[data-test="visit-tables-booked"]').text().trim()).toBe('1 of 20 tables booked')
-    expect($('[data-test="visit-visitors-total"]').text().trim()).toBe('2 visitors')
+    expect($('[data-test=visit-section-heading-open]').text().trim()).toBe('Open visits')
+    expect($('[data-test=visit-tables-booked-open]').text().trim()).toBe('1 of 40 tables booked')
+    expect($('[data-test=visit-visitors-total-open]').text()).toBe('2 visitors')
 
-    expect($('[data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
-    expect($('[data-test="prisoner-number"]').eq(0).text()).toBe('A1234BC')
-    expect($('[data-test="booked-on"]').eq(0).text()).toBe('1 January at 9am')
-    expect($('[data-test="view-visit-link"]').eq(0).attr('href')).toBe('/visit/ab-cd-ef-gh?back-link-query')
+    expect($('[data-test=visits-open] [data-test="prisoner-name"]').eq(0).text()).toBe('Smith, John')
+    expect($('[data-test=visits-open] [data-test="prisoner-number"]').eq(0).text()).toBe('A1234BC')
+    expect($('[data-test=visits-open] [data-test="booked-on"]').eq(0).text()).toBe('1 January at 9am')
+    expect($('[data-test=visits-open] [data-test="view-visit-link"]').eq(0).attr('href')).toBe(
+      '/visit/ab-cd-ef-gh?back-link-query',
+    )
 
     expect($('[data-test="no-visits-message"]').length).toBe(0)
   })


### PR DESCRIPTION
* Show both open and closed sections for a given selected session template (unless capacity is zero)
* Handle `UNKNOWN` (labelled 'All') visits