### PR TITLE
VB-5569 Needs review page: group by visit

### DIFF
--- a/integration_tests/e2e/reviewVisitsList.cy.ts
+++ b/integration_tests/e2e/reviewVisitsList.cy.ts
@@ -8,26 +8,23 @@ import { notificationTypes } from '../../server/constants/notifications'
 context('Bookings review listing page', () => {
   const prettyDateFormat = 'd MMMM yyyy'
 
-  const notificationGroups = [
-    TestData.notificationGroupRaw({
-      reference: 'bc*de*fg*hi',
-      type: 'PRISONER_RELEASED_EVENT',
-      affectedVisits: [
-        TestData.notificationVisitInfo({
-          bookedByUserName: 'user3',
-          bookedByName: 'User Three',
-          prisonerNumber: 'B1234CD',
-          visitDate: '2023-12-01',
-        }),
+  const visitNotifications = [
+    TestData.visitNotificationsRaw(),
+
+    TestData.visitNotificationsRaw({
+      visitReference: 'bc-de-fg-hi',
+      prisonerNumber: 'B1234CD',
+      bookedByUserName: 'user2',
+      bookedByName: 'User Two',
+      visitDate: '2025-07-02',
+      notifications: [
+        TestData.visitNotificationEventRaw({ type: 'PERSON_RESTRICTION_UPSERTED_EVENT' }),
+        TestData.visitNotificationEventRaw({ type: 'PRISON_VISITS_BLOCKED_FOR_DATE' }),
       ],
     }),
-    TestData.notificationGroupRaw({
-      reference: 'de*fg*hi*jk',
-      type: 'PRISON_VISITS_BLOCKED_FOR_DATE',
-      affectedVisits: [TestData.notificationVisitInfo()],
-    }),
   ]
-  const notificationCount = TestData.notificationCount({ count: notificationGroups.length })
+
+  const notificationCount = TestData.notificationCount({ count: visitNotifications.length })
 
   beforeEach(() => {
     cy.task('reset')
@@ -46,37 +43,34 @@ context('Bookings review listing page', () => {
     homePage.needReviewBadgeCount().contains(notificationCount.count)
 
     // booking review listing page
-    cy.task('stubGetNotificationGroups', { notificationGroups })
+    cy.task('stubGetVisitNotifications', { visitNotifications })
     homePage.needReviewTile().click()
     const listingPage = Page.verifyOnPage(VisitsReviewListingPage)
 
-    // Prisoner released
-    listingPage.getPrisonerNumber(1).contains(notificationGroups[0].affectedVisits[0].prisonerNumber)
-    listingPage
-      .getVisitDate(1)
-      .contains(format(new Date(notificationGroups[0].affectedVisits[0].visitDate), prettyDateFormat))
-    listingPage.getBookedBy(1).contains(notificationGroups[0].affectedVisits[0].bookedByName)
-    listingPage.getType(1).contains(notificationTypes[notificationGroups[0].type])
+    // Visit #1 - visitor restriction
+    listingPage.getPrisonerNumber(1).contains(visitNotifications[0].prisonerNumber)
+    listingPage.getVisitDate(1).contains(format(new Date(visitNotifications[0].visitDate), prettyDateFormat))
+    listingPage.getBookedBy(1).contains(visitNotifications[0].bookedByName)
+    listingPage.getTypes(1).contains(notificationTypes.VISITOR_RESTRICTION)
     listingPage
       .getActionLink(1)
-      .should('have.attr', 'href', `/visit/${notificationGroups[0].affectedVisits[0].bookingReference}?from=review`)
+      .should('have.attr', 'href', `/visit/${visitNotifications[0].visitReference}?from=review`)
 
-    // Visits blocked for date
-    listingPage.getPrisonerNumber(2).contains(notificationGroups[1].affectedVisits[0].prisonerNumber)
-    listingPage
-      .getVisitDate(2)
-      .contains(format(new Date(notificationGroups[1].affectedVisits[0].visitDate), prettyDateFormat))
-    listingPage.getBookedBy(2).contains(notificationGroups[1].affectedVisits[0].bookedByName)
-    listingPage.getType(2).contains(notificationTypes[notificationGroups[1].type])
+    // Visit #2 - blocked date and visitor restriction
+    listingPage.getPrisonerNumber(2).contains(visitNotifications[1].prisonerNumber)
+    listingPage.getVisitDate(2).contains(format(new Date(visitNotifications[1].visitDate), prettyDateFormat))
+    listingPage.getBookedBy(2).contains(visitNotifications[1].bookedByName)
+    listingPage.getTypes(2).contains(notificationTypes.VISITOR_RESTRICTION)
+    listingPage.getTypes(2).contains(notificationTypes.PRISON_VISITS_BLOCKED_FOR_DATE)
     listingPage
       .getActionLink(2)
-      .should('have.attr', 'href', `/visit/${notificationGroups[1].affectedVisits[0].bookingReference}?from=review`)
+      .should('have.attr', 'href', `/visit/${visitNotifications[1].visitReference}?from=review`)
   })
 
   it('should filter bookings review listing', () => {
     // Navigate to bookings review listing
     const homePage = Page.verifyOnPage(HomePage)
-    cy.task('stubGetNotificationGroups', { notificationGroups })
+    cy.task('stubGetVisitNotifications', { visitNotifications })
     homePage.needReviewTile().click()
     const listingPage = Page.verifyOnPage(VisitsReviewListingPage)
 
@@ -90,14 +84,14 @@ context('Bookings review listing page', () => {
     listingPage.removeFilter('User One')
 
     // Filter by reason
-    listingPage.filterByReason('Prisoner released')
+    listingPage.filterByReason('Time slot removed')
     listingPage.applyFilter()
     listingPage.getBookingsRows().should('have.length', 1)
-    listingPage.removeFilter('Prisoner released')
+    listingPage.removeFilter('Time slot removed')
 
     // Filter by both
     listingPage.filterByUser('User One')
-    listingPage.filterByReason('Prisoner released')
+    listingPage.filterByReason('Time slot removed')
     listingPage.applyFilter()
     listingPage.getBookingsRows().should('have.length', 0)
 

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -15,6 +15,7 @@ import {
   SessionSchedule,
   Visit,
   VisitBookingDetailsRaw,
+  VisitNotificationsRaw,
   VisitPreview,
   VisitSession,
 } from '../../server/data/orchestrationApiTypes'
@@ -394,6 +395,28 @@ export default {
       },
     })
   },
+
+  stubGetVisitNotifications: ({
+    prisonId = 'HEI',
+    visitNotifications = [TestData.visitNotificationsRaw()],
+  }: {
+    prisonId: string
+    visitNotifications: VisitNotificationsRaw[]
+  }): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/orchestration/visits/notification/${prisonId}/visits\\?types=.*`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: visitNotifications,
+      },
+    })
+  },
+
+  // TODO remove: endpoint deprecated
   stubGetNotificationGroups: ({
     prisonId = 'HEI',
     notificationGroups = [TestData.notificationGroupRaw()],

--- a/integration_tests/pages/visitsReviewListing.ts
+++ b/integration_tests/pages/visitsReviewListing.ts
@@ -35,7 +35,7 @@ export default class VisitsReviewListingPage extends Page {
 
   getBookedBy = (row: number): PageElement => cy.get(`[data-test="booked-by-${row}"]`)
 
-  getType = (row: number): PageElement => cy.get(`[data-test="type-${row}"]`)
+  getTypes = (row: number): PageElement => cy.get(`[data-test="type-${row}"]`)
 
   getActionLink = (row: number): PageElement => cy.get(`[data-test="action-${row}"] a`)
 }

--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -164,7 +164,15 @@ export interface Prison extends Omit<PrisonDto, 'code'> {
   prisonId: string
 }
 
-export type FilterField = { id: string; label: string; items: { label: string; value: string; checked: boolean }[] }
+export type FilterField = {
+  id: string
+  label: string
+  items: {
+    label: string
+    value: string
+    checked: boolean
+  }[]
+}
 
 export type BookOrUpdate = 'book' | 'update'
 

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -391,6 +391,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/visits/notification/{prisonCode}/visits': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * get future visits with notifications by prison code
+     * @description Retrieve future visits that have a notification event attribute associated, empty response if no future visits with notifications found.
+     */
+    get: operations['getFutureNotificationVisits']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/visits/notification/{prisonCode}/groups': {
     parameters: {
       query?: never
@@ -400,6 +420,7 @@ export interface paths {
     }
     /**
      * get future notification visit groups by prison code
+     * @deprecated
      * @description Retrieve future notification visit groups by prison code
      */
     get: operations['getFutureNotificationVisitGroups']
@@ -1321,10 +1342,11 @@ export interface components {
        */
       reserved: boolean
       /**
-       * @description Is the application complete
-       * @example true
+       * @description Status of the application
+       * @example IN_PROGRESS
+       * @enum {string}
        */
-      completed: boolean
+      applicationStatus: 'IN_PROGRESS' | 'ACCEPTED'
       /**
        * @description User type
        * @example STAFF
@@ -2049,26 +2071,87 @@ export interface components {
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     PageableObject: {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject']
-      unpaged?: boolean
+      /** Format: int32 */
+      pageSize?: number
       paged?: boolean
       /** Format: int32 */
       pageNumber?: number
-      /** Format: int32 */
-      pageSize?: number
+      unpaged?: boolean
     }
     SortObject: {
       empty?: boolean
       sorted?: boolean
       unsorted?: boolean
+    }
+    OrchestrationVisitNotificationsDto: {
+      /**
+       * @description Visit Booking Reference
+       * @example v9-d7-ed-7u
+       */
+      visitReference: string
+      /**
+       * @description Prisoner Number
+       * @example AF34567G
+       */
+      prisonerNumber: string
+      /**
+       * @description username of the last user to book the visit
+       * @example SMITH1
+       */
+      bookedByUserName: string
+      /**
+       * Format: date
+       * @description The date of the visit
+       * @example 2023-11-08
+       */
+      visitDate: string
+      /**
+       * @description Booked by name
+       * @example John Smith
+       */
+      bookedByName: string
+      /** @description A list of filtered notifications for a visit */
+      notifications: components['schemas']['VisitNotificationEventDto'][]
+    }
+    /** @description Visit notification event details. */
+    VisitNotificationEventDto: {
+      /**
+       * @description Notification Event Type
+       * @enum {string}
+       */
+      type:
+        | 'NON_ASSOCIATION_EVENT'
+        | 'PRISONER_RELEASED_EVENT'
+        | 'PRISONER_RESTRICTION_CHANGE_EVENT'
+        | 'PRISON_VISITS_BLOCKED_FOR_DATE'
+        | 'SESSION_VISITS_BLOCKED_FOR_DATE'
+        | 'PRISONER_RECEIVED_EVENT'
+        | 'PRISONER_ALERTS_UPDATED_EVENT'
+        | 'PERSON_RESTRICTION_UPSERTED_EVENT'
+        | 'VISITOR_RESTRICTION_UPSERTED_EVENT'
+        | 'VISITOR_UNAPPROVED_EVENT'
+      /**
+       * @description Notification Event Reference
+       * @example aa-bb-cc-dd
+       */
+      notificationEventReference: string
+      /**
+       * Format: date-time
+       * @description Created date and time
+       * @example 2018-12-01T13:45:00
+       */
+      createdDateTime: string
+      /** @description Additional data, empty list if no additional data associated */
+      additionalData: components['schemas']['VisitNotificationEventAttributeDto'][]
     }
     OrchestrationNotificationGroupDto: {
       /**
@@ -2246,11 +2329,15 @@ export interface components {
        * @example Wing C
        */
       prisonerLocationGroupNames: string[]
+      /** @description Determines behaviour of category groups. True will mean the category groups are inclusive, false means they are exclusive. */
+      areCategoryGroupsInclusive: boolean
       /**
        * @description prisoner category groups
        * @example Category A Prisoners
        */
       prisonerCategoryGroupNames: string[]
+      /** @description Determines behaviour of incentive groups. True will mean the incentive groups are inclusive, false means they are exclusive. */
+      areIncentiveGroupsInclusive: boolean
       /**
        * @description prisoner incentive level groups
        * @example Enhanced Incentive Level Prisoners
@@ -4293,6 +4380,64 @@ export interface operations {
         }
       }
       /** @description Incorrect permissions to get future visits for a prisoner */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getFutureNotificationVisits: {
+    parameters: {
+      query?: {
+        /** @description list of notificationEventTypes */
+        types?: (
+          | 'NON_ASSOCIATION_EVENT'
+          | 'PRISONER_RELEASED_EVENT'
+          | 'PRISONER_RESTRICTION_CHANGE_EVENT'
+          | 'PRISON_VISITS_BLOCKED_FOR_DATE'
+          | 'SESSION_VISITS_BLOCKED_FOR_DATE'
+          | 'PRISONER_RECEIVED_EVENT'
+          | 'PRISONER_ALERTS_UPDATED_EVENT'
+          | 'PERSON_RESTRICTION_UPSERTED_EVENT'
+          | 'VISITOR_RESTRICTION_UPSERTED_EVENT'
+          | 'VISITOR_UNAPPROVED_EVENT'
+        )[]
+      }
+      header?: never
+      path: {
+        /**
+         * @description prisonCode
+         * @example CFI
+         */
+        prisonCode: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Retrieved future visits with notifications by prison code */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['OrchestrationVisitNotificationsDto'][]
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to access this endpoint */
       403: {
         headers: {
           [name: string]: unknown

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -487,7 +487,7 @@ describe('orchestrationApiClient', () => {
   })
 
   describe('getVisitNotifications', () => {
-    it('should return standardised future visit notifications for given prison and enabled types', async () => {
+    it('should return future visits with standardised notifications for given prison and enabled types', async () => {
       const { enabledRawNotifications } = config.features.notificationTypes
 
       const visitNotificationsRaw = [

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -19,6 +19,8 @@ import {
   Visit,
   VisitBookingDetails,
   VisitBookingDetailsRaw,
+  VisitNotificationEvent,
+  VisitNotificationEventRaw,
   VisitRestriction,
 } from './orchestrationApiTypes'
 import { Prison, VisitSessionData } from '../@types/bapv'
@@ -481,6 +483,44 @@ describe('orchestrationApiClient', () => {
       const output = await orchestrationApiClient.getNotificationCount(prisonId)
 
       expect(output).toEqual(notificationCount)
+    })
+  })
+
+  describe('getVisitNotifications', () => {
+    it('should return standardised future visit notifications for given prison and enabled types', async () => {
+      const { enabledRawNotifications } = config.features.notificationTypes
+
+      const visitNotificationsRaw = [
+        TestData.visitNotificationsRaw({
+          notifications: [
+            { type: 'PRISONER_RELEASED_EVENT' },
+            // these notifications should be converted to VISITOR_RESTRICTION
+            { type: 'PERSON_RESTRICTION_UPSERTED_EVENT' },
+            { type: 'VISITOR_RESTRICTION_UPSERTED_EVENT' },
+          ] as VisitNotificationEventRaw[],
+        }),
+      ]
+
+      const expectedVisitNotifications = [
+        TestData.visitNotifications({
+          notifications: [
+            { type: 'PRISONER_RELEASED_EVENT' },
+            // these notifications should be converted to VISITOR_RESTRICTION
+            { type: 'VISITOR_RESTRICTION' },
+            { type: 'VISITOR_RESTRICTION' },
+          ] as VisitNotificationEvent[],
+        }),
+      ]
+
+      fakeOrchestrationApi
+        .get(`/visits/notification/${prisonId}/visits`)
+        .query(new URLSearchParams({ types: enabledRawNotifications }))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, visitNotificationsRaw)
+
+      const result = await orchestrationApiClient.getVisitNotifications(prisonId)
+
+      expect(result).toStrictEqual(expectedVisitNotifications)
     })
   })
 

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -25,6 +25,8 @@ import {
   Visit,
   VisitBookingDetails,
   VisitBookingDetailsRaw,
+  VisitNotifications,
+  VisitNotificationsRaw,
   VisitPreview,
   VisitRestriction,
   VisitSession,
@@ -238,6 +240,26 @@ export default class OrchestrationApiClient {
     return this.restClient.get({
       path: `/visits/notification/${prisonId}/count`,
       query: new URLSearchParams({ types: this.enabledRawNotifications }).toString(),
+    })
+  }
+
+  async getVisitNotifications(prisonId: string): Promise<VisitNotifications[]> {
+    const visits = await this.restClient.get<VisitNotificationsRaw[]>({
+      path: `/visits/notification/${prisonId}/visits`,
+      query: new URLSearchParams({ types: this.enabledRawNotifications }).toString(),
+    })
+
+    // return visit notifications with 'type' standardised
+    return visits.map(visit => {
+      return {
+        ...visit,
+        notifications: visit.notifications.map(notification => {
+          return {
+            ...notification,
+            type: this.getStandardisedType<NotificationType>(notification.type),
+          }
+        }),
+      }
     })
   }
 

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -263,6 +263,7 @@ export default class OrchestrationApiClient {
     })
   }
 
+  // TODO remove: endpoint deprecated
   async getNotificationGroups(prisonId: string): Promise<NotificationGroup[]> {
     const notificationGroups = await this.restClient.get<NotificationGroupRaw[]>({
       path: `/visits/notification/${prisonId}/groups`,

--- a/server/data/orchestrationApiTypes.ts
+++ b/server/data/orchestrationApiTypes.ts
@@ -9,10 +9,11 @@ export type VisitorSupport = components['schemas']['VisitorSupportDto']
 export type PageVisitDto = components['schemas']['PageVisitDto']
 export type Visit = components['schemas']['VisitDto']
 export type VisitBookingDetailsRaw = components['schemas']['VisitBookingDetailsDto']
+type VisitNotificationDto = components['schemas']['VisitNotificationDto']
 // Replace raw event and notifications 'type' ones that have VISITOR_RESTRICTION
-export type VisitBookingDetails = Omit<components['schemas']['VisitBookingDetailsDto'], 'events' | 'notifications'> & {
+export type VisitBookingDetails = Omit<VisitBookingDetailsRaw, 'events' | 'notifications'> & {
   events: EventAudit[]
-  notifications: (Omit<components['schemas']['VisitNotificationDto'], 'type'> & { type: NotificationType })[]
+  notifications: (Omit<VisitNotificationDto, 'type'> & { type: NotificationType })[]
 }
 export type VisitRestriction = Visit['visitRestriction']
 export type VisitPreview = components['schemas']['VisitPreviewDto']
@@ -42,19 +43,26 @@ export type PrisonerProfile = components['schemas']['PrisonerProfileDto']
 export type VisitSummary = components['schemas']['VisitSummaryDto']
 
 // Raw local/global visitor restrictions mapped to VISITOR_RESTRICTION as described above
-export type EventAuditTypeRaw = components['schemas']['EventAuditOrchestrationDto']['type']
+export type EventAuditRaw = components['schemas']['EventAuditOrchestrationDto']
+export type EventAuditTypeRaw = EventAuditRaw['type']
 export type EventAuditType =
   | Exclude<EventAuditTypeRaw, 'PERSON_RESTRICTION_UPSERTED_EVENT' | 'VISITOR_RESTRICTION_UPSERTED_EVENT'>
   | VISITOR_RESTRICTION
-export type EventAuditRaw = components['schemas']['EventAuditOrchestrationDto']
 export type EventAudit = Omit<EventAuditRaw, 'type'> & { type: EventAuditType }
 
 // Raw local/global visitor restrictions mapped to VISITOR_RESTRICTION as described above
 export type NotificationCount = components['schemas']['NotificationCountDto']
-export type NotificationTypeRaw = components['schemas']['OrchestrationNotificationGroupDto']['type']
+export type VisitNotificationEventRaw = components['schemas']['VisitNotificationEventDto']
+export type NotificationTypeRaw = VisitNotificationEventRaw['type']
 export type NotificationType =
   | Exclude<NotificationTypeRaw, 'PERSON_RESTRICTION_UPSERTED_EVENT' | 'VISITOR_RESTRICTION_UPSERTED_EVENT'>
   | VISITOR_RESTRICTION
+export type VisitNotificationEvent = Omit<VisitNotificationEventRaw, 'type'> & { type: NotificationType }
+export type VisitNotificationsRaw = components['schemas']['OrchestrationVisitNotificationsDto']
+export type VisitNotifications = Omit<VisitNotificationsRaw, 'notifications'> & {
+  notifications: (Omit<VisitNotificationEventRaw, 'type'> & { type: NotificationType })[]
+}
+// TODO review below when deprecated notification groups endpoint removed
 export type NotificationGroupRaw = components['schemas']['OrchestrationNotificationGroupDto']
 export type NotificationGroup = Omit<NotificationGroupRaw, 'type'> & { type: NotificationType }
 export type NotificationVisitInfo = components['schemas']['OrchestrationPrisonerVisitsNotificationDto']

--- a/server/routes/review/reviewUtils.test.ts
+++ b/server/routes/review/reviewUtils.test.ts
@@ -1,0 +1,188 @@
+import { FilterField } from '../../@types/bapv'
+import { NotificationType } from '../../data/orchestrationApiTypes'
+import TestData from '../testutils/testData'
+import { getVisitNotificationFilters } from './reviewUtils'
+
+describe('Visits to review utils', () => {
+  describe('getVisitNotificationFilters() - build filter fields for visit notifications', () => {
+    const visitNotifications = [
+      TestData.visitNotifications({
+        bookedByUserName: 'user3',
+        bookedByName: 'User C',
+        notifications: [TestData.visitNotificationEvent({ type: 'PRISONER_RECEIVED_EVENT' })],
+      }),
+
+      TestData.visitNotifications({
+        bookedByUserName: 'user1',
+        bookedByName: 'User B',
+        notifications: [TestData.visitNotificationEvent({ type: 'PRISONER_RELEASED_EVENT' })],
+      }),
+
+      TestData.visitNotifications({
+        bookedByUserName: 'user2',
+        bookedByName: 'User A',
+        notifications: [TestData.visitNotificationEvent({ type: 'PRISONER_RELEASED_EVENT' })],
+      }),
+    ]
+
+    it('should build list filters sorted alphabetically by label - when current user not in list', async () => {
+      const username = 'a-different-user'
+      const appliedFilters = { bookedBy: <string[]>[], type: <string[]>[] }
+
+      const expectedFilters: FilterField[] = [
+        {
+          id: 'bookedBy',
+          label: 'Booked by',
+          items: [
+            { label: 'User A', value: 'user2', checked: false },
+            { label: 'User B', value: 'user1', checked: false },
+            { label: 'User C', value: 'user3', checked: false },
+          ],
+        },
+        {
+          id: 'type',
+          label: 'Reason',
+          items: [
+            { label: 'Prisoner released', value: 'PRISONER_RELEASED_EVENT', checked: false },
+            { label: 'Prisoner transferred', value: 'PRISONER_RECEIVED_EVENT', checked: false },
+          ],
+        },
+      ]
+
+      const result = getVisitNotificationFilters({ visitNotifications, username, appliedFilters })
+      expect(result).toStrictEqual(expectedFilters)
+    })
+
+    it('should build list filters sorted alphabetically by label - with current user first', async () => {
+      const username = 'user3'
+      const appliedFilters = { bookedBy: <string[]>[], type: <string[]>[] }
+
+      const expectedFilters: FilterField[] = [
+        {
+          id: 'bookedBy',
+          label: 'Booked by',
+          items: [
+            { label: 'User C', value: 'user3', checked: false },
+            { label: 'User A', value: 'user2', checked: false },
+            { label: 'User B', value: 'user1', checked: false },
+          ],
+        },
+        {
+          id: 'type',
+          label: 'Reason',
+          items: [
+            { label: 'Prisoner released', value: 'PRISONER_RELEASED_EVENT', checked: false },
+            { label: 'Prisoner transferred', value: 'PRISONER_RECEIVED_EVENT', checked: false },
+          ],
+        },
+      ]
+
+      const result = getVisitNotificationFilters({ visitNotifications, username, appliedFilters })
+      expect(result).toStrictEqual(expectedFilters)
+    })
+
+    it('should build list filters and handle an unknown event type', async () => {
+      const username = 'user'
+      const appliedFilters = { bookedBy: <string[]>[], type: <string[]>[] }
+
+      const visitNotificationsWithUnknown = [
+        TestData.visitNotifications({
+          bookedByUserName: 'user1',
+          bookedByName: 'User B',
+          notifications: [TestData.visitNotificationEvent({ type: 'UNKNOWN_EVENT_TYPE' as NotificationType })],
+        }),
+      ]
+
+      const expectedFilters: FilterField[] = [
+        {
+          id: 'bookedBy',
+          label: 'Booked by',
+          items: [{ label: 'User B', value: 'user1', checked: false }],
+        },
+        {
+          id: 'type',
+          label: 'Reason',
+          items: [{ label: 'UNKNOWN_EVENT_TYPE', value: 'UNKNOWN_EVENT_TYPE', checked: false }],
+        },
+      ]
+
+      const result = getVisitNotificationFilters({
+        visitNotifications: visitNotificationsWithUnknown,
+        username,
+        appliedFilters,
+      })
+      expect(result).toStrictEqual(expectedFilters)
+    })
+
+    it('should build list filters with applied values checked', async () => {
+      const username = 'user'
+      const appliedFilters = {
+        bookedBy: ['user2', 'user3'],
+        type: ['PRISONER_RELEASED_EVENT'],
+      }
+
+      const expectedFilters: FilterField[] = [
+        {
+          id: 'bookedBy',
+          label: 'Booked by',
+          items: [
+            { label: 'User A', value: 'user2', checked: true },
+            { label: 'User B', value: 'user1', checked: false },
+            { label: 'User C', value: 'user3', checked: true },
+          ],
+        },
+        {
+          id: 'type',
+          label: 'Reason',
+          items: [
+            { label: 'Prisoner released', value: 'PRISONER_RELEASED_EVENT', checked: true },
+            { label: 'Prisoner transferred', value: 'PRISONER_RECEIVED_EVENT', checked: false },
+          ],
+        },
+      ]
+
+      const result = getVisitNotificationFilters({
+        visitNotifications,
+        username,
+        appliedFilters,
+      })
+      expect(result).toStrictEqual(expectedFilters)
+    })
+
+    it('should discard filter values that are not in the unfiltered data', async () => {
+      const username = 'user'
+      const appliedFilters = {
+        bookedBy: ['invalid-user'],
+        type: ['INVALID_EVENT'],
+        invalid: ['invalid-filter'],
+      }
+
+      const expectedFilters: FilterField[] = [
+        {
+          id: 'bookedBy',
+          label: 'Booked by',
+          items: [
+            { label: 'User A', value: 'user2', checked: false },
+            { label: 'User B', value: 'user1', checked: false },
+            { label: 'User C', value: 'user3', checked: false },
+          ],
+        },
+        {
+          id: 'type',
+          label: 'Reason',
+          items: [
+            { label: 'Prisoner released', value: 'PRISONER_RELEASED_EVENT', checked: false },
+            { label: 'Prisoner transferred', value: 'PRISONER_RECEIVED_EVENT', checked: false },
+          ],
+        },
+      ]
+
+      const result = getVisitNotificationFilters({
+        visitNotifications,
+        username,
+        appliedFilters,
+      })
+      expect(result).toStrictEqual(expectedFilters)
+    })
+  })
+})

--- a/server/routes/review/reviewUtils.ts
+++ b/server/routes/review/reviewUtils.ts
@@ -4,7 +4,14 @@ import { NotificationType, VisitNotifications } from '../../data/orchestrationAp
 
 type AppliedFilters = Record<'bookedBy' | 'type', string[]>
 
-// eslint-disable-next-line import/prefer-default-export
+export type VisitToReviewListItem = {
+  bookedByName: string
+  prisonerNumber: string
+  visitReference: string
+  notifications: { key: NotificationType; value: string }[]
+  visitDate: string
+}
+
 export const getVisitNotificationFilters = ({
   visitNotifications,
   username,
@@ -42,4 +49,27 @@ export const getVisitNotificationFilters = ({
     { id: 'bookedBy', label: 'Booked by', items: bookedByItems },
     { id: 'type', label: 'Reason', items: typeItems },
   ]
+}
+
+export const buildVisitsToReviewList = (visitNotifications: VisitNotifications[]): VisitToReviewListItem[] => {
+  return visitNotifications.map(visitNotification => {
+    const uniqueNotifications = new Map<NotificationType, string>()
+    visitNotification.notifications.forEach(notification =>
+      uniqueNotifications.set(notification.type, notificationTypes[notification.type] || notification.type),
+    )
+
+    const notifications = Array.from(uniqueNotifications).map(notification => {
+      return { key: notification[0], value: notification[1] }
+    })
+
+    notifications.sort((a, b) => a.value.localeCompare(b.value))
+
+    return {
+      bookedByName: visitNotification.bookedByName,
+      prisonerNumber: visitNotification.prisonerNumber,
+      visitReference: visitNotification.visitReference,
+      notifications,
+      visitDate: visitNotification.visitDate,
+    }
+  })
 }

--- a/server/routes/review/reviewUtils.ts
+++ b/server/routes/review/reviewUtils.ts
@@ -1,0 +1,45 @@
+import { FilterField } from '../../@types/bapv'
+import { notificationTypes } from '../../constants/notifications'
+import { NotificationType, VisitNotifications } from '../../data/orchestrationApiTypes'
+
+type AppliedFilters = Record<'bookedBy' | 'type', string[]>
+
+// eslint-disable-next-line import/prefer-default-export
+export const getVisitNotificationFilters = ({
+  visitNotifications,
+  username,
+  appliedFilters,
+}: {
+  visitNotifications: VisitNotifications[]
+  username: string
+  appliedFilters: AppliedFilters
+}): FilterField[] => {
+  // get unique username and notification types
+  const usernames = new Map<string, string>()
+  const types = new Map<NotificationType, string>()
+  visitNotifications.forEach(visitNotification => {
+    usernames.set(visitNotification.bookedByUserName, visitNotification.bookedByName)
+    visitNotification.notifications.forEach(notification =>
+      types.set(notification.type, notificationTypes[notification.type]),
+    )
+  })
+
+  // build filter field items from unique values
+  const bookedByItems: FilterField['items'] = []
+  usernames.forEach((label, value) =>
+    bookedByItems.push({ label, value, checked: appliedFilters.bookedBy.includes(value) }),
+  )
+  const typeItems: FilterField['items'] = []
+  types.forEach((label, value) =>
+    typeItems.push({ label: label || value, value, checked: appliedFilters.type.includes(value) }),
+  )
+
+  // sort field labels alphabetically (with current user at top, if present)
+  bookedByItems.sort((a, b) => (b.value === username ? 1 : a.label.localeCompare(b.label)))
+  typeItems.sort((a, b) => a.label.localeCompare(b.label))
+
+  return [
+    { id: 'bookedBy', label: 'Booked by', items: bookedByItems },
+    { id: 'type', label: 'Reason', items: typeItems },
+  ]
+}

--- a/server/routes/review/visitsReviewListingController.ts
+++ b/server/routes/review/visitsReviewListingController.ts
@@ -1,9 +1,14 @@
 import url from 'url'
 import { RequestHandler } from 'express'
-import { ValidationChain, check } from 'express-validator'
+import { ValidationChain, check, matchedData } from 'express-validator'
 import { VisitNotificationsService } from '../../services'
-import { notificationTypes, notificationTypeReasons } from '../../constants/notifications'
-import { buildVisitsToReviewList, getVisitNotificationFilters } from './reviewUtils'
+import { notificationTypeReasons } from '../../constants/notifications'
+import {
+  AppliedFilters,
+  buildVisitsToReviewList,
+  filterVisitNotifications,
+  getVisitNotificationFilters,
+} from './reviewUtils'
 
 export default class VisitsReviewListingController {
   public constructor(private readonly visitNotificationsService: VisitNotificationsService) {}
@@ -13,10 +18,7 @@ export default class VisitsReviewListingController {
       const { selectedEstablishment } = req.session
       const { username } = res.locals.user
 
-      // TODO use matchedData()
-      // OK to cast these as express-validator sanitises to string[]
-      const bookedBy = Array.isArray(req.query.bookedBy) ? <string[]>req.query.bookedBy : []
-      const type = Array.isArray(req.query.type) ? <string[]>req.query.type : []
+      const { bookedBy = [], type = [] } = matchedData<AppliedFilters>(req, { locations: ['query'] })
 
       const visitNotifications = await this.visitNotificationsService.getVisitNotifications({
         username,
@@ -24,34 +26,27 @@ export default class VisitsReviewListingController {
       })
 
       const filters = getVisitNotificationFilters({ visitNotifications, username, appliedFilters: { bookedBy, type } })
+      const isAFilterApplied = filters.some(filter => filter.items.some(item => item.checked))
 
-      // const { filters, visitsReviewList } = await this.visitNotificationsService.getVisitsReviewList(
-      //   res.locals.user.username,
-      //   req.session.selectedEstablishment.prisonId,
-      //   { bookedBy, type },
-      // )
-      const visitsReviewList = buildVisitsToReviewList(visitNotifications)
-
-      const isAFilterApplied = true // filters.some(filter => filter.items.some(item => item.checked))
+      const filteredVisitNotifications = filterVisitNotifications({
+        appliedFilters: { bookedBy, type },
+        visitNotifications,
+      })
+      const visitsReviewList = buildVisitsToReviewList(filteredVisitNotifications)
 
       return res.render('pages/review/visitsReviewListing', {
-        // TODO review these vars
-        notificationTypes,
         notificationTypeDescriptions: Object.values(notificationTypeReasons),
         prisonName: selectedEstablishment.prisonName,
         filters,
-        visitsReviewList,
         isAFilterApplied,
-        visitNotifications,
+        visitsReviewList,
       })
     }
   }
 
   public submit(): RequestHandler {
     return async (req, res) => {
-      // OK to cast these as express-validator sanitises to string[]
-      const bookedBy = Array.isArray(req.body.bookedBy) ? <string[]>req.body.bookedBy : []
-      const type = Array.isArray(req.body.type) ? <string[]>req.body.type : []
+      const { bookedBy, type } = matchedData<AppliedFilters>(req, { locations: ['body'] })
 
       return res.redirect(
         url.format({

--- a/server/routes/review/visitsReviewListingController.ts
+++ b/server/routes/review/visitsReviewListingController.ts
@@ -3,32 +3,46 @@ import { RequestHandler } from 'express'
 import { ValidationChain, check } from 'express-validator'
 import { VisitNotificationsService } from '../../services'
 import { notificationTypes, notificationTypeReasons } from '../../constants/notifications'
+import { buildVisitsToReviewList, getVisitNotificationFilters } from './reviewUtils'
 
 export default class VisitsReviewListingController {
   public constructor(private readonly visitNotificationsService: VisitNotificationsService) {}
 
   public view(): RequestHandler {
     return async (req, res) => {
-      const { prisonName } = req.session.selectedEstablishment
+      const { selectedEstablishment } = req.session
+      const { username } = res.locals.user
+
+      // TODO use matchedData()
       // OK to cast these as express-validator sanitises to string[]
       const bookedBy = Array.isArray(req.query.bookedBy) ? <string[]>req.query.bookedBy : []
       const type = Array.isArray(req.query.type) ? <string[]>req.query.type : []
 
-      const { filters, visitsReviewList } = await this.visitNotificationsService.getVisitsReviewList(
-        res.locals.user.username,
-        req.session.selectedEstablishment.prisonId,
-        { bookedBy, type },
-      )
+      const visitNotifications = await this.visitNotificationsService.getVisitNotifications({
+        username,
+        prisonId: selectedEstablishment.prisonId,
+      })
 
-      const isAFilterApplied = filters.some(filter => filter.items.some(item => item.checked))
+      const filters = getVisitNotificationFilters({ visitNotifications, username, appliedFilters: { bookedBy, type } })
+
+      // const { filters, visitsReviewList } = await this.visitNotificationsService.getVisitsReviewList(
+      //   res.locals.user.username,
+      //   req.session.selectedEstablishment.prisonId,
+      //   { bookedBy, type },
+      // )
+      const visitsReviewList = buildVisitsToReviewList(visitNotifications)
+
+      const isAFilterApplied = true // filters.some(filter => filter.items.some(item => item.checked))
 
       return res.render('pages/review/visitsReviewListing', {
+        // TODO review these vars
         notificationTypes,
         notificationTypeDescriptions: Object.values(notificationTypeReasons),
-        prisonName,
+        prisonName: selectedEstablishment.prisonName,
         filters,
         visitsReviewList,
         isAFilterApplied,
+        visitNotifications,
       })
     }
   }

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -106,7 +106,7 @@ export default class TestData {
     createdTimestamp = '2022-01-01T09:00:00',
     modifiedTimestamp = '2022-01-01T09:00:00',
     reserved = true,
-    completed = false,
+    applicationStatus = 'IN_PROGRESS',
   }: Partial<ApplicationDto> = {}): ApplicationDto =>
     ({
       reference,
@@ -124,7 +124,7 @@ export default class TestData {
       createdTimestamp,
       modifiedTimestamp,
       reserved,
-      completed,
+      applicationStatus,
     }) as ApplicationDto
 
   static caseLoad = ({
@@ -358,7 +358,9 @@ export default class TestData {
     capacity = { closed: 0, open: 40 },
     areLocationGroupsInclusive = true,
     prisonerLocationGroupNames = [],
+    areCategoryGroupsInclusive = true,
     prisonerCategoryGroupNames = [],
+    areIncentiveGroupsInclusive = true,
     prisonerIncentiveLevelGroupNames = [],
     weeklyFrequency = 1,
     visitType = 'SOCIAL',
@@ -370,7 +372,9 @@ export default class TestData {
     capacity,
     areLocationGroupsInclusive,
     prisonerLocationGroupNames,
+    areCategoryGroupsInclusive,
     prisonerCategoryGroupNames,
+    areIncentiveGroupsInclusive,
     prisonerIncentiveLevelGroupNames,
     weeklyFrequency,
     visitType,

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -16,6 +16,10 @@ import {
   Visit,
   VisitBookingDetails,
   VisitBookingDetailsRaw,
+  VisitNotificationEvent,
+  VisitNotificationEventRaw,
+  VisitNotifications,
+  VisitNotificationsRaw,
   VisitPreview,
   VisitSession,
   VisitSummary,
@@ -618,6 +622,66 @@ export default class TestData {
     prisoner,
     visitors,
     events,
+    notifications,
+  })
+
+  static visitNotificationEvent = ({
+    type = 'VISITOR_RESTRICTION',
+    notificationEventReference = 'qr*ub*ze*sb',
+    createdDateTime = '2025-06-02T17:30:00',
+    additionalData = [
+      { attributeName: 'VISITOR_ID', attributeValue: '4321' },
+      { attributeName: 'VISITOR_RESTRICTION', attributeValue: 'PREINF' },
+      { attributeName: 'VISITOR_RESTRICTION_ID', attributeValue: '1' },
+    ],
+  }: Partial<VisitNotificationEvent> = {}): VisitNotificationEvent => ({
+    type,
+    notificationEventReference,
+    createdDateTime,
+    additionalData,
+  })
+
+  static visitNotificationEventRaw = ({
+    type = 'VISITOR_RESTRICTION_UPSERTED_EVENT',
+    notificationEventReference = this.visitNotificationEvent().notificationEventReference,
+    createdDateTime = this.visitNotificationEvent().createdDateTime,
+    additionalData = this.visitNotificationEvent().additionalData,
+  }: Partial<VisitNotificationEventRaw> = {}): VisitNotificationEventRaw => ({
+    type,
+    notificationEventReference,
+    createdDateTime,
+    additionalData,
+  })
+
+  static visitNotifications = ({
+    visitReference = 'ab-cd-ef-gh',
+    prisonerNumber = 'A1234BC',
+    bookedByUserName = 'user1',
+    bookedByName = 'User One',
+    visitDate = '2025-07-01',
+    notifications = [this.visitNotificationEvent()],
+  }: Partial<VisitNotifications> = {}): VisitNotifications => ({
+    visitReference,
+    prisonerNumber,
+    bookedByUserName,
+    bookedByName,
+    visitDate,
+    notifications,
+  })
+
+  static visitNotificationsRaw = ({
+    visitReference = this.visitNotifications().visitReference,
+    prisonerNumber = this.visitNotifications().prisonerNumber,
+    bookedByUserName = this.visitNotifications().bookedByUserName,
+    bookedByName = this.visitNotifications().bookedByName,
+    visitDate = this.visitNotifications().visitDate,
+    notifications = [this.visitNotificationEventRaw()],
+  }: Partial<VisitNotificationsRaw> = {}): VisitNotificationsRaw => ({
+    visitReference,
+    prisonerNumber,
+    bookedByUserName,
+    bookedByName,
+    visitDate,
     notifications,
   })
 

--- a/server/services/visitNotificationsService.test.ts
+++ b/server/services/visitNotificationsService.test.ts
@@ -38,6 +38,17 @@ describe('Visit notifications service', () => {
     })
   })
 
+  describe('getVisitNotifications', () => {
+    it('should return future visits with notifications for given prison', async () => {
+      const visitNotifications = [TestData.visitNotifications()]
+      orchestrationApiClient.getVisitNotifications.mockResolvedValue(visitNotifications)
+
+      const result = await visitNotificationsService.getVisitNotifications({ username: 'user', prisonId })
+
+      expect(result).toStrictEqual(visitNotifications)
+    })
+  })
+
   describe('dateHasNotifications', () => {
     const date = '2024-04-24'
 

--- a/server/services/visitNotificationsService.ts
+++ b/server/services/visitNotificationsService.ts
@@ -1,7 +1,13 @@
 import { FilterField, VisitsReviewListItem } from '../@types/bapv'
 import { notificationTypes } from '../constants/notifications'
 import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
-import { IgnoreVisitNotificationsDto, NotificationCount, NotificationGroup, Visit } from '../data/orchestrationApiTypes'
+import {
+  IgnoreVisitNotificationsDto,
+  NotificationCount,
+  NotificationGroup,
+  Visit,
+  VisitNotifications,
+} from '../data/orchestrationApiTypes'
 import { prisonerDateTimePretty } from '../utils/utils'
 
 type AppliedFilters = Record<'bookedBy' | 'type', string[]>
@@ -17,6 +23,18 @@ export default class VisitNotificationsService {
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
     return orchestrationApiClient.getNotificationCount(prisonId)
+  }
+
+  async getVisitNotifications({
+    username,
+    prisonId,
+  }: {
+    username: string
+    prisonId: string
+  }): Promise<VisitNotifications[]> {
+    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
+    return orchestrationApiClient.getVisitNotifications(prisonId)
   }
 
   async dateHasNotifications(username: string, prisonId: string, date: string): Promise<boolean> {

--- a/server/views/pages/review/visitsReviewListing.njk
+++ b/server/views/pages/review/visitsReviewListing.njk
@@ -11,13 +11,39 @@
   {{ breadcrumbs() }}
 {% endblock %}
 
-{% macro arrayToList(items) %}
-  <ul class="govuk-list govuk-!-margin-bottom-0">
-    {% for item in items %}
-      <li class="govuk-!-margin-bottom-{{ "0" if loop.last else "3" }}">{{ item }}</li>
-    {% endfor %}
-  </ul>
-{% endmacro %}
+{% set reviewListRows = [] %}
+{% for listItem in visitsReviewList %}
+  {% set notifications %}
+    <ul class="govuk-list">
+      {% for notification in listItem.notifications -%}
+        <li class="govuk-!-margin-bottom-3">{{ govukTag({ text: notification.value, classes: "notification-tag notification-tag--" + notification.key | lower }) }}</li>
+      {%- endfor %}
+    </ul>
+  {% endset %}
+
+  {% set reviewListRows = (reviewListRows.push([
+    {
+      attributes: { "data-test": "prisoner-number-" + loop.index },
+      text: listItem.prisonerNumber
+    },
+    {
+      attributes: { "data-test": "visit-date-" + loop.index },
+      text: listItem.visitDate | formatDate
+    },
+    {
+      attributes: { "data-test": "booked-by-" + loop.index },
+      text: listItem.bookedByName
+    },
+    {
+      attributes: { "data-test": "type-" + loop.index },
+      html: notifications
+    },
+    {
+      attributes: { "data-test": "action-" + loop.index },
+      html: '<a class="govuk-link--no-visited-state" href="/visit/' + listItem.visitReference + '" >View</a>'
+    }
+  ]), reviewListRows) %}
+{% endfor %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -43,34 +69,6 @@
       {% endif %}
 
       {% if visitsReviewList | length %}
-        {% set reviewListRows = [] %}
-        {% for listItem in visitsReviewList %}
-          {% set reviewListRows = (reviewListRows.push([
-            {
-              attributes: { "data-test": "prisoner-number-" + loop.index },
-              html: arrayToList(listItem.prisonerNumbers)
-            },
-            {
-              attributes: { "data-test": "visit-date-" + loop.index },
-              html: arrayToList(listItem.visitDates)
-            },
-            {
-              attributes: { "data-test": "booked-by-" + loop.index },
-              html: arrayToList(listItem.bookedByNames)
-            },
-            {
-              attributes: { "data-test": "type-" + loop.index },
-              html: govukTag({
-                text: notificationTypes[listItem.type] | default(listItem.type),
-                classes: 'notification-tag notification-tag--' + listItem.type | lower
-              })
-            },
-            {
-              attributes: { "data-test": "action-" + loop.index },
-              html: '<a class="govuk-link--no-visited-state" href="' + listItem.actionUrl + '" data-test="' + listItem.reference + '">View</a>'
-            }
-          ]), reviewListRows) %}
-        {% endfor %}
 
         {{ govukTable({
           attributes: { "data-test": "bookings-list" },
@@ -94,14 +92,14 @@
           rows: reviewListRows
         }) }}
 
-      {% endif %}
+      {% else %}
 
-      {% if visitsReviewList | length == 0 %}
         {% if isAFilterApplied  %}
           <p data-test="no-bookings-for-filters">There are no bookings to review for {{ prisonName }} that match the selected filters.</p>
         {% else %}
           <p data-test="no-bookings">There are no bookings for {{ prisonName }} that need review.</p>
         {% endif %}
+
       {% endif %}
     </div>
   </div>

--- a/server/views/pages/review/visitsReviewListing.njk
+++ b/server/views/pages/review/visitsReviewListing.njk
@@ -40,7 +40,7 @@
     },
     {
       attributes: { "data-test": "action-" + loop.index },
-      html: '<a class="govuk-link--no-visited-state" href="/visit/' + listItem.visitReference + '" >View</a>'
+      html: '<a class="govuk-link--no-visited-state" href="/visit/' + listItem.visitReference + '?from=review" >View</a>'
     }
   ]), reviewListRows) %}
 {% endfor %}


### PR DESCRIPTION
Rewrite of 'Needs review' visit listing page:
*  use new API that groups by visit, with potentially multiple notifications per visit (previously, a single visit with two notifications would mean two rows)
* reduplicates notification types within a visit row so only one of each type is shown

(Some tidying to do in a follow-on PR to remove now-redundant code for handling the old API and data format.)
