### PR TITLE
VB-5790 Tweak minimum booking window

### DIFF
--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -543,7 +543,7 @@ export default {
     offenderNo,
     visitSessions,
     username = 'USER1',
-    min = '2',
+    min = '3',
   }: {
     prisonId: string
     offenderNo: string

--- a/server/routes/visitJourney/dateAndTime.test.ts
+++ b/server/routes/visitJourney/dateAndTime.test.ts
@@ -178,7 +178,7 @@ testJourneys.forEach(journey => {
               offenderNo: visitSessionData.prisoner.offenderNo,
               prisonId,
               visitRestriction: visitSessionData.visitRestriction,
-              minNumberOfDays: 2,
+              minNumberOfDays: 3,
             })
           })
       })
@@ -252,7 +252,7 @@ testJourneys.forEach(journey => {
       })
 
       it('should show warning message when visitor ban days set in session is greater than default min booking days', () => {
-        visitSessionData.daysUntilBanExpiry = 3 // default minimum booking ahead days is 2
+        visitSessionData.daysUntilBanExpiry = 4 // default minimum booking ahead days is 3 (2 + 1 - to ensure 'full' days)
 
         sessionApp = appWithAllRoutes({
           services: { visitSessionsService },

--- a/server/routes/visitJourney/dateAndTime.ts
+++ b/server/routes/visitJourney/dateAndTime.ts
@@ -25,7 +25,7 @@ export default class DateAndTime {
     // calculate min booking window and any override or bans in place
     const policyNoticeDaysMin = visitSessionData.overrideBookingWindow
       ? 0
-      : req.session.selectedEstablishment.policyNoticeDaysMin
+      : req.session.selectedEstablishment.policyNoticeDaysMin + 1 // ensure 'full' min days
 
     const isBanActive = visitSessionData.daysUntilBanExpiry > policyNoticeDaysMin
     const minNumberOfDays = isBanActive ? visitSessionData.daysUntilBanExpiry : policyNoticeDaysMin


### PR DESCRIPTION
Add one to the minimum number of days for the booking window to ensure correct minimum 'full' days are used.