### PR TITLE
VB-5149, filter notifications on visit details page

### DIFF
--- a/integration_tests/e2e/reviewAVisit.cy.ts
+++ b/integration_tests/e2e/reviewAVisit.cy.ts
@@ -26,7 +26,7 @@ context('Review a visit', () => {
       createTimestamp: '2024-04-11T09:00:00',
     },
     {
-      type: 'NON_ASSOCIATION_EVENT',
+      type: 'PRISONER_RECEIVED_EVENT',
       applicationMethodType: 'NOT_APPLICABLE',
       actionedByFullName: '',
       userType: 'SYSTEM',
@@ -57,14 +57,14 @@ context('Review a visit', () => {
     cy.task('stubVisitHistory', visitHistoryDetails)
     cy.task('stubPrisonerSocialContacts', { offenderNo, contacts, approvedVisitorsOnly: false })
 
-    const notifications: NotificationType[] = ['NON_ASSOCIATION_EVENT']
+    const notifications: NotificationType[] = ['PRISONER_RECEIVED_EVENT']
     cy.task('stubGetVisitNotifications', { reference: visitHistoryDetails.visit.reference, notifications })
 
     // Start on booking summary page and chose 'Do not change' button
     cy.visit('/visit/ab-cd-ef-gh')
     const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
-    visitDetailsPage.visitNotification().eq(0).contains(notificationTypeWarnings.NON_ASSOCIATION_EVENT)
-    visitDetailsPage.needsReview(1).contains(notificationTypes.NON_ASSOCIATION_EVENT)
+    visitDetailsPage.visitNotification().eq(0).contains(notificationTypeWarnings.PRISONER_RECEIVED_EVENT)
+    visitDetailsPage.needsReview(1).contains(notificationTypes.PRISONER_RECEIVED_EVENT)
     visitDetailsPage.clearNotifications().click()
 
     // Clear notifications page - select Yes and give a reason

--- a/integration_tests/e2e/visitDetails.cy.ts
+++ b/integration_tests/e2e/visitDetails.cy.ts
@@ -228,7 +228,7 @@ context('Visit details page', () => {
     visitDetailsPage.selectHistoryTab()
     visitDetailsPage.eventHeader(1).contains('Needs review')
     visitDetailsPage.eventTime(1).contains('Saturday 1 January 2022 at 11am')
-    visitDetailsPage.needsReview(1).contains('Reason: Non-association')
+    visitDetailsPage.needsReview(1).contains('Reason: Time slot removed')
     visitDetailsPage.actionedBy(2).contains('User Two')
     visitDetailsPage.eventHeader(2).contains('Updated')
     visitDetailsPage.eventTime(2).contains('Saturday 1 January 2022 at 10am')

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -445,8 +445,12 @@ describe('orchestrationApiClient', () => {
   })
 
   describe('getVisitNotifications', () => {
-    it('should return notifications for a given visit reference', async () => {
-      const notifications: NotificationType[] = ['NON_ASSOCIATION_EVENT']
+    it('should return filtered notifications for a given visit reference', async () => {
+      const notifications: NotificationType[] = [
+        'NON_ASSOCIATION_EVENT', // should be filtered
+        'PRISONER_RELEASED_EVENT',
+        'PRISON_VISITS_BLOCKED_FOR_DATE',
+      ]
 
       fakeOrchestrationApi
         .get(`/visits/notification/visit/ab-cd-ef-gh/types`)
@@ -455,7 +459,7 @@ describe('orchestrationApiClient', () => {
 
       const output = await orchestrationApiClient.getVisitNotifications('ab-cd-ef-gh')
 
-      expect(output).toStrictEqual(notifications)
+      expect(output).toStrictEqual([notifications[1], notifications[2]])
     })
   })
 

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -191,7 +191,13 @@ export default class OrchestrationApiClient {
   }
 
   async getVisitNotifications(reference: string): Promise<NotificationType[]> {
-    return this.restClient.get({ path: `/visits/notification/visit/${reference}/types` })
+    const { enabledNotifications } = config.features.notificationTypes
+
+    const notifications = await this.restClient.get<NotificationType[]>({
+      path: `/visits/notification/visit/${reference}/types`,
+    })
+
+    return notifications.filter(notification => enabledNotifications.includes(notification))
   }
 
   // orchestration-prisons-exclude-date-controller

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -468,7 +468,7 @@ export default class TestData {
         createTimestamp: '2022-01-01T10:00:00',
       },
       {
-        type: 'NON_ASSOCIATION_EVENT',
+        type: 'PRISON_VISITS_BLOCKED_FOR_DATE',
         applicationMethodType: 'NOT_APPLICABLE',
         actionedByFullName: '',
         userType: 'SYSTEM',

--- a/server/routes/visit/visitDetailsController.test.ts
+++ b/server/routes/visit/visitDetailsController.test.ts
@@ -150,7 +150,7 @@ describe('Visit details page', () => {
           expect($('[data-test="visit-actioned-by-1"]').text().trim()).toBe('') // no actioned by on needs review event
           expect($('[data-test="visit-event-date-time-1"]').text()).toBe('Saturday 1 January 2022 at 11am')
           expect($('[data-test="visit-request-method-1"]').length).toBe(0) // no request method on needs review event
-          expect($('[data-test="visit-needs-review-description-1"]').text()).toBe('Reason: Non-association')
+          expect($('[data-test="visit-needs-review-description-1"]').text()).toBe('Reason: Time slot removed')
           // second event
           expect($('[data-test="visit-event-2"]').text()).toBe('Updated')
           expect($('[data-test="visit-actioned-by-2"]').text().trim().replace(/\s+/g, ' ')).toBe('by User Two')


### PR DESCRIPTION
filter notifications on `getVisitNotifications` - so the `Visit details` page won't display them

 (they're already hidden on `Needs review` page)