### PR TITLE
VB-5795 Add visit request events to booking history timeline (and integration test refactor)

### DIFF
--- a/integration_tests/e2e/blockVisitDates/blockVisitDates.cy.ts
+++ b/integration_tests/e2e/blockVisitDates/blockVisitDates.cy.ts
@@ -55,7 +55,7 @@ context('Block visit dates', () => {
 
     // back to listings page and see success message and new blocked date
     blockedVisitPage.checkOnPage()
-    blockedVisitPage.getMessage().contains(`Visits are blocked for ${firstOfNextMonthLong}.`)
+    blockedVisitPage.getMessages().eq(0).contains(`Visits are blocked for ${firstOfNextMonthLong}.`)
     blockedVisitPage.blockedDate(1).contains(firstOfNextMonthLong)
     blockedVisitPage.blockedBy(1).contains('User one')
     blockedVisitPage.unblockLink(1).contains('Unblock')
@@ -82,7 +82,7 @@ context('Block visit dates', () => {
 
     // back to listings page and see success message and no blocked dates
     blockedVisitPage.checkOnPage()
-    blockedVisitPage.getMessage().contains(`Visits are unblocked for ${firstOfNextMonthLong}.`)
+    blockedVisitPage.getMessages().eq(0).contains(`Visits are unblocked for ${firstOfNextMonthLong}.`)
     blockedVisitPage.noBlockedDates().contains('no upcoming blocked dates')
   })
 })

