### PR TITLE
VB-5785, VB-5818, VB-5819 Add request action (approve/reject) to timeline and rejected message

### DIFF
--- a/integration_tests/e2e/visit/visitDetails.cy.ts
+++ b/integration_tests/e2e/visit/visitDetails.cy.ts
@@ -20,6 +20,7 @@ context('Visit details page', () => {
   it('should display all visit information for a past visit', () => {
     const visitDetails = TestData.visitBookingDetailsRaw({
       visitStatus: 'CANCELLED',
+      visitSubStatus: 'CANCELLED',
       outcomeStatus: 'VISITOR_CANCELLED',
       visitNotes: [{ type: 'VISIT_OUTCOMES', text: 'Illness' }],
     })

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -1736,6 +1736,7 @@ export interface components {
         | 'CANCELLED_VISIT'
         | 'REQUESTED_VISIT'
         | 'REQUESTED_VISIT_APPROVED'
+        | 'REQUESTED_VISIT_REJECTED'
         | 'NON_ASSOCIATION_EVENT'
         | 'PRISONER_RELEASED_EVENT'
         | 'PRISONER_RECEIVED_EVENT'

--- a/server/constants/eventAudit.ts
+++ b/server/constants/eventAudit.ts
@@ -5,6 +5,8 @@ const eventAuditTypes: Partial<Record<EventAuditType, string>> = {
   UPDATED_VISIT: 'Updated',
   CANCELLED_VISIT: 'Cancelled',
   REQUESTED_VISIT: 'Requested',
+  REQUESTED_VISIT_APPROVED: 'Approved',
+  REQUESTED_VISIT_REJECTED: 'Rejected',
   MIGRATED_VISIT: 'Migrated',
   NON_ASSOCIATION_EVENT: 'Needs review',
   PRISONER_RECEIVED_EVENT: 'Needs review',

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -49,6 +49,8 @@ export default class OrchestrationApiClient {
     'UPDATED_VISIT',
     'CANCELLED_VISIT',
     'REQUESTED_VISIT',
+    'REQUESTED_VISIT_APPROVED',
+    'REQUESTED_VISIT_REJECTED',
     'IGNORE_VISIT_NOTIFICATIONS_EVENT',
     ...this.enabledRawNotifications,
   ]

--- a/server/routes/visit/visitEventsTimelineBuilder.test.ts
+++ b/server/routes/visit/visitEventsTimelineBuilder.test.ts
@@ -274,6 +274,58 @@ describe('visitEventsTimelineBuilder - Build MoJ Timeline items from visit event
     expect(timeline).toStrictEqual(expectedTimeline)
   })
 
+  it('should return a timeline with an event for Request "Approved - Method: GOV.UK', () => {
+    params.events = [
+      {
+        type: 'REQUESTED_VISIT_APPROVED',
+        applicationMethodType: 'WEBSITE',
+        actionedByFullName: 'User One',
+        userType: 'STAFF',
+        createTimestamp: '2022-01-01T09:00:00',
+      },
+    ]
+
+    const expectedTimeline: MojTimelineItem[] = [
+      {
+        label: { text: 'Approved' },
+        text: 'Method: GOV.UK',
+        datetime: { timestamp: '2022-01-01T09:00:00', type: 'datetime' },
+        byline: { text: 'User One' },
+        attributes: { 'data-test': 'timeline-entry-0' },
+      },
+    ]
+
+    const timeline = visitEventsTimelineBuilder(params)
+
+    expect(timeline).toStrictEqual(expectedTimeline)
+  })
+
+  it('should return a timeline with an event for Request "Rejected - Method: GOV.UK', () => {
+    params.events = [
+      {
+        type: 'REQUESTED_VISIT_REJECTED',
+        applicationMethodType: 'WEBSITE',
+        actionedByFullName: 'User One',
+        userType: 'STAFF',
+        createTimestamp: '2022-01-01T09:00:00',
+      },
+    ]
+
+    const expectedTimeline: MojTimelineItem[] = [
+      {
+        label: { text: 'Rejected' },
+        text: 'Method: GOV.UK',
+        datetime: { timestamp: '2022-01-01T09:00:00', type: 'datetime' },
+        byline: { text: 'User One' },
+        attributes: { 'data-test': 'timeline-entry-0' },
+      },
+    ]
+
+    const timeline = visitEventsTimelineBuilder(params)
+
+    expect(timeline).toStrictEqual(expectedTimeline)
+  })
+
   it('should return a timeline with an event for "No change required" - Reason: /free text/', () => {
     params.events = [
       {

--- a/server/routes/visit/visitEventsTimelineBuilder.ts
+++ b/server/routes/visit/visitEventsTimelineBuilder.ts
@@ -54,6 +54,8 @@ export default ({
           break
 
         case 'REQUESTED_VISIT':
+        case 'REQUESTED_VISIT_APPROVED':
+        case 'REQUESTED_VISIT_REJECTED':
           timelineItem.text = 'Method: GOV.UK'
           break
 

--- a/server/routes/visit/visitUtils.test.ts
+++ b/server/routes/visit/visitUtils.test.ts
@@ -158,6 +158,7 @@ describe('Visit utils', () => {
       it('should return no alert if visitStatus **not** CANCELLED', () => {
         const visitDetails = TestData.visitBookingDetails({
           visitStatus: 'BOOKED',
+          visitSubStatus: 'AUTO_APPROVED',
           outcomeStatus: 'ADMINISTRATIVE_CANCELLATION',
         })
         expect(getVisitAlerts(visitDetails)).toStrictEqual([])
@@ -172,7 +173,11 @@ describe('Visit utils', () => {
         ])(
           "should handle %s: '%s' => %s",
           (_: string, outcomeStatus: VisitBookingDetails['outcomeStatus'], expected: string) => {
-            const visitDetails = TestData.visitBookingDetails({ visitStatus: 'CANCELLED', outcomeStatus })
+            const visitDetails = TestData.visitBookingDetails({
+              visitStatus: 'CANCELLED',
+              visitSubStatus: 'CANCELLED',
+              outcomeStatus,
+            })
             expect(getVisitAlerts(visitDetails)).toStrictEqual<MoJAlert[]>([
               {
                 variant: 'information',
@@ -183,6 +188,34 @@ describe('Visit utils', () => {
             ])
           },
         )
+      })
+    })
+
+    describe('Visit request REJECTED', () => {
+      it('should return an alert if visit request is REJECTED', () => {
+        const visitDetails = TestData.visitBookingDetails({
+          visitStatus: 'CANCELLED',
+          visitSubStatus: 'REJECTED',
+          outcomeStatus: 'ESTABLISHMENT_CANCELLED',
+          events: [
+            {
+              type: 'REQUESTED_VISIT_REJECTED',
+              applicationMethodType: 'WEBSITE',
+              actionedByFullName: 'User One',
+              userType: 'STAFF',
+              createTimestamp: '',
+            },
+          ],
+        })
+
+        expect(getVisitAlerts(visitDetails)).toStrictEqual<MoJAlert[]>([
+          {
+            variant: 'information',
+            title: 'Request rejected',
+            showTitleAsHeading: true,
+            text: 'This visit request was rejected by User One',
+          },
+        ])
       })
     })
 


### PR DESCRIPTION
Visit details page:
* Show 'Approved' and 'Rejected' entries on timeline for visit requests
* For rejected visit requests, show a 'Request rejected' alert message at the top