### PR TITLE
VB-5042 Add custom heading styles

### DIFF
--- a/assets/sass/application.scss
+++ b/assets/sass/application.scss
@@ -10,6 +10,7 @@ $govuk-page-width: $moj-page-width;
 @import 'node_modules/@ministryofjustice/hmpps-connect-dps-components/dist/assets/footer';
 @import 'node_modules/@ministryofjustice/hmpps-connect-dps-components/dist/assets/header-bar';
 
+@import './components/bapv_headings';
 @import './components/card';
 @import './components/expandableComment';
 @import './components/block-background';

--- a/assets/sass/components/_bapv_headings.scss
+++ b/assets/sass/components/_bapv_headings.scss
@@ -1,0 +1,37 @@
+// Customise headings
+
+// Decrease bottom margin
+.govuk-heading-l.bapv-heading {
+  @include govuk-responsive-margin(4, "bottom");
+}
+
+.govuk-heading-m.bapv-heading {
+  @include govuk-responsive-margin(3, "bottom");
+}
+
+.govuk-heading-s.bapv-heading {
+  @include govuk-responsive-margin(3, "bottom");
+}
+
+// Increase top padding after paragraphs and lists
+p + .govuk-heading-l.bapv-heading,
+.govuk-list + .govuk-heading-l.bapv-heading {
+  @include govuk-responsive-padding(6, "top");
+}
+
+p + .govuk-heading-m.bapv-heading,
+.govuk-list + .govuk-heading-m.bapv-heading {
+  @include govuk-responsive-padding(5, "top");
+}
+
+p + .govuk-heading-s.bapv-heading,
+.govuk-list + .govuk-heading-s.bapv-heading {
+  @include govuk-responsive-padding(4, "top");
+}
+
+// Decrease bottom margin for list headings
+.govuk-heading-l.bapv-heading:has(+ .govuk-list),
+.govuk-heading-m.bapv-heading:has(+ .govuk-list),
+.govuk-heading-s.bapv-heading:has(+ .govuk-list) {
+  @include govuk-responsive-margin(1, "bottom");
+}

--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -272,25 +272,18 @@
     display: grid;
     grid-template-columns: 22% auto;
     gap: govuk-spacing(2) govuk-spacing(3);
-    margin-top: 0;
   }
 
-  & dt, dd {
-    @include govuk-font($size: 19);
-    margin: 0;
-  }
-
-  & .moj-timeline__title {
-    @include govuk-font-size($size: 24);
-    margin-right: govuk-spacing(1);
-  }
-
-  & .moj-timeline__date {
-    @include govuk-font-size($size: 19);
+  & dd {
+    margin-left: 0;
   }
 }
 
 .bapv-visit-details__summary {
+  & dl {
+    grid-template-columns: max-content auto;
+  }
+
   & li, & dt {
     @include govuk-typography-weight-bold;
   }
@@ -302,4 +295,15 @@
 
 .bapv-visit-details__restriction-dates {
   color:  $govuk-secondary-text-colour;
+}
+
+.bapv-visit-details {
+  & .moj-timeline__title {
+    @include govuk-font-size($size: 24);
+    margin-right: govuk-spacing(1);
+  }
+
+  & .moj-timeline__date {
+    @include govuk-font-size($size: 19);
+  }
 }

--- a/server/views/pages/visit/visitDetails.njk
+++ b/server/views/pages/visit/visitDetails.njk
@@ -20,12 +20,11 @@
   {% set backLinkHref = "/" %}
 {% endif %}
 
+{% set mainClasses = "bapv-visit-details" %}
+
 {% block content %}
-<div class="govuk-grid-row bapv-visit-details">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
     <h1 class="govuk-heading-xl">Visit booking details</h1>
 
     {% if prisoner %}
@@ -91,7 +90,7 @@
         </div>
 
         <div class="govuk-grid-column-one-half">
-          <dl>
+          <dl class="govuk-list">
             <dt>Main contact</dt>
             <dd data-test="visit-contact">{{ visit.visitContact.name }}</dd>
             
@@ -156,14 +155,14 @@
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-heading-l">Prisoner</h2>
-          <h3 class="govuk-heading-m">
+          <h2 class="govuk-heading-l bapv-heading">Prisoner</h2>
+          <h3 class="govuk-heading-m bapv-heading">
             <span data-test="prisoner-name">{{ (prisoner.firstName + " " + prisoner.lastName) | properCaseFullName }}</span>
             <span class="govuk-body" >
               (<span data-test="prisoner-number">{{ prisoner.prisonerNumber }}</span>)
             </span>
           </h3>
-          <dl>
+          <dl class="govuk-list">
             <dt>Location</dt>
             <dd data-test="prisoner-location">{{ prisonerLocation }}</dd>
 
@@ -174,15 +173,15 @@
             </dd>
           </dl>
 
-          <h2 class="govuk-heading-l">Visitors</h2>
+          <h2 class="govuk-heading-l bapv-heading">Visitors</h2>
           {% for visitor in visitors %}
-            <h3 class="govuk-heading-m">
+            <h3 class="govuk-heading-m bapv-heading">
               <span data-test="visitor-name-{{ loop.index }}">{{ visitor.name }}</span>
               <span>
                 (<span data-test="visitor-relation-{{ loop.index }}">{{ visitor.relationshipDescription | lower }}</span>)
               </span>
             </h3>
-            <dl class="bapv-visit-details__person-details">
+            <dl class="govuk-list bapv-visit-details__person-details">
               <dt>Date of birth</dt>
               <dd>
                 <span data-test="visitor-dob-{{ loop.index }}">{{ visitor.dateOfBirth | formatDate }}</span>
@@ -215,7 +214,7 @@
             {% endfor %}
           {% endfor %}
 
-          <h2 class="govuk-heading-l">Booking history</h2>
+          <h2 class="govuk-heading-l bapv-heading">Booking history</h2>
           {{ mojTimeline({
             headingLevel: 3,
             items: eventsTimeline


### PR DESCRIPTION
Add `bapv-heading` class to customise padding/margin when used with `govuk-heading-(l|m|s)` styles.