### PR TITLE
VB-3758 Process raw API event and notification types

### DIFF
--- a/integration_tests/e2e/cancelVisit.cy.ts
+++ b/integration_tests/e2e/cancelVisit.cy.ts
@@ -14,7 +14,7 @@ context('Cancel visit journey', () => {
   const today = new Date()
 
   const futureVisitDate = format(add(today, { months: 1 }), shortDateFormat)
-  const visitDetails = TestData.visitBookingDetailsDto({
+  const visitDetails = TestData.visitBookingDetailsRaw({
     startTimestamp: `${futureVisitDate}T12:00:00`,
     endTimestamp: `${futureVisitDate}T14:00:00`,
   })

--- a/integration_tests/e2e/reviewAVisit.cy.ts
+++ b/integration_tests/e2e/reviewAVisit.cy.ts
@@ -21,7 +21,7 @@ context('Review a visit', () => {
   })
 
   it('should dismiss notifications when a visit is marked as not needing to be updated or cancelled', () => {
-    const visitDetails = TestData.visitBookingDetailsDto({
+    const visitDetails = TestData.visitBookingDetailsRaw({
       startTimestamp: `${futureVisitDate}T12:00:00`,
       endTimestamp: `${futureVisitDate}T14:00:00`,
       events: [
@@ -65,7 +65,7 @@ context('Review a visit', () => {
     clearNotificationsPage.enterReason('some reason')
 
     // Submit and should be returned to booking summary with notification gone and timeline updated
-    const visitDetailsUpdated = TestData.visitBookingDetailsDto({
+    const visitDetailsUpdated = TestData.visitBookingDetailsRaw({
       ...visitDetails,
       notifications: [],
       events: [

--- a/integration_tests/e2e/reviewVisitsList.cy.ts
+++ b/integration_tests/e2e/reviewVisitsList.cy.ts
@@ -9,7 +9,7 @@ context('Bookings review listing page', () => {
   const prettyDateFormat = 'd MMMM yyyy'
 
   const notificationGroups = [
-    TestData.notificationGroup({
+    TestData.notificationGroupRaw({
       reference: 'bc*de*fg*hi',
       type: 'PRISONER_RELEASED_EVENT',
       affectedVisits: [
@@ -21,7 +21,7 @@ context('Bookings review listing page', () => {
         }),
       ],
     }),
-    TestData.notificationGroup({
+    TestData.notificationGroupRaw({
       reference: 'de*fg*hi*jk',
       type: 'PRISON_VISITS_BLOCKED_FOR_DATE',
       affectedVisits: [TestData.notificationVisitInfo()],

--- a/integration_tests/e2e/searchForABooking.cy.ts
+++ b/integration_tests/e2e/searchForABooking.cy.ts
@@ -44,7 +44,7 @@ context('Search for a booking by reference', () => {
     searchBookingByReferenceResultsPage.prisonerNumber().contains(offenderNo)
     searchBookingByReferenceResultsPage.visitStatus().contains('Booked')
 
-    cy.task('stubGetVisitDetailed', TestData.visitBookingDetailsDto())
+    cy.task('stubGetVisitDetailed', TestData.visitBookingDetailsRaw())
     searchBookingByReferenceResultsPage.visitReferenceLink().click()
 
     const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
@@ -77,7 +77,7 @@ context('Search for a booking by reference', () => {
     searchBookingByPrisonerResultsPage.prisonerLink().click()
 
     const prisonerProfilePage = Page.verifyOnPageTitle(PrisonerProfilePage, 'Smith, John')
-    cy.task('stubGetVisitDetailed', TestData.visitBookingDetailsDto())
+    cy.task('stubGetVisitDetailed', TestData.visitBookingDetailsRaw())
     prisonerProfilePage.visitTabReference().eq(0).click()
 
     const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)

--- a/integration_tests/e2e/updateAVisit.cy.ts
+++ b/integration_tests/e2e/updateAVisit.cy.ts
@@ -41,7 +41,7 @@ context('Update a visit', () => {
       }),
     ]
 
-    const originalVisit = TestData.visitBookingDetailsDto({
+    const originalVisit = TestData.visitBookingDetailsRaw({
       startTimestamp: visitSessions[0].startTimestamp,
       endTimestamp: visitSessions[0].endTimestamp,
       visitorSupport: null,
@@ -61,7 +61,7 @@ context('Update a visit', () => {
 
     cy.task(
       'stubGetVisitDetailed',
-      TestData.visitBookingDetailsDto({
+      TestData.visitBookingDetailsRaw({
         startTimestamp: originalVisit.startTimestamp,
         endTimestamp: originalVisit.endTimestamp,
         visitors: [contacts[0]],
@@ -211,7 +211,7 @@ context('Update a visit', () => {
       }),
     ]
 
-    const originalVisit = TestData.visitBookingDetailsDto({
+    const originalVisit = TestData.visitBookingDetailsRaw({
       startTimestamp: visitSessions[0].startTimestamp,
       endTimestamp: visitSessions[0].endTimestamp,
       visitorSupport: null,

--- a/integration_tests/e2e/visitDetails.cy.ts
+++ b/integration_tests/e2e/visitDetails.cy.ts
@@ -18,7 +18,7 @@ context('Visit details page', () => {
   })
 
   it('should display all visit information for a past visit', () => {
-    const visitDetails = TestData.visitBookingDetailsDto({
+    const visitDetails = TestData.visitBookingDetailsRaw({
       visitStatus: 'CANCELLED',
       outcomeStatus: 'VISITOR_CANCELLED',
       visitNotes: [{ type: 'VISIT_OUTCOMES', text: 'Illness' }],
@@ -83,7 +83,7 @@ context('Visit details page', () => {
 
     cy.task(
       'stubGetVisitDetailed',
-      TestData.visitBookingDetailsDto({
+      TestData.visitBookingDetailsRaw({
         startTimestamp: `${futureVisitDate}T12:00:00`,
         endTimestamp: `${futureVisitDate}T14:00:00`,
         notifications: [{ type: 'PRISON_VISITS_BLOCKED_FOR_DATE', createdDateTime: '', additionalData: [] }],
@@ -113,7 +113,7 @@ context('Visit details page', () => {
 
     cy.task(
       'stubGetVisitDetailed',
-      TestData.visitBookingDetailsDto({
+      TestData.visitBookingDetailsRaw({
         startTimestamp: `${futureVisitDate}T12:00:00`,
         endTimestamp: `${futureVisitDate}T14:00:00`,
         notifications: [{ type: 'PRISONER_RECEIVED_EVENT', createdDateTime: '', additionalData: [] }],

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -8,13 +8,13 @@ import {
   ExcludeDateDto,
   IgnoreVisitNotificationsDto,
   NotificationCount,
-  NotificationGroup,
+  NotificationGroupRaw,
   PrisonDto,
   PrisonerProfile,
   SessionCapacity,
   SessionSchedule,
   Visit,
-  VisitBookingDetailsDto,
+  VisitBookingDetailsRaw,
   VisitPreview,
   VisitSession,
 } from '../../server/data/orchestrationApiTypes'
@@ -246,7 +246,7 @@ export default {
       },
     })
   },
-  stubGetVisitDetailed: (visitDetails: VisitBookingDetailsDto): SuperAgentRequest => {
+  stubGetVisitDetailed: (visitDetails: VisitBookingDetailsRaw): SuperAgentRequest => {
     return stubFor({
       request: {
         method: 'GET',
@@ -396,10 +396,10 @@ export default {
   },
   stubGetNotificationGroups: ({
     prisonId = 'HEI',
-    notificationGroups = [TestData.notificationGroup()],
+    notificationGroups = [TestData.notificationGroupRaw()],
   }: {
     prisonId: string
-    notificationGroups: NotificationGroup[]
+    notificationGroups: NotificationGroupRaw[]
   }): SuperAgentRequest => {
     return stubFor({
       request: {

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,4 +1,4 @@
-import { NotificationType } from './data/orchestrationApiTypes'
+import { NotificationTypeRaw } from './data/orchestrationApiTypes'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -130,10 +130,10 @@ export default {
   },
   features: {
     notificationTypes: {
-      enabledNotifications: <NotificationType[]>(
+      enabledRawNotifications: <NotificationTypeRaw[]>(
         get(
-          'FEATURE_ENABLED_NOTIFICATION_TYPES',
-          'PRISONER_RELEASED_EVENT,PRISONER_RECEIVED_EVENT,PRISON_VISITS_BLOCKED_FOR_DATE',
+          'FEATURE_ENABLED_RAW_NOTIFICATION_TYPES',
+          'PRISONER_RECEIVED_EVENT,PRISONER_RELEASED_EVENT,PRISON_VISITS_BLOCKED_FOR_DATE',
         ).split(',')
       ),
     },

--- a/server/constants/eventAudit.ts
+++ b/server/constants/eventAudit.ts
@@ -11,8 +11,8 @@ const eventAuditTypes: Partial<Record<EventAuditType, string>> = {
   PRISONER_RESTRICTION_CHANGE_EVENT: 'Needs review',
   PRISON_VISITS_BLOCKED_FOR_DATE: 'Needs review',
   IGNORE_VISIT_NOTIFICATIONS_EVENT: 'No change required',
-  PERSON_RESTRICTION_UPSERTED_EVENT: 'Needs review',
   PRISONER_ALERTS_UPDATED_EVENT: 'Needs review',
+  VISITOR_RESTRICTION: 'Needs review',
 }
 
 export default eventAuditTypes

--- a/server/data/orchestrationApiTypes.ts
+++ b/server/data/orchestrationApiTypes.ts
@@ -1,10 +1,19 @@
 import { components } from '../@types/orchestration-api'
 
+// Visitor restrictions can be 2 types (local/global). Raw API values are processed in the data layer
+// and replaced with the VISITOR_RESTRICTION value for use within the application
+type VISITOR_RESTRICTION = 'VISITOR_RESTRICTION'
+
 export type VisitorSupport = components['schemas']['VisitorSupportDto']
 
 export type PageVisitDto = components['schemas']['PageVisitDto']
 export type Visit = components['schemas']['VisitDto']
-export type VisitBookingDetailsDto = components['schemas']['VisitBookingDetailsDto']
+export type VisitBookingDetailsRaw = components['schemas']['VisitBookingDetailsDto']
+// Replace raw event and notifications 'type' ones that have VISITOR_RESTRICTION
+export type VisitBookingDetails = Omit<components['schemas']['VisitBookingDetailsDto'], 'events' | 'notifications'> & {
+  events: EventAudit[]
+  notifications: (Omit<components['schemas']['VisitNotificationDto'], 'type'> & { type: NotificationType })[]
+}
 export type VisitRestriction = Visit['visitRestriction']
 export type VisitPreview = components['schemas']['VisitPreviewDto']
 
@@ -32,12 +41,22 @@ export type OffenderRestriction = components['schemas']['OffenderRestrictionDto'
 export type PrisonerProfile = components['schemas']['PrisonerProfileDto']
 export type VisitSummary = components['schemas']['VisitSummaryDto']
 
-export type EventAudit = components['schemas']['EventAuditOrchestrationDto']
-export type EventAuditType = components['schemas']['EventAuditOrchestrationDto']['type']
+// Raw local/global visitor restrictions mapped to VISITOR_RESTRICTION as described above
+export type EventAuditTypeRaw = components['schemas']['EventAuditOrchestrationDto']['type']
+export type EventAuditType =
+  | Exclude<EventAuditTypeRaw, 'PERSON_RESTRICTION_UPSERTED_EVENT' | 'VISITOR_RESTRICTION_UPSERTED_EVENT'>
+  | VISITOR_RESTRICTION
+export type EventAuditRaw = components['schemas']['EventAuditOrchestrationDto']
+export type EventAudit = Omit<EventAuditRaw, 'type'> & { type: EventAuditType }
 
+// Raw local/global visitor restrictions mapped to VISITOR_RESTRICTION as described above
 export type NotificationCount = components['schemas']['NotificationCountDto']
-export type NotificationType = components['schemas']['OrchestrationNotificationGroupDto']['type']
-export type NotificationGroup = components['schemas']['OrchestrationNotificationGroupDto']
+export type NotificationTypeRaw = components['schemas']['OrchestrationNotificationGroupDto']['type']
+export type NotificationType =
+  | Exclude<NotificationTypeRaw, 'PERSON_RESTRICTION_UPSERTED_EVENT' | 'VISITOR_RESTRICTION_UPSERTED_EVENT'>
+  | VISITOR_RESTRICTION
+export type NotificationGroupRaw = components['schemas']['OrchestrationNotificationGroupDto']
+export type NotificationGroup = Omit<NotificationGroupRaw, 'type'> & { type: NotificationType }
 export type NotificationVisitInfo = components['schemas']['OrchestrationPrisonerVisitsNotificationDto']
 
 export type PrisonDto = components['schemas']['PrisonDto']

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -2,20 +2,23 @@ import CaseLoad from '@ministryofjustice/hmpps-connect-dps-components/dist/types
 import {
   Alert,
   ApplicationDto,
+  ExcludeDateDto,
   NotificationCount,
   NotificationGroup,
+  NotificationGroupRaw,
+  NotificationTypeRaw,
   NotificationVisitInfo,
+  OffenderRestriction,
   PrisonDto,
   PrisonerProfile,
-  ExcludeDateDto,
   SessionCapacity,
   SessionSchedule,
   Visit,
+  VisitBookingDetails,
+  VisitBookingDetailsRaw,
   VisitPreview,
   VisitSession,
   VisitSummary,
-  VisitBookingDetailsDto,
-  OffenderRestriction,
 } from '../../data/orchestrationApiTypes'
 import { CurrentIncentive, Prisoner } from '../../data/prisonerOffenderSearchTypes'
 import { Address, Contact, Restriction } from '../../data/prisonerContactRegistryApiTypes'
@@ -199,6 +202,7 @@ export default class TestData {
 
   static notificationCount = ({ count = 5 }: Partial<NotificationCount> = {}): NotificationCount => ({ count })
 
+  // data with notification types processed
   static notificationGroup = ({
     reference = 'ab*cd*ef*gh',
     type = 'NON_ASSOCIATION_EVENT',
@@ -207,6 +211,13 @@ export default class TestData {
       this.notificationVisitInfo({ bookedByName: 'User Two', bookedByUserName: 'user2', prisonerNumber: 'A5678DE' }),
     ],
   }: Partial<NotificationGroup> = {}): NotificationGroup => ({ reference, type, affectedVisits })
+
+  // raw data with types as returned from API
+  static notificationGroupRaw = ({
+    reference = this.notificationGroup().reference,
+    type = this.notificationGroup().type as NotificationTypeRaw,
+    affectedVisits = this.notificationGroup().affectedVisits,
+  }: Partial<NotificationGroupRaw> = {}): NotificationGroupRaw => ({ reference, type, affectedVisits })
 
   static notificationVisitInfo = ({
     prisonerNumber = 'A1234BC',
@@ -480,7 +491,8 @@ export default class TestData {
       modifiedTimestamp,
     }) as Visit
 
-  static visitBookingDetailsDto = ({
+  // data with event/notification types processed
+  static visitBookingDetails = ({
     reference = 'ab-cd-ef-gh',
     visitRoom = 'Visit room 1',
     visitStatus = 'BOOKED',
@@ -552,7 +564,44 @@ export default class TestData {
       },
     ],
     notifications = [],
-  }: Partial<VisitBookingDetailsDto> = {}): VisitBookingDetailsDto => ({
+  }: Partial<VisitBookingDetails> = {}): VisitBookingDetails => ({
+    reference,
+    visitRoom,
+    visitStatus,
+    outcomeStatus,
+    visitRestriction,
+    startTimestamp,
+    endTimestamp,
+    sessionTemplateReference,
+    visitNotes,
+    visitContact,
+    visitorSupport,
+    prison,
+    prisoner,
+    visitors,
+    events,
+    notifications,
+  })
+
+  // raw data as returned from API
+  static visitBookingDetailsRaw = ({
+    reference = this.visitBookingDetails().reference,
+    visitRoom = this.visitBookingDetails().visitRoom,
+    visitStatus = this.visitBookingDetails().visitStatus,
+    outcomeStatus = this.visitBookingDetails().outcomeStatus,
+    visitRestriction = this.visitBookingDetails().visitRestriction,
+    startTimestamp = this.visitBookingDetails().startTimestamp,
+    endTimestamp = this.visitBookingDetails().endTimestamp,
+    sessionTemplateReference = this.visitBookingDetails().sessionTemplateReference,
+    visitNotes = this.visitBookingDetails().visitNotes,
+    visitContact = this.visitBookingDetails().visitContact,
+    visitorSupport = this.visitBookingDetails().visitorSupport,
+    prison = this.visitBookingDetails().prison,
+    prisoner = this.visitBookingDetails().prisoner,
+    visitors = this.visitBookingDetails().visitors,
+    events = this.visitBookingDetails().events as VisitBookingDetailsRaw['events'],
+    notifications = this.visitBookingDetails().notifications as VisitBookingDetailsRaw['notifications'],
+  }: Partial<VisitBookingDetailsRaw> = {}): VisitBookingDetailsRaw => ({
     reference,
     visitRoom,
     visitStatus,

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -205,11 +205,8 @@ export default class TestData {
   // data with notification types processed
   static notificationGroup = ({
     reference = 'ab*cd*ef*gh',
-    type = 'NON_ASSOCIATION_EVENT',
-    affectedVisits = [
-      this.notificationVisitInfo(),
-      this.notificationVisitInfo({ bookedByName: 'User Two', bookedByUserName: 'user2', prisonerNumber: 'A5678DE' }),
-    ],
+    type = 'PRISONER_RELEASED_EVENT',
+    affectedVisits = [this.notificationVisitInfo()],
   }: Partial<NotificationGroup> = {}): NotificationGroup => ({ reference, type, affectedVisits })
 
   // raw data with types as returned from API

--- a/server/routes/visit/updateVisitController.test.ts
+++ b/server/routes/visit/updateVisitController.test.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express'
 import request from 'supertest'
 import { SessionData } from 'express-session'
 import { appWithAllRoutes, user } from '../testutils/appSetup'
-import { VisitBookingDetailsDto } from '../../data/orchestrationApiTypes'
+import { VisitBookingDetails } from '../../data/orchestrationApiTypes'
 import { VisitSessionData } from '../../@types/bapv'
 import { clearSession } from '../visitorUtils'
 import TestData from '../testutils/testData'
@@ -12,7 +12,7 @@ let app: Express
 
 const visitService = createMockVisitService()
 
-let visitDetails: VisitBookingDetailsDto
+let visitDetails: VisitBookingDetails
 let visitSessionData: VisitSessionData
 
 jest.mock('../visitorUtils', () => {
@@ -29,7 +29,7 @@ beforeEach(() => {
   const fakeDate = new Date('2022-01-01')
   jest.useFakeTimers({ advanceTimers: true, now: new Date(fakeDate) })
 
-  visitDetails = TestData.visitBookingDetailsDto()
+  visitDetails = TestData.visitBookingDetails()
   visitSessionData = {} as VisitSessionData
   visitService.getVisitDetailed.mockResolvedValue(visitDetails)
 

--- a/server/routes/visit/visitDetailsController.test.ts
+++ b/server/routes/visit/visitDetailsController.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { SessionData } from 'express-session'
 import { appWithAllRoutes, user } from '../testutils/appSetup'
-import { VisitBookingDetailsDto } from '../../data/orchestrationApiTypes'
+import { VisitBookingDetails } from '../../data/orchestrationApiTypes'
 import TestData from '../testutils/testData'
 import { createMockAuditService, createMockVisitService } from '../../services/testutils/mocks'
 import { MojTimelineItem } from './visitEventsTimelineBuilder'
@@ -44,7 +44,7 @@ afterEach(() => {
 })
 
 describe('Visit details page', () => {
-  let visitDetails: VisitBookingDetailsDto
+  let visitDetails: VisitBookingDetails
 
   visitEventsTimeline = [
     {
@@ -61,7 +61,7 @@ describe('Visit details page', () => {
     visitCancelledAlert = undefined
     visitNotificationAlerts = []
 
-    visitDetails = TestData.visitBookingDetailsDto()
+    visitDetails = TestData.visitBookingDetails()
 
     const fakeDate = new Date('2022-01-01')
     jest.useFakeTimers({ advanceTimers: true, now: new Date(fakeDate) })

--- a/server/routes/visit/visitEventsTimelineBuilder.ts
+++ b/server/routes/visit/visitEventsTimelineBuilder.ts
@@ -1,7 +1,7 @@
 import eventAuditTypes from '../../constants/eventAudit'
 import { notificationTypes } from '../../constants/notifications'
 import { requestMethodDescriptions } from '../../constants/requestMethods'
-import { EventAudit, VisitBookingDetailsDto } from '../../data/orchestrationApiTypes'
+import { EventAudit, VisitBookingDetails } from '../../data/orchestrationApiTypes'
 
 export type MojTimelineItem = {
   label: { text: string }
@@ -19,7 +19,7 @@ export default ({
   visitNotes,
 }: {
   events: EventAudit[]
-  visitNotes: VisitBookingDetailsDto['visitNotes']
+  visitNotes: VisitBookingDetails['visitNotes']
 }): MojTimelineItem[] => {
   return events
     .filter(event => event.type in eventAuditTypes)
@@ -76,7 +76,7 @@ const isPublicBooking = (event: EventAudit): boolean =>
   event.userType === 'PUBLIC' && event.applicationMethodType === 'WEBSITE'
 
 // Get user-entered cancellation reason, if set
-const getCancellationReason = (visitNotes: VisitBookingDetailsDto['visitNotes']): string | undefined => {
+const getCancellationReason = (visitNotes: VisitBookingDetails['visitNotes']): string | undefined => {
   const reason = visitNotes.find(note => note.type === 'VISIT_OUTCOMES')?.text
   return reason ? `Reason: ${reason}` : undefined
 }

--- a/server/routes/visit/visitUtils.test.ts
+++ b/server/routes/visit/visitUtils.test.ts
@@ -1,7 +1,7 @@
 import { MoJAlert } from '../../@types/bapv'
 import { notificationTypeAlerts } from '../../constants/notifications'
 import { visitCancellationAlerts } from '../../constants/visitCancellation'
-import { EventAudit, VisitBookingDetailsDto } from '../../data/orchestrationApiTypes'
+import { EventAudit, VisitBookingDetails } from '../../data/orchestrationApiTypes'
 import {
   getPrisonerLocation,
   getAvailableVisitActions,
@@ -23,7 +23,7 @@ describe('Visit utils', () => {
         prisonName: 'Hewell (HMP)',
         cellLocation: '1-1-C-028',
         locationDescription: '',
-      } as VisitBookingDetailsDto['prisoner'])
+      } as VisitBookingDetails['prisoner'])
 
       expect(prisonerLocation).toBe('1-1-C-028, Hewell (HMP)')
     })
@@ -34,7 +34,7 @@ describe('Visit utils', () => {
         prisonName: '',
         cellLocation: '',
         locationDescription: '',
-      } as VisitBookingDetailsDto['prisoner'])
+      } as VisitBookingDetails['prisoner'])
 
       expect(prisonerLocation).toBe('Unknown')
     })
@@ -45,7 +45,7 @@ describe('Visit utils', () => {
         prisonName: '',
         cellLocation: '',
         locationDescription: 'Outside - released from Hewell (HMP)',
-      } as VisitBookingDetailsDto['prisoner'])
+      } as VisitBookingDetails['prisoner'])
 
       expect(prisonerLocation).toBe('Outside - released from Hewell (HMP)')
     })
@@ -89,13 +89,13 @@ describe('Visit utils', () => {
 
         it('should set update to false if before start time but prisoner has been released', () => {
           jest.useFakeTimers({ now: new Date('2025-04-01T08:59:59') })
-          params.notifications = [{ type: 'PRISONER_RELEASED_EVENT' }] as VisitBookingDetailsDto['notifications']
+          params.notifications = [{ type: 'PRISONER_RELEASED_EVENT' }] as VisitBookingDetails['notifications']
           expect(getAvailableVisitActions(params).update).toBe(false)
         })
 
         it('should set update to false if before start time but prisoner has been transferred', () => {
           jest.useFakeTimers({ now: new Date('2025-04-01T08:59:59') })
-          params.notifications = [{ type: 'PRISONER_RECEIVED_EVENT' }] as VisitBookingDetailsDto['notifications']
+          params.notifications = [{ type: 'PRISONER_RECEIVED_EVENT' }] as VisitBookingDetails['notifications']
           expect(getAvailableVisitActions(params).update).toBe(false)
         })
       })
@@ -123,7 +123,7 @@ describe('Visit utils', () => {
         })
 
         it('should set clearNotifications to true if a visit notification is set', () => {
-          params.notifications = [{ type: 'NON_ASSOCIATION_EVENT' }] as VisitBookingDetailsDto['notifications']
+          params.notifications = [{ type: 'NON_ASSOCIATION_EVENT' }] as VisitBookingDetails['notifications']
           expect(getAvailableVisitActions(params).clearNotifications).toBe(true)
         })
 
@@ -131,7 +131,7 @@ describe('Visit utils', () => {
           params.notifications = [
             { type: 'NON_ASSOCIATION_EVENT' },
             { type: 'PRISON_VISITS_BLOCKED_FOR_DATE' },
-          ] as VisitBookingDetailsDto['notifications']
+          ] as VisitBookingDetails['notifications']
           expect(getAvailableVisitActions(params).clearNotifications).toBe(false)
         })
       })
@@ -153,7 +153,7 @@ describe('Visit utils', () => {
         ['handle undefined', undefined, visitCancellationAlerts.default],
       ])(
         "should handle %s: '%s' => %s",
-        (_: string, outcomeStatus: VisitBookingDetailsDto['outcomeStatus'], expected: string) => {
+        (_: string, outcomeStatus: VisitBookingDetails['outcomeStatus'], expected: string) => {
           expect(getVisitCancelledAlert({ visitStatus: 'CANCELLED', outcomeStatus })).toStrictEqual<MoJAlert>({
             variant: 'information',
             title: 'Visit cancelled',
@@ -183,12 +183,9 @@ describe('Visit utils', () => {
         [notificationTypeAlerts.PRISONER_RELEASED_EVENT],
       ],
       ['no notifications', [], []],
-    ])(
-      'should handle %s',
-      (_: string, notifications: VisitBookingDetailsDto['notifications'], expected: MoJAlert[]) => {
-        expect(getVisitNotificationsAlerts(notifications)).toStrictEqual(expected)
-      },
-    )
+    ])('should handle %s', (_: string, notifications: VisitBookingDetails['notifications'], expected: MoJAlert[]) => {
+      expect(getVisitNotificationsAlerts(notifications)).toStrictEqual(expected)
+    })
   })
 
   describe('isPublicBooking', () => {

--- a/server/routes/visit/visitUtils.ts
+++ b/server/routes/visit/visitUtils.ts
@@ -2,12 +2,12 @@ import { MoJAlert } from '../../@types/bapv'
 import config from '../../config'
 import { notificationTypeAlerts } from '../../constants/notifications'
 import { visitCancellationAlerts } from '../../constants/visitCancellation'
-import { EventAudit, VisitBookingDetailsDto } from '../../data/orchestrationApiTypes'
+import { EventAudit, VisitBookingDetails } from '../../data/orchestrationApiTypes'
 
 const A_DAY_IN_MS = 24 * 60 * 60 * 1000
 const CANCELLATION_LIMIT_MS = config.visit.cancellationLimitDays * A_DAY_IN_MS
 
-export const getPrisonerLocation = (prisoner: VisitBookingDetailsDto['prisoner']) => {
+export const getPrisonerLocation = (prisoner: VisitBookingDetails['prisoner']) => {
   if (prisoner.prisonId === 'OUT') {
     return prisoner.locationDescription
   }
@@ -26,9 +26,9 @@ export const getAvailableVisitActions = ({
   startTimestamp,
   notifications,
 }: {
-  visitStatus: VisitBookingDetailsDto['visitStatus']
-  startTimestamp: VisitBookingDetailsDto['startTimestamp']
-  notifications: VisitBookingDetailsDto['notifications']
+  visitStatus: VisitBookingDetails['visitStatus']
+  startTimestamp: VisitBookingDetails['startTimestamp']
+  notifications: VisitBookingDetails['notifications']
 }): { update: boolean; cancel: boolean; clearNotifications: boolean } => {
   const availableVisitActions = { update: false, cancel: false, clearNotifications: false }
 
@@ -71,8 +71,8 @@ export const getVisitCancelledAlert = ({
   visitStatus,
   outcomeStatus,
 }: {
-  visitStatus: VisitBookingDetailsDto['visitStatus']
-  outcomeStatus: VisitBookingDetailsDto['outcomeStatus']
+  visitStatus: VisitBookingDetails['visitStatus']
+  outcomeStatus: VisitBookingDetails['outcomeStatus']
 }): MoJAlert | undefined => {
   if (visitStatus !== 'CANCELLED') {
     return undefined
@@ -86,7 +86,7 @@ export const getVisitCancelledAlert = ({
   }
 }
 
-export const getVisitNotificationsAlerts = (notifications: VisitBookingDetailsDto['notifications']): MoJAlert[] => {
+export const getVisitNotificationsAlerts = (notifications: VisitBookingDetails['notifications']): MoJAlert[] => {
   const alerts = <MoJAlert[]>[]
 
   notifications.forEach(notification => {

--- a/server/services/visitNotificationsService.test.ts
+++ b/server/services/visitNotificationsService.test.ts
@@ -185,7 +185,17 @@ describe('Visit notifications service', () => {
 
     describe('Visits review list filtering', () => {
       const notificationGroups = [
-        TestData.notificationGroup(),
+        TestData.notificationGroup({
+          type: 'NON_ASSOCIATION_EVENT',
+          affectedVisits: [
+            TestData.notificationVisitInfo(),
+            TestData.notificationVisitInfo({
+              bookedByUserName: 'user2',
+              bookedByName: 'User Two',
+              prisonerNumber: 'A5678DE',
+            }),
+          ],
+        }),
         TestData.notificationGroup({
           type: 'PRISONER_RELEASED_EVENT',
           affectedVisits: [TestData.notificationVisitInfo({ bookedByUserName: 'user2', bookedByName: 'User Two' })],

--- a/server/services/visitService.test.ts
+++ b/server/services/visitService.test.ts
@@ -218,7 +218,7 @@ describe('Visit service', () => {
 
     describe('getVisitDetailed', () => {
       it('should return visit details given a visit reference, with alerts and restrictions sorted', async () => {
-        const visitDetails = TestData.visitBookingDetailsDto()
+        const visitDetails = TestData.visitBookingDetails()
         orchestrationApiClient.getVisitDetailed.mockResolvedValue(visitDetails)
 
         const result = await visitService.getVisitDetailed({ username: 'user', reference: 'ab-cd-ef-gh' })

--- a/server/services/visitService.ts
+++ b/server/services/visitService.ts
@@ -5,7 +5,7 @@ import {
   ApplicationMethodType,
   CancelVisitOrchestrationDto,
   Visit,
-  VisitBookingDetailsDto,
+  VisitBookingDetails,
   VisitPreview,
 } from '../data/orchestrationApiTypes'
 import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
@@ -147,7 +147,7 @@ export default class VisitService {
   }: {
     username: string
     reference: string
-  }): Promise<VisitBookingDetailsDto> {
+  }): Promise<VisitBookingDetails> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 


### PR DESCRIPTION
The API returns notifications (e.g. `PRISONER_RELEASED`) and audit events (these include notification types and others like `CANCELLED`).

Most of these events have a one-to-one mapping to labels and functionality on the front-end. Visitor restrictions though can be local or global (`PERSON_RESTRICTION_UPSERTED_EVENT`, `VISITOR_RESTRICTION_UPSERTED_EVENT`) but these effectively have to be labelled and treated the same - as a `Visitor restriction`.

This change makes a distinction for events/notifications between raw data/types returned from the API and data/types for use in the application. In the data layer, the two visitor restriction types are converted to a custom value: `VISITOR_RESTRICTION`.

This means that:
* API can remain unchanged - so the distinction is maintained for future use / other services 
* impact on the application is minimal: existing functionality to list, group, filter events/notifications doesn't need to change
* visitor restriction events/notifications can be supported (next PR!)

(N.B. this is all preparatory work for supporting visitor restrictions - no feature changes in this)