--- a/integration_tests/e2e/blockVisitDates/blockVisitDates.cy.ts
+++ b/integration_tests/e2e/blockVisitDates/blockVisitDates.cy.ts
@@ -40,10 +40,9 @@ context('Block visit dates', () => {
     // Continue to Are you sure page
     cy.task('stubGetBookedVisitCountByDate', { date: firstOfNextMonthShort })
     blockedVisitPage.continue()
-    const blockVisitDateConfirmationPage = Page.verifyOnPageTitle(
-      BlockVisitDateConfirmationPage,
-      format(firstOfNextMonth, longDateFormat),
-    )
+    const blockVisitDateConfirmationPage = Page.verifyOnPage(BlockVisitDateConfirmationPage, {
+      date: format(firstOfNextMonth, longDateFormat),
+    })
 
     // select Yes and confirm
     cy.task('stubBlockVisitDate', { date: firstOfNextMonthShort })

--- a/integration_tests/e2e/establishmentNotSupported.cy.ts
+++ b/integration_tests/e2e/establishmentNotSupported.cy.ts
@@ -14,7 +14,7 @@ context('Establishment not supported', () => {
     cy.task('stubSupportedPrisonIds')
     cy.signIn()
 
-    Page.verifyOnPageTitle(EstablishmentNotSupportedPage, 'XYZ (HMP) does not use this service')
+    Page.verifyOnPage(EstablishmentNotSupportedPage, { title: 'XYZ (HMP) does not use this service' })
   })
 
   it('should redirect to establishment not supported page if case load changes from supported to unsupported', () => {
@@ -39,6 +39,6 @@ context('Establishment not supported', () => {
     searchForAPrisonerPage.searchButton().click()
 
     // Redirected to establishment not supported page
-    Page.verifyOnPageTitle(EstablishmentNotSupportedPage, 'XYZ (HMP) does not use this service')
+    Page.verifyOnPage(EstablishmentNotSupportedPage, { title: 'XYZ (HMP) does not use this service' })
   })
 })

--- a/integration_tests/e2e/prisoner/prisonerProfile.cy.ts
+++ b/integration_tests/e2e/prisoner/prisonerProfile.cy.ts
@@ -48,7 +48,7 @@ context('Prisoner profile page', () => {
 
     // Go to prisoner profile page
     cy.visit(`/prisoner/${prisonerId}`)
-    const prisonerProfilePage = Page.verifyOnPageTitle(PrisonerProfilePage, prisonerDisplayName)
+    const prisonerProfilePage = Page.verifyOnPage(PrisonerProfilePage, { title: prisonerDisplayName })
 
     // Prisoner details
     prisonerProfilePage.flaggedAlerts().eq(0).contains('Protective Isolation Unit')

--- a/integration_tests/e2e/review/reviewAVisit.cy.ts
+++ b/integration_tests/e2e/review/reviewAVisit.cy.ts
@@ -50,8 +50,8 @@ context('Review a visit', () => {
 
     // Start on booking summary page and chose 'Do not change' button
     cy.visit('/visit/ab-cd-ef-gh')
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
-    visitDetailsPage.visitMessages().eq(0).contains(notificationTypeAlerts.PRISONER_RECEIVED_EVENT.title)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
+    visitDetailsPage.getMessages().eq(0).contains(notificationTypeAlerts.PRISONER_RECEIVED_EVENT.title)
     visitDetailsPage.eventDescription(0).contains(notificationTypes.PRISONER_RECEIVED_EVENT)
     visitDetailsPage.clearNotifications().click()
 
@@ -83,7 +83,7 @@ context('Review a visit', () => {
     cy.task('stubGetVisitDetailed', visitDetailsUpdated)
 
     clearNotificationsPage.submit()
-    visitDetailsPage.visitMessages().should('not.exist')
+    visitDetailsPage.getMessages().should('not.exist')
     visitDetailsPage.eventHeader(0).contains(eventAuditTypes.IGNORE_VISIT_NOTIFICATIONS_EVENT)
     visitDetailsPage.actionedBy(0).contains('User One')
     visitDetailsPage.eventTime(0).contains('Thursday 11 April 2024 at 11am')

--- a/integration_tests/e2e/search/searchForABooking.cy.ts
+++ b/integration_tests/e2e/search/searchForABooking.cy.ts
@@ -47,7 +47,7 @@ context('Search for a booking by reference', () => {
     cy.task('stubGetVisitDetailed', TestData.visitBookingDetailsRaw())
     searchBookingByReferenceResultsPage.visitReferenceLink().click()
 
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
     visitDetailsPage.visitReference().contains('ab-cd-ef-gh')
     visitDetailsPage.prisonerName().contains('John Smith')
   })
@@ -80,7 +80,7 @@ context('Search for a booking by reference', () => {
     cy.task('stubGetVisitDetailed', TestData.visitBookingDetailsRaw())
     prisonerProfilePage.visitTabReference().eq(0).click()
 
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
     visitDetailsPage.visitReference().contains('ab-cd-ef-gh')
     visitDetailsPage.prisonerName().contains('John Smith')
   })

--- a/integration_tests/e2e/search/searchForABooking.cy.ts
+++ b/integration_tests/e2e/search/searchForABooking.cy.ts
@@ -76,7 +76,7 @@ context('Search for a booking by reference', () => {
     cy.task('stubPrisonerProfile', TestData.prisonerProfile({ visits: [TestData.visitSummary()] }))
     searchBookingByPrisonerResultsPage.prisonerLink().click()
 
-    const prisonerProfilePage = Page.verifyOnPageTitle(PrisonerProfilePage, 'Smith, John')
+    const prisonerProfilePage = Page.verifyOnPage(PrisonerProfilePage, { title: 'Smith, John' })
     cy.task('stubGetVisitDetailed', TestData.visitBookingDetailsRaw())
     prisonerProfilePage.visitTabReference().eq(0).click()
 

--- a/integration_tests/e2e/visit/cancelVisit.cy.ts
+++ b/integration_tests/e2e/visit/cancelVisit.cy.ts
@@ -52,7 +52,7 @@ context('Cancel visit journey', () => {
 
     cy.visit('/visit/ab-cd-ef-gh')
 
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
     visitDetailsPage.visitReference().contains('ab-cd-ef-gh')
     visitDetailsPage.cancelBooking().click()
 
@@ -88,7 +88,7 @@ context('Cancel visit journey', () => {
 
     cy.visit('/visit/ab-cd-ef-gh')
 
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
     visitDetailsPage.visitReference().contains('ab-cd-ef-gh')
     visitDetailsPage.cancelBooking().click()
 

--- a/integration_tests/e2e/visit/visitDetails.cy.ts
+++ b/integration_tests/e2e/visit/visitDetails.cy.ts
@@ -33,9 +33,9 @@ context('Visit details page', () => {
     cy.task('stubGetVisitDetailed', visitDetails)
 
     cy.visit('/visit/ab-cd-ef-gh')
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
 
-    visitDetailsPage.visitMessages().eq(0).contains('This visit was cancelled by a visitor.')
+    visitDetailsPage.getMessages().eq(0).contains('This visit was cancelled by a visitor.')
 
     // visit Details
     visitDetailsPage.visitDate().contains('Friday 14 January 2022')
@@ -92,14 +92,14 @@ context('Visit details page', () => {
 
     cy.visit('/visit/ab-cd-ef-gh')
 
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
     visitDetailsPage.visitReference().contains('ab-cd-ef-gh')
     visitDetailsPage.updateBooking().should('have.length', 1)
     visitDetailsPage.cancelBooking().should('have.length', 1)
     visitDetailsPage.clearNotifications().should('have.length', 0)
 
     // Messages
-    visitDetailsPage.visitMessages().eq(0).contains(notificationTypeAlerts.PRISON_VISITS_BLOCKED_FOR_DATE.title)
+    visitDetailsPage.getMessages().eq(0).contains(notificationTypeAlerts.PRISON_VISITS_BLOCKED_FOR_DATE.title)
 
     // Prisoner Details
     visitDetailsPage.prisonerName().contains('John Smith')
@@ -122,14 +122,14 @@ context('Visit details page', () => {
 
     cy.visit('/visit/ab-cd-ef-gh')
 
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
     visitDetailsPage.visitReference().contains('ab-cd-ef-gh')
     visitDetailsPage.updateBooking().should('have.length', 0)
     visitDetailsPage.cancelBooking().should('have.length', 1)
     visitDetailsPage.clearNotifications().should('have.length', 1)
 
     // Messages
-    visitDetailsPage.visitMessages().eq(0).contains(notificationTypeAlerts.PRISONER_RECEIVED_EVENT.title)
+    visitDetailsPage.getMessages().eq(0).contains(notificationTypeAlerts.PRISONER_RECEIVED_EVENT.title)
 
     // Prisoner Details
     visitDetailsPage.prisonerName().contains('John Smith')
@@ -170,11 +170,11 @@ context('Visit details page', () => {
     cy.task('stubGetVisitDetailed', visitDetails)
 
     cy.visit('/visit/ab-cd-ef-gh')
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
 
     // Messages - alert component
     visitDetailsPage
-      .visitMessages()
+      .getMessages()
       .eq(0)
       .within(() => {
         cy.contains('This visit needs review')

--- a/integration_tests/e2e/visitJourney/bookAVisit.cy.ts
+++ b/integration_tests/e2e/visitJourney/bookAVisit.cy.ts
@@ -112,7 +112,7 @@ context('Book a visit', () => {
     // Prisoner profile page
     cy.task('stubPrisonerProfile', profile)
     searchForAPrisonerResultsPage.firstResultLink().contains('Smith, John').click()
-    const prisonerProfilePage = Page.verifyOnPageTitle(PrisonerProfilePage, 'Smith, John')
+    const prisonerProfilePage = Page.verifyOnPage(PrisonerProfilePage, { title: 'Smith, John' })
 
     // Select visitors
     cy.task('stubPrisonerSocialContacts', { offenderNo, contacts })
@@ -228,7 +228,7 @@ context('Book a visit', () => {
     })
 
     checkYourBookingPage.submitBooking()
-    const confirmationPage = Page.verifyOnPageTitle(ConfirmationPage, 'Booking confirmed')
+    const confirmationPage = Page.verifyOnPage(ConfirmationPage, { title: 'Booking confirmed' })
     confirmationPage.bookingReference().contains(TestData.visit().reference)
     confirmationPage.prisonerName().contains('John Smith')
     confirmationPage.prisonerNumber().contains(offenderNo)
@@ -263,7 +263,7 @@ context('Book a visit', () => {
 
     cy.visit(`/prisoner/${prisonerId}`)
 
-    const prisonerProfilePage = Page.verifyOnPageTitle(PrisonerProfilePage, prisonerDisplayName)
+    const prisonerProfilePage = Page.verifyOnPage(PrisonerProfilePage, { title: prisonerDisplayName })
 
     prisonerProfilePage.bookAVisitButton().should('be.disabled')
     prisonerProfilePage
@@ -293,7 +293,7 @@ context('Book a visit', () => {
 
     cy.visit(`/prisoner/${prisonerId}`)
 
-    const prisonerProfilePage = Page.verifyOnPageTitle(PrisonerProfilePage, prisonerDisplayName)
+    const prisonerProfilePage = Page.verifyOnPage(PrisonerProfilePage, { title: prisonerDisplayName })
     prisonerProfilePage.bookAVisitButton().click()
 
     const selectVisitorsPage = Page.verifyOnPage(SelectVisitorsPage)

--- a/integration_tests/e2e/visitJourney/checkYourBooking.cy.ts
+++ b/integration_tests/e2e/visitJourney/checkYourBooking.cy.ts
@@ -58,7 +58,7 @@ context('Check visit details page', () => {
     cy.task('stubPrisonerProfile', profile)
     cy.visit(`/prisoner/${prisonerId}`)
 
-    const prisonerProfilePage = Page.verifyOnPageTitle(PrisonerProfilePage, 'Smith, John')
+    const prisonerProfilePage = Page.verifyOnPage(PrisonerProfilePage, { title: 'Smith, John' })
 
     // Select visitors - first of two
     prisonerProfilePage.bookAVisitButton().click()
@@ -254,7 +254,7 @@ context('Check visit details page', () => {
     })
 
     checkYourBookingPage.submitBooking()
-    const confirmationPage = Page.verifyOnPageTitle(ConfirmationPage, 'Booking confirmed')
+    const confirmationPage = Page.verifyOnPage(ConfirmationPage, { title: 'Booking confirmed' })
     confirmationPage.bookingReference().contains(TestData.visit().reference)
     confirmationPage.prisonerName().contains('John Smith')
     confirmationPage.prisonerNumber().contains(prisonerId)
@@ -274,7 +274,7 @@ context('Check visit details page', () => {
     cy.task('stubPrisonerProfile', profile)
     cy.visit(`/prisoner/${prisonerId}`)
 
-    const prisonerProfilePage = Page.verifyOnPageTitle(PrisonerProfilePage, 'Smith, John')
+    const prisonerProfilePage = Page.verifyOnPage(PrisonerProfilePage, { title: 'Smith, John' })
 
     // Select visitors - first of two
     prisonerProfilePage.bookAVisitButton().click()

--- a/integration_tests/e2e/visitJourney/checkYourBooking.cy.ts
+++ b/integration_tests/e2e/visitJourney/checkYourBooking.cy.ts
@@ -350,7 +350,8 @@ context('Check visit details page', () => {
     // Check alert on select date and time page
     Page.verifyOnPage(SelectVisitDateAndTime)
     selectVisitDateAndTime
-      .mojAlertTitle()
+      .getMessages()
+      .eq(0)
       .contains(
         `John Smith now has a non-association on ${format(new Date(visitSessions[0].startTimestamp), dayMonthFormat)}.`,
       )

--- a/integration_tests/e2e/visitJourney/updateAVisit.cy.ts
+++ b/integration_tests/e2e/visitJourney/updateAVisit.cy.ts
@@ -71,7 +71,7 @@ context('Update a visit', () => {
 
     // Visit details page
     cy.visit('/visit/ab-cd-ef-gh')
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
     visitDetailsPage.visitReference().contains('ab-cd-ef-gh')
     visitDetailsPage.prisonerName().contains('John Smith')
 
@@ -233,7 +233,7 @@ context('Update a visit', () => {
 
     // Visit details page
     cy.visit('/visit/ab-cd-ef-gh')
-    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage)
+    const visitDetailsPage = Page.verifyOnPage(VisitDetailsPage, 'booking')
     visitDetailsPage.visitReference().contains('ab-cd-ef-gh')
     visitDetailsPage.prisonerName().contains('John Smith')
 

--- a/integration_tests/e2e/visitJourney/updateAVisit.cy.ts
+++ b/integration_tests/e2e/visitJourney/updateAVisit.cy.ts
@@ -185,7 +185,7 @@ context('Update a visit', () => {
     checkYourBookingPage.submitBooking()
 
     // Confirmation page
-    const confirmationPage = Page.verifyOnPageTitle(ConfirmationPage, 'Booking updated')
+    const confirmationPage = Page.verifyOnPage(ConfirmationPage, { title: 'Booking updated' })
     confirmationPage.bookingReference().contains(TestData.visit().reference)
     confirmationPage.prisonerName().contains('John Smith')
     confirmationPage.prisonerNumber().contains(offenderNo)

--- a/integration_tests/pages/blockVisitDates/blockVisitDateConfirmation.ts
+++ b/integration_tests/pages/blockVisitDates/blockVisitDateConfirmation.ts
@@ -1,7 +1,7 @@
 import Page from '../page'
 
 export default class BlockVisitDateConfirmationPage extends Page {
-  constructor(date: string) {
+  constructor({ date }: { date: string }) {
     super(`Are you sure you want to block visits on ${date}?`)
   }
 

--- a/integration_tests/pages/blockVisitDates/blockVisitDates.ts
+++ b/integration_tests/pages/blockVisitDates/blockVisitDates.ts
@@ -9,8 +9,6 @@ export default class BlockVisitDatesPage extends Page {
     this.datePicker = new DatePickerComponent()
   }
 
-  getMessage = (): PageElement => cy.get('.moj-alert__content')
-
   continue = (): void => {
     cy.get('[data-test="submit"]').click()
   }

--- a/integration_tests/pages/establishmentNotSupported.ts
+++ b/integration_tests/pages/establishmentNotSupported.ts
@@ -1,7 +1,7 @@
 import Page from './page'
 
 export default class EstablishmentNotSupportedPage extends Page {
-  constructor(title: string) {
+  constructor({ title }: { title: string }) {
     super(title)
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -8,10 +8,6 @@ export default abstract class Page {
     return new constructor(options)
   }
 
-  static verifyOnPageTitle = <T>(constructor: new (string) => T, title?: string): T => {
-    return new constructor(title)
-  }
-
   protected constructor(
     private readonly title: string,
     private readonly options: { axeTest?: boolean; axeRulesToIgnore?: string[] } = {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -4,23 +4,23 @@ import logAccessibilityViolations from '../support/logAccessibilityViolations'
 export type PageElement = Cypress.Chainable<JQuery>
 
 export default abstract class Page {
-  static verifyOnPage<T>(constructor: new () => T): T {
-    return new constructor()
+  static verifyOnPage<T, Options>(constructor: new (options: Options) => T, options?: Options): T {
+    return new constructor(options)
   }
 
   static verifyOnPageTitle = <T>(constructor: new (string) => T, title?: string): T => {
     return new constructor(title)
   }
 
-  constructor(
+  protected constructor(
     private readonly title: string,
     private readonly options: { axeTest?: boolean; axeRulesToIgnore?: string[] } = {
       axeTest: true,
     },
   ) {
     this.checkOnPage()
-    if (options.axeTest || options.axeRulesToIgnore?.length) {
-      this.runAxe(options.axeRulesToIgnore)
+    if (this.options.axeTest || this.options.axeRulesToIgnore?.length) {
+      this.runAxe(this.options.axeRulesToIgnore)
     }
   }
 
@@ -46,7 +46,8 @@ export default abstract class Page {
 
   signOut = (): PageElement => cy.get('[data-qa=signOut]')
 
-  mojAlertTitle = (): PageElement => cy.get('.moj-alert__content h2')
+  // Messages (MoJ Alerts)
+  getMessages = (): PageElement => cy.get('.moj-alert')
 
   mojAlertBody = (): PageElement => cy.get('.moj-alert__content')
 }

--- a/integration_tests/pages/prisoner/prisonerProfile.ts
+++ b/integration_tests/pages/prisoner/prisonerProfile.ts
@@ -1,8 +1,8 @@
 import Page, { PageElement } from '../page'
 
 export default class PrisonerProfilePage extends Page {
-  constructor(variableTitle: string) {
-    super(variableTitle)
+  constructor({ title }: { title: string }) {
+    super(title)
   }
 
   flaggedAlerts = (): PageElement => cy.get('.flagged-alert')

--- a/integration_tests/pages/request/visitRequestsListing.ts
+++ b/integration_tests/pages/request/visitRequestsListing.ts
@@ -15,5 +15,5 @@ export default class VisitRequestsListingPage extends Page {
 
   getMainContact = (row: number): PageElement => cy.get(`[data-test="main-contact-${row}"]`)
 
-  getAction = (row: number): PageElement => cy.get(`[data-test="action-${row}"]`)
+  getAction = (row: number): PageElement => cy.get(`[data-test="action-${row}"] a`)
 }

--- a/integration_tests/pages/visit/visitDetails.ts
+++ b/integration_tests/pages/visit/visitDetails.ts
@@ -1,12 +1,9 @@
 import Page, { PageElement } from '../page'
 
 export default class VisitDetailsPage extends Page {
-  constructor() {
-    super('Visit booking details')
+  constructor(type: 'booking' | 'request') {
+    super(type === 'booking' ? 'Visit booking details' : 'Visit request details')
   }
-
-  // Messages (MoJ Alerts)
-  visitMessages = (): PageElement => cy.get('.moj-alert')
 
   // Visit Details
   visitDate = (): PageElement => cy.get('[data-test="visit-date"]')

--- a/integration_tests/pages/visitJourney/confirmation.ts
+++ b/integration_tests/pages/visitJourney/confirmation.ts
@@ -1,8 +1,8 @@
 import Page, { PageElement } from '../page'
 
 export default class ConfirmationPage extends Page {
-  constructor(variableTitle: string) {
-    super(variableTitle)
+  constructor({ title }: { title: string }) {
+    super(title)
 
     cy.get('[data-test=go-to-home]').contains('Go to manage prison visits').should('have.attr', 'href', '/')
   }

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -55,6 +55,46 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/visits/requests/{reference}/reject': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    /**
+     * Reject a visit request
+     * @description Endpoint to reject a visit request by visit reference
+     */
+    put: operations['rejectVisitRequestByReference']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/visits/requests/{reference}/approve': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    /**
+     * Approve a visit request
+     * @description Endpoint to approve a visit request by visit reference
+     */
+    put: operations['approveVisitRequestByReference']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/visits/notification/visit/{reference}/ignore': {
     parameters: {
       query?: never
@@ -1283,6 +1323,26 @@ export interface components {
       /** @description flag to determine if visit should be a request or instant booking */
       isRequestBooking?: boolean
     }
+    RejectVisitRequestBodyDto: {
+      /** @description Reference of the visit for rejection */
+      visitReference: string
+      /** @description Username for user who actioned this request */
+      actionedBy: string
+    }
+    OrchestrationApproveRejectVisitRequestResponseDto: {
+      /** @description Reference of the approved visit */
+      visitReference: string
+      /** @description First name of the prisoner being visited */
+      prisonerFirstName: string
+      /** @description Last name of the prisoner being visited */
+      prisonerLastName: string
+    }
+    ApproveVisitRequestBodyDto: {
+      /** @description Reference of the visit for approval */
+      visitReference: string
+      /** @description Username for user who actioned this request */
+      actionedBy: string
+    }
     IgnoreVisitNotificationsDto: {
       /** @description Reason why the visit's notifications can be ignored */
       reason: string
@@ -1674,6 +1734,8 @@ export interface components {
         | 'BOOKED_VISIT'
         | 'UPDATED_VISIT'
         | 'CANCELLED_VISIT'
+        | 'REQUESTED_VISIT'
+        | 'REQUESTED_VISIT_APPROVED'
         | 'NON_ASSOCIATION_EVENT'
         | 'PRISONER_RELEASED_EVENT'
         | 'PRISONER_RECEIVED_EVENT'
@@ -1761,8 +1823,6 @@ export interface components {
        * @example Moorland HMP
        */
       prisonName: string
-      /** @description Whether the prison is still active */
-      active: boolean
     }
     PrisonerDetailsDto: {
       /**
@@ -2149,9 +2209,9 @@ export interface components {
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
       pageSize?: number
+      paged?: boolean
       /** Format: int32 */
       pageNumber?: number
-      paged?: boolean
       unpaged?: boolean
     }
     SortObject: {
@@ -3175,6 +3235,114 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ApplicationValidationErrorResponse']
+        }
+      }
+    }
+  }
+  rejectVisitRequestByReference: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description visit reference */
+        reference: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['RejectVisitRequestBodyDto']
+      }
+    }
+    responses: {
+      /** @description Successfully rejected visit request */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['OrchestrationApproveRejectVisitRequestResponseDto']
+        }
+      }
+      /** @description Incorrect request to reject visit request by reference (not found or not in correct sub status) */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to access this endpoint */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  approveVisitRequestByReference: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description visit reference */
+        reference: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ApproveVisitRequestBodyDto']
+      }
+    }
+    responses: {
+      /** @description Successfully approved visit request */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['OrchestrationApproveRejectVisitRequestResponseDto']
+        }
+      }
+      /** @description Incorrect request to approve visit request by reference (not found or not in correct sub status) */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to access this endpoint */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
         }
       }
     }

--- a/server/constants/eventAudit.ts
+++ b/server/constants/eventAudit.ts
@@ -4,6 +4,7 @@ const eventAuditTypes: Partial<Record<EventAuditType, string>> = {
   BOOKED_VISIT: 'Booked',
   UPDATED_VISIT: 'Updated',
   CANCELLED_VISIT: 'Cancelled',
+  REQUESTED_VISIT: 'Requested',
   MIGRATED_VISIT: 'Migrated',
   NON_ASSOCIATION_EVENT: 'Needs review',
   PRISONER_RECEIVED_EVENT: 'Needs review',

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -45,6 +45,7 @@ export default class OrchestrationApiClient {
     'BOOKED_VISIT',
     'UPDATED_VISIT',
     'CANCELLED_VISIT',
+    'REQUESTED_VISIT',
     'IGNORE_VISIT_NOTIFICATIONS_EVENT',
     ...this.enabledRawNotifications,
   ]

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -490,7 +490,6 @@ export default class TestData {
     prison = {
       prisonId: 'HEI',
       prisonName: 'Hewell (HMP)',
-      active: true,
     },
     prisoner = {
       prisonerNumber: 'A1234BC',

--- a/server/routes/visit/visitEventsTimelineBuilder.test.ts
+++ b/server/routes/visit/visitEventsTimelineBuilder.test.ts
@@ -28,7 +28,7 @@ describe('visitEventsTimelineBuilder - Build MoJ Timeline items from visit event
       {
         type: 'BOOKED_VISIT',
         applicationMethodType: 'WEBSITE',
-        actionedByFullName: '',
+        actionedByFullName: null,
         userType: 'PUBLIC',
         createTimestamp: '2022-01-01T09:00:00',
       },
@@ -93,7 +93,7 @@ describe('visitEventsTimelineBuilder - Build MoJ Timeline items from visit event
       {
         type: 'BOOKED_VISIT',
         applicationMethodType: 'WEBSITE',
-        actionedByFullName: '',
+        actionedByFullName: null,
         userType: 'PUBLIC',
         createTimestamp: '2022-01-01T09:00:00',
       },
@@ -144,7 +144,7 @@ describe('visitEventsTimelineBuilder - Build MoJ Timeline items from visit event
       {
         type: 'UPDATED_VISIT',
         applicationMethodType: 'WEBSITE',
-        actionedByFullName: '',
+        actionedByFullName: null,
         userType: 'PUBLIC',
         createTimestamp: '2022-01-01T09:00:00',
       },
@@ -240,6 +240,31 @@ describe('visitEventsTimelineBuilder - Build MoJ Timeline items from visit event
         text: 'Method: Prisoner request',
         datetime: { timestamp: '2022-01-01T09:00:00', type: 'datetime' },
         byline: { text: 'User One' },
+        attributes: { 'data-test': 'timeline-entry-0' },
+      },
+    ]
+
+    const timeline = visitEventsTimelineBuilder(params)
+
+    expect(timeline).toStrictEqual(expectedTimeline)
+  })
+
+  it('should return a timeline with an event for "Requested" - Method: GOV.UK', () => {
+    params.events = [
+      {
+        type: 'REQUESTED_VISIT',
+        applicationMethodType: 'WEBSITE',
+        actionedByFullName: null,
+        userType: 'PUBLIC',
+        createTimestamp: '2022-01-01T09:00:00',
+      },
+    ]
+
+    const expectedTimeline: MojTimelineItem[] = [
+      {
+        label: { text: 'Requested' },
+        text: 'Method: GOV.UK',
+        datetime: { timestamp: '2022-01-01T09:00:00', type: 'datetime' },
         attributes: { 'data-test': 'timeline-entry-0' },
       },
     ]

--- a/server/routes/visit/visitEventsTimelineBuilder.ts
+++ b/server/routes/visit/visitEventsTimelineBuilder.ts
@@ -53,6 +53,10 @@ export default ({
             : (getCancellationReason(visitNotes) ?? requestMethodDescriptions[event.applicationMethodType])
           break
 
+        case 'REQUESTED_VISIT':
+          timelineItem.text = 'Method: GOV.UK'
+          break
+
         default:
           timelineItem.text = isANotificationType(event.type) ? `Reason: ${notificationTypes[event.type]}` : ''
       }


### PR DESCRIPTION
* Handle new event type `REQUESTED_VISIT` on the booking event history timeline
* Add integration test for processing a visit request (to be finished when approve/reject implemented)
* Refactor integration tests so `Page` class constructors can have optional typed parameters passed (e.g. for pages with variable titles)