### PR TITLE
VB-5454 Fix for potentially undefined main contact

### DIFF
--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -332,7 +332,7 @@ export default class OrchestrationApiClient {
           name: mainContact.contactName,
         }
       : undefined
-    const mainContactId = mainContact.contactId ?? null
+    const mainContactId = mainContact?.contactId ?? null
     return { visitContact, mainContactId }
   }
 }


### PR DESCRIPTION
On a booking journey, if an application is changed **before** a main contact is selected (e.g. by going back in journey) `mainContact` will be `undefined`. Fix to handle this.