### PR TITLE
VB-5790 Confirm update prompt: align with minimum booking window

### DIFF
--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -266,6 +266,7 @@
   color: #005ea5;
 }
 
+.bapv-align-end-col-right,
 [data-module=moj-sortable-table] {
   & th:last-child, & td:last-child {
   text-align: right;

--- a/server/routes/visit/updateVisitController.test.ts
+++ b/server/routes/visit/updateVisitController.test.ts
@@ -26,7 +26,7 @@ jest.mock('../visitorUtils', () => {
 })
 
 beforeEach(() => {
-  const fakeDate = new Date('2022-01-01')
+  const fakeDate = new Date('2022-01-01T08:00:00')
   jest.useFakeTimers({ advanceTimers: true, now: new Date(fakeDate) })
 
   visitDetails = TestData.visitBookingDetails()
@@ -133,16 +133,10 @@ describe('Start a visit update journey', () => {
       return request(app).post('/visit/ab-cd-ef-gh').expect(302).expect('location', '/visit/ab-cd-ef-gh')
     })
 
-    // default visit is 13 days away so using 14 days for simplicity
-    it('should redirect to /visit/:reference/confirm-update if visit is less days away than policy notice days', () => {
-      app = appWithAllRoutes({
-        services: {
-          visitService,
-        },
-        sessionData: {
-          selectedEstablishment: TestData.prison({ policyNoticeDaysMin: 14 }),
-        } as SessionData,
-      })
+    it('should redirect to /visit/:reference/confirm-update if visit is within minimum booking window days', () => {
+      // fake test date is 2022-01-01 and default min booking window days is 2
+      // so visit on 3rd or sooner triggers update confirmation
+      visitDetails.startTimestamp = '2022-01-03T10:00:00'
 
       return request(app).post('/visit/ab-cd-ef-gh').expect(302).expect('location', '/visit/ab-cd-ef-gh/confirm-update')
     })

--- a/server/routes/visit/updateVisitController.ts
+++ b/server/routes/visit/updateVisitController.ts
@@ -78,7 +78,7 @@ export default class UpdateVisitController {
 
       const numberOfDays = differenceInCalendarDays(new Date(visitDetails.startTimestamp), new Date())
 
-      if (numberOfDays >= policyNoticeDaysMin) {
+      if (numberOfDays > policyNoticeDaysMin) {
         return res.redirect('/update-a-visit/select-visitors')
       }
       return res.redirect(`/visit/${reference}/confirm-update`)

--- a/server/views/pages/review/visitsReviewListing.njk
+++ b/server/views/pages/review/visitsReviewListing.njk
@@ -74,6 +74,7 @@
 
         {{ govukTable({
           attributes: { "data-test": "bookings-list" },
+          classes: "bapv-align-end-col-right",
           head: [
             {
               text: "Prison number"


### PR DESCRIPTION
Follow on from #1053.

* Align 'Confirm update' prompt page with minimum booking window
* (plus an unrelated table styling fix)