### PR TITLE
VB-5293 Fix prisoner alert descriptions

### DIFF
--- a/integration_tests/e2e/visitDetails.cy.ts
+++ b/integration_tests/e2e/visitDetails.cy.ts
@@ -58,7 +58,7 @@ context('Visit details page', () => {
     visitDetailsPage.prisonerLocation().contains('1-1-C-028, Hewell (HMP)')
     visitDetailsPage.prisonerDob().contains('2 April 1975')
     visitDetailsPage.prisonerRestriction(1).contains('Restricted')
-    visitDetailsPage.prisonerAlert(1).contains('COVID unit management')
+    visitDetailsPage.prisonerAlert(1).contains('Protective Isolation Unit')
 
     // visitor details
     visitDetailsPage.visitorName(1).contains('Jeanette Smith')

--- a/server/routes/visit/visitDetailsController.test.ts
+++ b/server/routes/visit/visitDetailsController.test.ts
@@ -80,7 +80,7 @@ describe('Visit details page', () => {
           expect($('[data-test="all-alerts-link"]').attr('href')).toBe(
             'https://prisoner-dev.digital.prison.service.justice.gov.uk/prisoner/A1234BC/alerts/active',
           )
-          expect($('[data-test="prisoner-alert-1"]').text()).toContain('COVID unit management')
+          expect($('[data-test="prisoner-alert-1"]').text()).toContain('Protective Isolation Unit')
           expect($('[data-test="prisoner-alert-1-start"]').text()).toContain('2 January 2023')
           expect($('[data-test="prisoner-alert-1-end"]').text()).toContain('No end date')
           expect($('[data-test="prisoner-alert-1-text"]').text()).toContain('Alert comment')

--- a/server/views/pages/visit/visitDetails.njk
+++ b/server/views/pages/visit/visitDetails.njk
@@ -208,7 +208,7 @@
                 <span>
                   <span class="govuk-tag alert-tag alert-tag--{{ alert.alertType }}"
                     data-test="prisoner-alert-{{ loop.index }}">
-                    {{- alert.alertTypeDescription -}}
+                    {{- alert.alertCodeDescription -}}
                   </span>
                 </span>
                 <span class="bapv-visit-details__restriction-dates">From <span data-test="prisoner-alert-{{ loop.index }}-start">{{ alert.dateCreated | formatDate }}</span>


### PR DESCRIPTION
For prisoner alerts on Visit details page, use `alertCodeDescription` instead of `alertTypeDescription` in order to match what is displayed on Select visitor page.