### PR TITLE
Enable deployment to deploy dev & staging environments in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,10 @@ workflows:
           <<: *feature_branch
           type: approval
           requires:
-            - deploy_dev_preview
+            - helm_lint
+            - unit_test
+            - integration_test
+            - build_docker
       - hmpps/deploy_env:
           <<: *feature_branch
           name: deploy_staging_preview
@@ -255,7 +258,10 @@ workflows:
           <<: *feature_branch
           type: approval
           requires:
-            - deploy_staging_preview
+            - helm_lint
+            - unit_test
+            - integration_test
+            - build_docker
       - hmpps/deploy_env:
           <<: *feature_branch
           name: deploy_preprod_preview
@@ -278,13 +284,17 @@ workflows:
             - build_docker
 
       - hmpps/deploy_env:
+          <<: *main_branch
           name: deploy_staging
           env: "staging"
           context:
             - hmpps-common-vars
             - book-a-prison-visit-staff-ui-stage
           requires:
-            - deploy_dev
+            - helm_lint
+            - unit_test
+            - integration_test
+            - build_docker
 
       - request-acceptance-tests-approval:
           <<: *main_branch


### PR DESCRIPTION
Avoid unnecessary waiting when deploying.