### PR TITLE
VB-4411 Sort alerts on prisoner profile page by date

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -31,8 +31,7 @@ export type VisitorListItem = {
 }
 
 export type PrisonerProfilePage = {
-  activeAlerts: Alert[]
-  activeAlertCount: number
+  alerts: Alert[]
   flaggedAlerts: Alert[]
   prisonerDetails: {
     prisonerId: string
@@ -101,7 +100,7 @@ export type VisitSessionData = {
     name: string
     offenderNo: string
     location: string
-    activeAlerts?: Alert[]
+    alerts?: Alert[]
     restrictions?: OffenderRestriction[]
   }
   visitSlot?: VisitSlot

--- a/server/routes/prisoner.test.ts
+++ b/server/routes/prisoner.test.ts
@@ -65,8 +65,7 @@ describe('/prisoner/:offenderNo - Prisoner profile', () => {
 
   beforeEach(() => {
     prisonerProfile = {
-      activeAlerts: [alert],
-      activeAlertCount: 1,
+      alerts: [alert],
       flaggedAlerts: [TestData.alert({ alertCode: 'UPIU', alertCodeDescription: 'Protective Isolation Unit' })],
       visitsByMonth: new Map(),
       prisonerDetails: {
@@ -253,8 +252,7 @@ describe('/prisoner/:offenderNo - Prisoner profile', () => {
 
     it('should render the prisoner profile page for offender number A1234BC without active alerts if there are none', () => {
       prisonerProfile.flaggedAlerts = []
-      prisonerProfile.activeAlerts = []
-      prisonerProfile.activeAlertCount = 0
+      prisonerProfile.alerts = []
 
       return request(app)
         .get('/prisoner/A1234BC')
@@ -387,7 +385,7 @@ describe('/prisoner/:offenderNo - Prisoner profile', () => {
               name: 'Smith, John',
               offenderNo: 'A1234BC',
               location: '1-1-C-028, Hewell (HMP)',
-              activeAlerts: [alert],
+              alerts: [alert],
               restrictions: [restriction],
             },
           })
@@ -419,7 +417,7 @@ describe('/prisoner/:offenderNo - Prisoner profile', () => {
               name: 'Smith, John',
               offenderNo: 'A1234BC',
               location: '1-1-C-028, Hewell (HMP)',
-              activeAlerts: [
+              alerts: [
                 TestData.alert({
                   alertType: 'X',
                   alertTypeDescription: 'Security',
@@ -456,7 +454,7 @@ describe('/prisoner/:offenderNo - Prisoner profile', () => {
               name: 'Smith, John',
               offenderNo: 'A1234BC',
               location: '1-1-C-028, Hewell (HMP)',
-              activeAlerts: [
+              alerts: [
                 TestData.alert({
                   alertType: 'X',
                   alertTypeDescription: 'Security',

--- a/server/routes/prisoner.ts
+++ b/server/routes/prisoner.ts
@@ -42,7 +42,7 @@ export default function routes({ auditService, prisonerProfileService }: Service
     const { prisonId } = req.session.selectedEstablishment
     const { username } = res.locals.user
 
-    const [{ prisonerDetails, activeAlerts }, restrictions] = await Promise.all([
+    const [{ prisonerDetails, alerts }, restrictions] = await Promise.all([
       prisonerProfileService.getProfile(prisonId, offenderNo, username),
       prisonerProfileService.getRestrictions(offenderNo, username),
     ])
@@ -74,7 +74,7 @@ export default function routes({ auditService, prisonerProfileService }: Service
       name: prisonerDetails.name,
       offenderNo,
       location: prisonerDetails.cellLocation ? `${prisonerDetails.cellLocation}, ${prisonerDetails.prisonName}` : '',
-      activeAlerts,
+      alerts,
       restrictions,
     }
 

--- a/server/routes/visit.test.ts
+++ b/server/routes/visit.test.ts
@@ -157,8 +157,7 @@ describe('/visit/:reference', () => {
     })
     beforeEach(() => {
       const prisonerProfile: PrisonerProfilePage = {
-        activeAlerts: [alert],
-        activeAlertCount: 1,
+        alerts: [alert],
         flaggedAlerts: [],
         visitsByMonth: new Map(),
         prisonerDetails: {
@@ -202,7 +201,7 @@ describe('/visit/:reference', () => {
               name: 'Smith, John',
               offenderNo: 'A1234BC',
               location: '1-1-C-028, HMP Hewell',
-              activeAlerts: [alert],
+              alerts: [alert],
               restrictions: [restriction],
             },
             visitSlot: {

--- a/server/routes/visit.ts
+++ b/server/routes/visit.ts
@@ -76,12 +76,12 @@ export default function routes({
     // clean then load session
     clearSession(req)
 
-    const [{ activeAlerts }, restrictions] = await Promise.all([
+    const [{ alerts }, restrictions] = await Promise.all([
       prisonerProfileService.getProfile(visit.prisonId, visit.prisonerId, username),
       prisonerProfileService.getRestrictions(visit.prisonerId, username),
     ])
 
-    sortItemsByDateAsc<Alert, 'dateExpires'>(activeAlerts, 'dateExpires')
+    sortItemsByDateAsc<Alert, 'dateExpires'>(alerts, 'dateExpires')
     sortItemsByDateAsc<OffenderRestriction, 'expiryDate'>(restrictions, 'expiryDate')
 
     const visitRestriction =
@@ -103,7 +103,7 @@ export default function routes({
         name: properCaseFullName(`${prisoner.lastName}, ${prisoner.firstName}`),
         offenderNo: prisoner.prisonerNumber,
         location: prisonerLocation,
-        activeAlerts,
+        alerts,
         restrictions,
       },
       visitSlot,

--- a/server/routes/visitJourney/selectVisitors.test.ts
+++ b/server/routes/visitJourney/selectVisitors.test.ts
@@ -106,7 +106,7 @@ testJourneys.forEach(journey => {
           name: 'John Smith',
           offenderNo: 'A1234BC',
           location: 'location place',
-          activeAlerts: [],
+          alerts: [],
           restrictions: [],
         },
         visitRestriction: 'OPEN',
@@ -126,7 +126,7 @@ testJourneys.forEach(journey => {
 
     it('should render the prisoner restrictions and alerts when they are present', () => {
       visitSessionData.prisoner.restrictions = restrictions
-      visitSessionData.prisoner.activeAlerts = alerts
+      visitSessionData.prisoner.alerts = alerts
       return request(sessionApp)
         .get(`${journey.urlPrefix}/select-visitors`)
         .expect(200)
@@ -147,7 +147,7 @@ testJourneys.forEach(journey => {
 
     it('should render the prisoner restrictions and alerts when they are present, displaying a message if dates are not set', () => {
       visitSessionData.prisoner.restrictions = [TestData.offenderRestriction()]
-      visitSessionData.prisoner.activeAlerts = [TestData.alert()]
+      visitSessionData.prisoner.alerts = [TestData.alert()]
 
       sessionApp = appWithAllRoutes({
         services: { prisonerVisitorsService },

--- a/server/routes/visitJourney/selectVisitors.ts
+++ b/server/routes/visitJourney/selectVisitors.ts
@@ -27,7 +27,7 @@ export default class SelectVisitors {
     const atLeastOneAdult = visitorList.some(visitor => visitor.adult === true)
     const eligibleVisitors = visitorList.some(visitor => visitor.banned === false && visitor.adult === true)
 
-    const { restrictions, activeAlerts } = visitSessionData.prisoner
+    const { restrictions, alerts } = visitSessionData.prisoner
 
     const formValues = getFlashFormValues(req)
     if (!Object.keys(formValues).length && visitSessionData.visitors) {
@@ -43,7 +43,7 @@ export default class SelectVisitors {
       visitorList,
       atLeastOneAdult,
       eligibleVisitors,
-      activeAlerts,
+      alerts,
       restrictions,
       formValues,
       prisonerDpsAlertsUrl: getDpsPrisonerAlertsUrl(offenderNo),

--- a/server/services/prisonerProfileService.test.ts
+++ b/server/services/prisonerProfileService.test.ts
@@ -9,6 +9,7 @@ import {
   createMockPrisonApiClient,
   createMockPrisonerSearchClient,
 } from '../data/testutils/mocks'
+import * as utils from '../utils/utils'
 
 const token = 'some token'
 
@@ -48,6 +49,7 @@ describe('Prisoner profile service', () => {
     it('should retrieve and process data for prisoner profile', async () => {
       const prisonerProfile = TestData.prisonerProfile()
       orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)
+      const sortItemsSpy = jest.spyOn(utils, 'sortItemsByDateAsc')
 
       const prisonerProfilePage: PrisonerProfilePage = {
         alerts: [],
@@ -77,9 +79,11 @@ describe('Prisoner profile service', () => {
 
       expect(OrchestrationApiClientFactory).toHaveBeenCalledWith(token)
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith('user')
-      expect(orchestrationApiClient.getPrisonerProfile).toHaveBeenCalledTimes(1)
-
+      expect(orchestrationApiClient.getPrisonerProfile).toHaveBeenCalledWith(prisonId, prisonerId)
       expect(results).toEqual(prisonerProfilePage)
+      expect(sortItemsSpy).toHaveBeenCalledWith(prisonerProfilePage.alerts, 'dateExpires')
+
+      sortItemsSpy.mockRestore()
     })
 
     it('should return visit balances as null if prisoner is on REMAND', async () => {
@@ -90,8 +94,7 @@ describe('Prisoner profile service', () => {
 
       expect(OrchestrationApiClientFactory).toHaveBeenCalledWith(token)
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith('user')
-      expect(orchestrationApiClient.getPrisonerProfile).toHaveBeenCalledTimes(1)
-
+      expect(orchestrationApiClient.getPrisonerProfile).toHaveBeenCalledWith(prisonId, prisonerId)
       expect(results.prisonerDetails.visitBalances).toBeNull()
     })
 
@@ -145,7 +148,7 @@ describe('Prisoner profile service', () => {
 
       expect(OrchestrationApiClientFactory).toHaveBeenCalledWith(token)
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith('user')
-      expect(orchestrationApiClient.getPrisonerProfile).toHaveBeenCalledTimes(1)
+      expect(orchestrationApiClient.getPrisonerProfile).toHaveBeenCalledWith(prisonId, prisonerId)
 
       expect(results.alerts).toStrictEqual([alertNotToFlag, ...alertsToFlag])
       expect(results.flaggedAlerts).toStrictEqual(alertsToFlag)

--- a/server/services/prisonerProfileService.test.ts
+++ b/server/services/prisonerProfileService.test.ts
@@ -50,8 +50,7 @@ describe('Prisoner profile service', () => {
       orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)
 
       const prisonerProfilePage: PrisonerProfilePage = {
-        activeAlerts: [],
-        activeAlertCount: 0,
+        alerts: [],
         flaggedAlerts: [],
         visitsByMonth: new Map(),
         prisonerDetails: {
@@ -126,9 +125,7 @@ describe('Prisoner profile service', () => {
       )
     })
 
-    it('should filter active alerts and those to be flagged', async () => {
-      const inactiveAlert = TestData.alert({ active: false })
-
+    it('should filter alerts to be flagged', async () => {
       const alertsToFlag = [
         TestData.alert({ alertCode: 'UPIU' }),
         TestData.alert({ alertCode: 'RCDR' }),
@@ -137,10 +134,10 @@ describe('Prisoner profile service', () => {
       const alertNotToFlag = TestData.alert({ alertCode: 'XR' })
 
       const prisonerProfile = TestData.prisonerProfile({
-        alerts: [inactiveAlert, alertNotToFlag, ...alertsToFlag],
+        alerts: [alertNotToFlag, ...alertsToFlag],
       })
 
-      prisonerProfile.alerts = [inactiveAlert, alertNotToFlag, ...alertsToFlag]
+      prisonerProfile.alerts = [alertNotToFlag, ...alertsToFlag]
 
       orchestrationApiClient.getPrisonerProfile.mockResolvedValue(prisonerProfile)
 
@@ -150,8 +147,7 @@ describe('Prisoner profile service', () => {
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith('user')
       expect(orchestrationApiClient.getPrisonerProfile).toHaveBeenCalledTimes(1)
 
-      expect(results.activeAlerts).toStrictEqual([alertNotToFlag, ...alertsToFlag])
-      expect(results.activeAlertCount).toBe(4)
+      expect(results.alerts).toStrictEqual([alertNotToFlag, ...alertsToFlag])
       expect(results.flaggedAlerts).toStrictEqual(alertsToFlag)
     })
   })

--- a/server/services/prisonerProfileService.ts
+++ b/server/services/prisonerProfileService.ts
@@ -1,7 +1,13 @@
 import { NotFound } from 'http-errors'
 import { format, isBefore } from 'date-fns'
 import { PrisonerProfilePage } from '../@types/bapv'
-import { nextIepAdjustDate, nextPrivIepAdjustDate, prisonerDateTimePretty, properCaseFullName } from '../utils/utils'
+import {
+  nextIepAdjustDate,
+  nextPrivIepAdjustDate,
+  prisonerDateTimePretty,
+  properCaseFullName,
+  sortItemsByDateAsc,
+} from '../utils/utils'
 import { Alert, OffenderRestriction } from '../data/prisonApiTypes'
 import { HmppsAuthClient, OrchestrationApiClient, PrisonApiClient, RestClientBuilder } from '../data'
 
@@ -20,6 +26,7 @@ export default class PrisonerProfileService {
     const prisonerProfile = await orchestrationApiClient.getPrisonerProfile(prisonId, prisonerId)
 
     const { alerts } = prisonerProfile
+    sortItemsByDateAsc<Alert, 'dateExpires'>(alerts, 'dateExpires')
     const flaggedAlerts: Alert[] = alerts.filter(alert => this.alertCodesToFlag.includes(alert.alertCode))
 
     const visitsByMonth: PrisonerProfilePage['visitsByMonth'] = new Map()

--- a/server/services/prisonerProfileService.ts
+++ b/server/services/prisonerProfileService.ts
@@ -19,10 +19,8 @@ export default class PrisonerProfileService {
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
     const prisonerProfile = await orchestrationApiClient.getPrisonerProfile(prisonId, prisonerId)
 
-    const alerts = prisonerProfile.alerts || []
-    const activeAlerts: Alert[] = alerts.filter(alert => alert.active)
-    const activeAlertCount = activeAlerts.length
-    const flaggedAlerts: Alert[] = activeAlerts.filter(alert => this.alertCodesToFlag.includes(alert.alertCode))
+    const { alerts } = prisonerProfile
+    const flaggedAlerts: Alert[] = alerts.filter(alert => this.alertCodesToFlag.includes(alert.alertCode))
 
     const visitsByMonth: PrisonerProfilePage['visitsByMonth'] = new Map()
     const now = new Date()
@@ -72,8 +70,7 @@ export default class PrisonerProfileService {
     }
 
     return {
-      activeAlerts,
-      activeAlertCount,
+      alerts,
       flaggedAlerts,
       prisonerDetails,
       visitsByMonth,

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -308,7 +308,7 @@ describe('Visit service', () => {
         expect(sortItemsSpy).toHaveBeenNthCalledWith(1, visitDetails.prisoner.prisonerAlerts, 'dateExpires')
         expect(sortItemsSpy).toHaveBeenNthCalledWith(2, visitDetails.prisoner.prisonerRestrictions, 'expiryDate')
 
-        jest.restoreAllMocks()
+        sortItemsSpy.mockRestore()
       })
     })
 

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -69,7 +69,7 @@
 
         <p>This page shows alerts that are relevant for social visits. You can also <a class="govuk-link--no-visited-state" href="{{ prisonerDpsAlertsUrl }}" target="_blank" data-test="all-alerts-link">view all alerts</a>.</p>
 
-        {% if restrictions | length or activeAlerts | length %}
+        {% if restrictions | length or alerts | length %}
           {% set prisonerRestrictions = [] %}
           {% for restriction in restrictions %}
             {% set restrictionExpiryDate %}{% if restriction.expiryDate %}{{ restriction.expiryDate | formatDate }}{% else %}No end date{% endif %}{% endset %}
@@ -90,7 +90,7 @@
           {% endfor %}
 
           {% set prisonerAlerts = [] %}
-          {% for alert in activeAlerts %}
+          {% for alert in alerts %}
             {% set alertExpiryDate %}{% if alert.dateExpires %}{{ alert.dateExpires | formatDate }}{% else %}No end date{% endif %}{% endset %}
             {%- set prisonerAlerts = (prisonerAlerts.push([
               {
@@ -124,7 +124,7 @@
             }) }}
           {% endif %}
 
-          {% if activeAlerts | length %}
+          {% if alerts | length %}
           {{ govukTable({
             classes: 'bapv-table-no-bottom-border fix-width-alert-restriction',
             head: [

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -63,7 +63,7 @@
         </li>
         <li>
           <strong>Alerts</strong>
-          <span data-test="active-alert-count">{{ activeAlertCount }} active</span>
+          <span data-test="active-alert-count">{{ alerts | length }} active</span>
         </li>
         {% if prisonerDetails.visitBalances %}
           <li>
@@ -212,11 +212,11 @@
       <h2 class="govuk-heading-m">Active alerts</h2>
       <p>This page shows alerts that are relevant for social visits. You can also <a class="govuk-link--no-visited-state" href="{{ prisonerDpsAlertsUrl }}" target="_blank" data-test="all-alerts-link">view all alerts</a>.</p>
 
-      {% if activeAlerts | length %}
+      {% if alerts | length %}
 
         {# Build rows for alerts table #}
         {% set alertRows = [] %}
-        {% for alert in activeAlerts %}
+        {% for alert in alerts %}
           {% set alertRows = (alertRows.push([
             {
               text: alert.alertTypeDescription + " (" + alert.alertType + ")",


### PR DESCRIPTION
* Use same date sort order for prisoner alerts on profile page as is used on visit details page (expiring soonest first)
* Remove unnecessary filter for `active | inactive` alerts (API does this)
* Rename `activeAlerts` to `alerts` for simplicity and consistency with restrictions