### PR TITLE
VB-5761 Visit details page: fix for visitors with no date of birth

### DIFF
--- a/server/routes/visit/visitDetailsController.test.ts
+++ b/server/routes/visit/visitDetailsController.test.ts
@@ -119,8 +119,7 @@ describe('Visit details page', () => {
           // visitor details
           expect($('[data-test="visitor-name-1"]').text()).toBe('Jeanette Smith')
           expect($('[data-test="visitor-relation-1"]').text()).toBe('wife')
-          expect($('[data-test="visitor-dob-1"]').text()).toBe('28 July 1986')
-          expect($('[data-test="visitor-age-1"]').text()).toBe('35 years old')
+          expect($('[data-test="visitor-dob-1"]').text()).toMatch(/28 July 1986\s+\(35 years old\)/)
           expect($('[data-test="visitor-address-1"]').text()).toBe('123 The Street,\nCoventry')
           expect($('[data-test="visitor-1-restriction-1"]').text()).toContain('Closed')
           expect($('[data-test="visitor-1-restriction-1-start"]').text()).toContain('11/1/2022')

--- a/server/views/pages/bookAVisit/checkYourBooking.njk
+++ b/server/views/pages/bookAVisit/checkYourBooking.njk
@@ -138,7 +138,7 @@
             text: "Main contact"
           },
           value: {
-            html: '<p><span class="test-main-contact-name">' + contactName | escape+ '</span><br><span class="test-main-contact-number">' +
+            html: '<p><span class="test-main-contact-name">' + contactName + '</span><br><span class="test-main-contact-number">' +
               mainContact.phoneNumber | d("No phone number provided", true) | escape + "</span></p>"
           },
           actions: {

--- a/server/views/pages/bookAVisit/confirmation.njk
+++ b/server/views/pages/bookAVisit/confirmation.njk
@@ -154,7 +154,7 @@
         text: "Main contact"
       },
       value: {
-        html: '<p class="test-main-contact-name">' + contactName | escape + '</p><p class="test-main-contact-number">' +
+        html: '<p class="test-main-contact-name">' + contactName + '</p><p class="test-main-contact-number">' +
           mainContact.phoneNumber | d("No phone number provided", true) | escape + '</p>'
       }
     }

--- a/server/views/pages/visit/visitDetails.njk
+++ b/server/views/pages/visit/visitDetails.njk
@@ -3,6 +3,7 @@
 {%- from "moj/components/alert/macro.njk" import mojAlert -%}
 {%- from "moj/components/timeline/macro.njk" import mojTimeline -%}
 {%- from "components/expandableComment/macro.njk" import bapvExpandableComment -%}
+{% from "components/visitors.njk" import visitorDateOfBirth %}
 
 {% set pageHeaderTitle = "Visit booking details (" + visitDetails.reference + ")" %}
 
@@ -200,9 +201,8 @@
           </h3>
           <dl class="govuk-list bapv-visit-details__person-details">
             <dt>Date of birth</dt>
-            <dd>
-              <span data-test="visitor-dob-{{ loop.index }}">{{ visitor.dateOfBirth | formatDate }}</span>
-              (<span data-test="visitor-age-{{ loop.index }}">{{ visitor.dateOfBirth | displayAge }}</span>)
+            <dd data-test="visitor-dob-{{ loop.index }}">
+              {{- visitorDateOfBirth(visitor) -}}
             </dd>
 
             <dt>Address</dt>


### PR DESCRIPTION
* Show "Not entered" if a visitor has no date of birth set
* Fix double-escaping of main contact name on check details and booking confirmation page