### PR TITLE
Make homepage full width

### DIFF
--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -9,8 +9,8 @@
 
 {% block content %}
 
-  <div class="govuk-body">
-    <div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">{{ applicationName }}</h1>
 
       <ul class="govuk-grid-row card-group">


### PR DESCRIPTION
The homepage was not displaying full width to match the other pages in the service. THis is only noticeable when you lower the width of the window.

Not full width:
![image](https://github.com/user-attachments/assets/d87fcfd9-558e-408c-8665-79dd32e08229)

Full width:

![image](https://github.com/user-attachments/assets/ac83d00a-bc82-4678-be28-d8f53b75918c)
