### PR TITLE
VB-5293 Visit details page tweaks and sort prisoner alerts/restrictions by date

### DIFF
--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -9,7 +9,7 @@ import { clearSession } from './visitorUtils'
 import { VisitSessionData, VisitSlot } from '../@types/bapv'
 import SelectVisitors from './visitJourney/selectVisitors'
 import VisitType from './visitJourney/visitType'
-import { properCaseFullName } from '../utils/utils'
+import { properCaseFullName, sortItemsByDateAsc } from '../utils/utils'
 import DateAndTime from './visitJourney/dateAndTime'
 import AdditionalSupport from './visitJourney/additionalSupport'
 import CheckYourBooking from './visitJourney/checkYourBooking'
@@ -19,6 +19,8 @@ import RequestMethod from './visitJourney/requestMethod'
 import sessionCheckMiddleware from '../middleware/sessionCheckMiddleware'
 import { type Services } from '../services'
 import Overbooking from './visitJourney/overbooking'
+import { Alert } from '../data/orchestrationApiTypes'
+import { OffenderRestriction } from '../data/prisonApiTypes'
 
 export default function routes({
   auditService,
@@ -78,6 +80,10 @@ export default function routes({
       prisonerProfileService.getProfile(visit.prisonId, visit.prisonerId, username),
       prisonerProfileService.getRestrictions(visit.prisonerId, username),
     ])
+
+    sortItemsByDateAsc<Alert, 'dateExpires'>(activeAlerts, 'dateExpires')
+    sortItemsByDateAsc<OffenderRestriction, 'expiryDate'>(restrictions, 'expiryDate')
+
     const visitRestriction =
       visit.visitRestriction === 'OPEN' || visit.visitRestriction === 'CLOSED' ? visit.visitRestriction : undefined
     const visitSlot: VisitSlot = {

--- a/server/routes/visit/visitDetailsController.test.ts
+++ b/server/routes/visit/visitDetailsController.test.ts
@@ -75,14 +75,14 @@ describe('Visit details page', () => {
           expect($('[data-test="prisoner-age"]').text()).toBe('46 years old')
           expect($('[data-test="prisoner-restriction-1"]').text()).toContain('Restricted')
           expect($('[data-test="prisoner-restriction-1-start"]').text()).toContain('15 March 2022')
-          expect($('[data-test="prisoner-restriction-1-end"]').text()).toContain('End date not entered')
+          expect($('[data-test="prisoner-restriction-1-end"]').text()).toContain('No end date')
           expect($('[data-test="prisoner-restriction-1-text"]').text()).toContain('Details about this restriction')
           expect($('[data-test="all-alerts-link"]').attr('href')).toBe(
             'https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/A1234BC/alerts/active',
           )
           expect($('[data-test="prisoner-alert-1"]').text()).toContain('COVID unit management')
           expect($('[data-test="prisoner-alert-1-start"]').text()).toContain('2 January 2023')
-          expect($('[data-test="prisoner-alert-1-end"]').text()).toContain('End date not entered')
+          expect($('[data-test="prisoner-alert-1-end"]').text()).toContain('No end date')
           expect($('[data-test="prisoner-alert-1-text"]').text()).toContain('Alert comment')
           // visitor details
           expect($('[data-test="visitor-name-1"]').text()).toBe('Jeanette Smith')

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -15,6 +15,7 @@ import {
   createMockOrchestrationApiClient,
   createMockPrisonerContactRegistryApiClient,
 } from '../data/testutils/mocks'
+import * as utils from '../utils/utils'
 
 const token = 'some token'
 
@@ -295,14 +296,19 @@ describe('Visit service', () => {
     })
 
     describe('getVisitDetailed', () => {
-      it('should return visit details given a visit reference', async () => {
+      it('should return visit details given a visit reference, with alerts and restrictions sorted', async () => {
         const visitDetails = TestData.visitBookingDetailsDto()
         orchestrationApiClient.getVisitDetailed.mockResolvedValue(visitDetails)
 
+        const sortItemsSpy = jest.spyOn(utils, 'sortItemsByDateAsc')
         const result = await visitService.getVisitDetailed({ username: 'user', reference: 'ab-cd-ef-gh' })
 
         expect(orchestrationApiClient.getVisitDetailed).toHaveBeenCalledWith('ab-cd-ef-gh')
         expect(result).toStrictEqual(visitDetails)
+        expect(sortItemsSpy).toHaveBeenNthCalledWith(1, visitDetails.prisoner.prisonerAlerts, 'dateExpires')
+        expect(sortItemsSpy).toHaveBeenNthCalledWith(2, visitDetails.prisoner.prisonerRestrictions, 'expiryDate')
+
+        jest.restoreAllMocks()
       })
     })
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -11,6 +11,7 @@ import {
   getWeekOfDatesStartingMonday,
   isSameVisitSlot,
   initialiseName,
+  sortItemsByDateAsc,
 } from './utils'
 import getResultsPagingLinksTestData from './utils.testData'
 import { VisitSlot } from '../@types/bapv'
@@ -242,5 +243,25 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
+  })
+})
+
+describe('sortItemsByDateAsc', () => {
+  type Item = { date: string }
+
+  it('should sort objects in place by ascending date order, given object type and field containing date strings', () => {
+    const firstDate: Item = { date: '2025-01-01' }
+    const nextDate: Item = { date: '2025-02-01' }
+    const lastDate: Item = { date: '2025-03-01' }
+    const emptyDate: Item = { date: '' }
+    const invalidDate: Item = { date: 'not a date' }
+    const undefinedDate: Item = { date: undefined }
+    const wrongTypeDate = { date: [1] } as unknown as Item
+
+    const items: Item[] = [emptyDate, invalidDate, undefinedDate, wrongTypeDate, lastDate, nextDate, firstDate]
+
+    const result = sortItemsByDateAsc<Item, 'date'>(items, 'date')
+
+    expect(result).toStrictEqual([firstDate, nextDate, lastDate, emptyDate, invalidDate, undefinedDate, wrongTypeDate])
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -179,3 +179,19 @@ export const initialiseName = (fullName?: string): string | null => {
 export const getDpsPrisonerAlertsUrl = (offenderNo: string): string => {
   return `${config.dpsPrisoner}prisoner/${offenderNo}/alerts/active`
 }
+
+export const sortItemsByDateAsc = <Type, Key extends keyof Type>(items: Type[], dateField: Key): Type[] => {
+  return items.sort((a, b) => {
+    const dateA = typeof a[dateField] === 'string' ? new Date(a[dateField]).getTime() : NaN
+    const dateB = typeof b[dateField] === 'string' ? new Date(b[dateField]).getTime() : NaN
+
+    // both dates invalid: preserve order
+    if (Number.isNaN(dateA) && Number.isNaN(dateB)) return 0
+    // one date invalid: put at the end
+    if (Number.isNaN(dateA)) return 1
+    if (Number.isNaN(dateB)) return -1
+
+    // both dates valid: sort ascending
+    return dateA - dateB
+  })
+}

--- a/server/views/pages/visit/visitDetails.njk
+++ b/server/views/pages/visit/visitDetails.njk
@@ -187,14 +187,12 @@
                 <span class="bapv-visit-details__restriction-dates">From <span data-test="prisoner-restriction-{{ loop.index }}-start">{{ restriction.startDate | formatDate }}</span>
                   {%- if restriction.expiryDate %} to {% else %}.{% endif %}
                   <span data-test="prisoner-restriction-{{ loop.index }}-end">
-                    {{- restriction.expiryDate | formatDate | default("End date not entered", true) -}}
+                    {{- restriction.expiryDate | formatDate | default("No end date", true) -}}
                   </span>.
                 </span>
               </p>
               {% if restriction.comment %}
-                <div class="govuk-body" data-test="prisoner-restriction-{{ loop.index }}-text">
-                  {{- bapvExpandableComment({ text: restriction.comment }) -}}
-                </div>
+                <p data-test="prisoner-restriction-{{ loop.index }}-text">{{ restriction.comment }}</p>
               {% endif %}
             {% endfor %}
           {% endif %}
@@ -216,7 +214,7 @@
                 <span class="bapv-visit-details__restriction-dates">From <span data-test="prisoner-alert-{{ loop.index }}-start">{{ alert.dateCreated | formatDate }}</span>
                   {%- if alert.dateExpires %} to {% else %}.{% endif %}
                   <span data-test="prisoner-alert-{{ loop.index }}-end">
-                    {{- alert.dateExpires | formatDate | default("End date not entered", true) -}}
+                    {{- alert.dateExpires | formatDate | default("No end date", true) -}}
                   </span>.
                 </span>
               </p>
@@ -259,7 +257,7 @@
                 <span class="bapv-visit-details__restriction-dates">From <span data-test="visitor-{{ visitorIndex }}-restriction-{{ loop.index }}-start">{{ restriction.startDate | formatDate }}</span>
                   {%- if restriction.expiryDate %} to {% else %}.{% endif %}
                   <span data-test="visitor-{{ visitorIndex }}-restriction-{{ loop.index }}-end">
-                    {{- restriction.expiryDate | formatDate | default("End date not entered", true) -}}
+                    {{- restriction.expiryDate | formatDate | default("No end date", true) -}}
                   </span>.
                 </span>
               </p>


### PR DESCRIPTION
* Minor tweaks to Visit details page.
* Add generic `sortItemsByDateAsc()` function to sort an array of any type of item by a specified field that contains a date string. Sorts by date ascending with invalid or missing values at the end.
* Use this to sort the listing of prisoner alerts/restrictions on Select visitors and Visit details pages.