### PR TITLE
Improve cancellation confirmation page

### DIFF
--- a/integration_tests/pages/visitCancelled.ts
+++ b/integration_tests/pages/visitCancelled.ts
@@ -7,5 +7,5 @@ export default class VisitCancelledPage extends Page {
 
   visitDetails = (): PageElement => cy.get('[data-test="visit-details"]')
 
-  homeButton = (): PageElement => cy.get('[data-test="go-to-home"]')
+  homeButton = (): PageElement => cy.get('[data-test="back-to-start"]')
 }

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -165,3 +165,8 @@ export interface Prison extends Omit<PrisonDto, 'code'> {
 export type FilterField = { id: string; label: string; items: { label: string; value: string; checked: boolean }[] }
 
 export type BookOrUpdate = 'book' | 'update'
+
+export type CancelledVisitInfo = {
+  startTimestamp: string
+  endTimestamp: string
+}

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,7 +1,7 @@
 import HeaderFooterMeta from '@ministryofjustice/hmpps-connect-dps-components/dist/types/HeaderFooterMeta'
 import { ValidationError } from 'express-validator'
 import { PrisonUser } from '../../interfaces/hmppsUser'
-import { FlashFormValues, MojAlert, Prison, VisitorListItem, VisitSessionData } from '../bapv'
+import { CancelledVisitInfo, FlashFormValues, MojAlert, Prison, VisitorListItem, VisitSessionData } from '../bapv'
 
 export declare module 'express-session' {
   // Declare that the session will potentially contain these additional fields
@@ -14,6 +14,7 @@ export declare module 'express-session' {
     visitSessionData: VisitSessionData
     selectedEstablishment: Prison
     visitBlockDate?: string // format YYYY-MM-DD
+    cancelledVisitInfo?: CancelledVisitInfo
   }
 }
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -56,8 +56,6 @@ export type FlashData = {
   errors?: ValidationError[]
   formValues?: FlashFormValues[]
   messages?: MoJAlert[]
-  // FIXME below needed for cancel visit route; remove when this is updated to store in req.session
-  [key: string]: string[] | ValidationError[] | FlashFormValues[] | MoJAlert[] | undefined
 }
 
 export const flashProvider = jest.fn()

--- a/server/routes/visit/cancelVisitController.test.ts
+++ b/server/routes/visit/cancelVisitController.test.ts
@@ -49,7 +49,7 @@ describe('GET /visit/:reference/cancelled', () => {
         const $ = cheerio.load(res.text)
         expect($('h1').text().trim()).toBe('Booking cancelled')
         expect($('[data-test="visit-details"]').text().trim()).toBe('10:15am to 11am on Wednesday 9 February 2022')
-        expect($('[data-test="go-to-home"]').length).toBe(1)
+        expect($('[data-test="back-to-start"]').attr('href')).toBe('/back-to-start')
       })
   })
 

--- a/server/routes/visitorUtils.test.ts
+++ b/server/routes/visitorUtils.test.ts
@@ -184,6 +184,7 @@ describe('clearSession', () => {
     slotsList: {},
     visitSessionData: { allowOverBooking: false, prisoner: undefined },
     selectedEstablishment: TestData.prison(),
+    cancelledVisitInfo: { startTimestamp: '', endTimestamp: '' },
   }
 
   req.session = sessionData as Session & SessionData

--- a/server/routes/visitorUtils.ts
+++ b/server/routes/visitorUtils.ts
@@ -35,7 +35,9 @@ export const getFlashFormValues = (req: Request): FlashFormValues => {
 }
 
 export const clearSession = (req: Request): void => {
-  ;['visitorList', 'adultVisitors', 'slotsList', 'visitSessionData'].forEach((sessionItem: keyof SessionData) => {
-    delete req.session[sessionItem]
-  })
+  ;['visitorList', 'adultVisitors', 'slotsList', 'visitSessionData', 'cancelledVisitInfo'].forEach(
+    (sessionItem: keyof SessionData) => {
+      delete req.session[sessionItem]
+    },
+  )
 }

--- a/server/views/pages/visit/cancelConfirmation.njk
+++ b/server/views/pages/visit/cancelConfirmation.njk
@@ -20,13 +20,7 @@
     {% endif %}
     <p>The main contact for this visit will get a text message to confirm it has been cancelled.</p>
 
-    {{ govukButton({
-      text: "Go to manage prison visits",
-      classes: "govuk-!-margin-top-3",
-      href: "/",
-      attributes: { "data-test": "go-to-home" },
-      preventDoubleClick: true
-    }) }}
+    {% include "partials/backToStartButton.njk" %}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
* Use `req.session` instead of `req.flash` for storing data so it won't fail if page refreshed
* Update links from `/` to `/back-to-start` (which incorporates clearing session between journeys)
* Handle visiting cancellation confirmation page when no appropriate session data set