### PR TITLE
VB-5364 Fix prisoner alerts/restrictions on update journey

### DIFF
--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -113,16 +113,7 @@ describe('orchestrationApiClient', () => {
   })
 
   describe('getVisitDetailed', () => {
-    afterEach(() => {
-      jest.restoreAllMocks()
-    })
-
     it('should return full visit details for requested visit with filtered notification events', async () => {
-      jest.replaceProperty(config, 'features', {
-        ...config.features,
-        showPrisonerAlertsRestrictions: true,
-      })
-
       const rawVisitBookingDetailsDto = TestData.visitBookingDetailsDto()
 
       // add an audit event that should be filtered
@@ -151,25 +142,6 @@ describe('orchestrationApiClient', () => {
       const output = await orchestrationApiClient.getVisitDetailed(rawVisitBookingDetailsDto.reference)
 
       expect(output).toEqual(filteredVisitBookingDetailsDto)
-    })
-
-    it('should return visit details without prisoner alerts/restrictions if SHOW_VISIT_DETAILS_PRISONER_ALERTS_RESTRICTIONS not enabled', async () => {
-      jest.replaceProperty(config, 'features', {
-        ...config.features,
-        showPrisonerAlertsRestrictions: false,
-      })
-
-      const visitDetails = TestData.visitBookingDetailsDto()
-
-      fakeOrchestrationApi
-        .get(`/visits/${visitDetails.reference}/detailed`)
-        .matchHeader('authorization', `Bearer ${token}`)
-        .reply(200, visitDetails)
-
-      const output = await orchestrationApiClient.getVisitDetailed(visitDetails.reference)
-
-      expect(output.prisoner.prisonerAlerts).toStrictEqual([])
-      expect(output.prisoner.prisonerRestrictions).toStrictEqual([])
     })
   })
 

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -88,11 +88,6 @@ export default class OrchestrationApiClient {
       this.enabledNotifications.includes(notification.type),
     )
 
-    if (!config.features.showPrisonerAlertsRestrictions) {
-      visitDetails.prisoner.prisonerAlerts = []
-      visitDetails.prisoner.prisonerRestrictions = []
-    }
-
     return visitDetails
   }
 

--- a/server/routes/visit/visitDetailsController.test.ts
+++ b/server/routes/visit/visitDetailsController.test.ts
@@ -8,6 +8,7 @@ import TestData from '../testutils/testData'
 import { createMockAuditService, createMockVisitService } from '../../services/testutils/mocks'
 import { notificationTypeWarnings } from '../../constants/notificationEvents'
 import { MojTimelineItem } from '../../services/visitService'
+import config from '../../config'
 
 let app: Express
 
@@ -33,6 +34,11 @@ describe('Visit details page', () => {
   ]
 
   beforeEach(() => {
+    jest.replaceProperty(config, 'features', {
+      ...config.features,
+      showPrisonerAlertsRestrictions: true,
+    })
+
     visitDetails = TestData.visitBookingDetailsDto()
 
     const fakeDate = new Date('2022-01-01')
@@ -45,7 +51,34 @@ describe('Visit details page', () => {
   })
 
   describe('GET /visit/:reference', () => {
-    it('should render full booking summary page with visit information and prisoner tab selected, with default back link', () => {
+    it('should NOT show prisoner alerts and restrictions if feature disabled', () => {
+      jest.replaceProperty(config, 'features', {
+        ...config.features,
+        showPrisonerAlertsRestrictions: false,
+      })
+
+      app = appWithAllRoutes({ services: { auditService, visitService } })
+
+      return request(app)
+        .get('/visit/ab-cd-ef-gh')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('h1').text()).toBe('Visit booking details')
+
+          // prisoner details
+          expect($('[data-test="prisoner-name"]').text()).toBe('John Smith')
+          expect($('[data-test="prisoner-number"]').text()).toBe('A1234BC')
+          expect($('[data-test="prisoner-location"]').text()).toBe('1-1-C-028, Hewell (HMP)')
+          expect($('[data-test="prisoner-dob"]').text()).toBe('2 April 1975')
+          expect($('[data-test="prisoner-age"]').text()).toBe('46 years old')
+          expect($('[data-test="prisoner-restriction-1"]').length).toBe(0)
+          expect($('[data-test="prisoner-alert-1"]').length).toBe(0)
+        })
+    })
+
+    it('should render full visit booking summary page', () => {
       return request(app)
         .get('/visit/ab-cd-ef-gh')
         .expect(200)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -20,6 +20,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   app.locals.environmentName = config.environmentName
   app.locals.dpsHome = config.dpsHome
   app.locals.dpsPrisoner = config.dpsPrisoner
+  app.locals.features = config.features
 
   // Cachebusting version string
   if (production) {

--- a/server/views/pages/visit/visitDetails.njk
+++ b/server/views/pages/visit/visitDetails.njk
@@ -174,7 +174,7 @@
             </dd>
           </dl>
 
-          {% if visitDetails.prisoner.prisonerRestrictions | length %}
+          {% if features.showPrisonerAlertsRestrictions and visitDetails.prisoner.prisonerRestrictions | length %}
             <h4 class="govuk-heading-s">Restrictions</h4>
             {% for restriction in visitDetails.prisoner.prisonerRestrictions %}
               <p class="bapv-visit-details__restriction">
@@ -197,7 +197,7 @@
             {% endfor %}
           {% endif %}
 
-          {% if visitDetails.prisoner.prisonerAlerts | length %}
+          {% if features.showPrisonerAlertsRestrictions and visitDetails.prisoner.prisonerAlerts | length %}
             <h4 class="govuk-heading-s">Alerts</h4>
             <p>
               This page shows alerts that are relevant for social visits. You can also


### PR DESCRIPTION
The way the feature flag to hide prisoner alerts/restrictions on visit details page was implemented prevented these being passed through to the update journey.

Change to just hide the alerts/restrictions in the visit details page template, based on the feature flag.