### PR TITLE
VB-5835, visit request days text change

### DIFF
--- a/integration_tests/e2e/request/processVisitRequest.cy.ts
+++ b/integration_tests/e2e/request/processVisitRequest.cy.ts
@@ -37,7 +37,7 @@ context('Process a visit Request', () => {
 
     // Requested visits page
     const visitRequestsListingPage = Page.verifyOnPage(VisitRequestsListingPage)
-    visitRequestsListingPage.checkBeforeDays().contains('before the visit date.')
+    visitRequestsListingPage.getBeforeDaysMessage().contains('before the visit date.')
     visitRequestsListingPage.getVisitDate(1).contains('10/7/2025')
     visitRequestsListingPage.getVisitRequestedDate(1).contains('1/7/2025')
     visitRequestsListingPage.getPrisonerName(1).contains('John Smith')

--- a/integration_tests/pages/request/visitRequestsListing.ts
+++ b/integration_tests/pages/request/visitRequestsListing.ts
@@ -19,5 +19,5 @@ export default class VisitRequestsListingPage extends Page {
 
   getNoRequestsMessage = (): PageElement => cy.get('[data-test="no-visit-requests"]')
 
-  checkBeforeDays = (): PageElement => cy.get(`[data-test="check-before-days"]`)
+  getBeforeDaysMessage = (): PageElement => cy.get(`[data-test="check-before-days"]`)
 }

--- a/server/routes/request/visitRequestsListingController.test.ts
+++ b/server/routes/request/visitRequestsListingController.test.ts
@@ -34,7 +34,7 @@ describe('GET /requested-visits - Requested visits listing', () => {
         expect($('.govuk-breadcrumbs li').length).toBe(2)
         expect($('.moj-alert').length).toBe(0)
         expect($('h1').text()).toBe('Requested visits')
-        expect($('[data-test=check-before-days]').text()).toBe('at least 2 days before the visit date.')
+        expect($('[data-test=check-before-days]').text()).toBe('at least 2 full days before the visit date.')
 
         expect($('[data-test=visit-requests] tbody tr').length).toBe(1)
 
@@ -64,7 +64,7 @@ describe('GET /requested-visits - Requested visits listing', () => {
         expect($('.govuk-breadcrumbs li').length).toBe(2)
         expect($('.moj-alert').length).toBe(0)
         expect($('h1').text()).toBe('Requested visits')
-        expect($('[data-test=check-before-days]').text()).toBe('at least 2 days before the visit date.')
+        expect($('[data-test=check-before-days]').text()).toBe('at least 2 full days before the visit date.')
 
         expect($('[data-test=visit-requests] tbody tr').length).toBe(1)
 

--- a/server/views/pages/request/visitRequestsListing.njk
+++ b/server/views/pages/request/visitRequestsListing.njk
@@ -83,7 +83,7 @@
           {% if checkBeforeDays === 0 %}
             <span data-test="check-before-days">before the visit date.</span>
           {% else %}
-            <span data-test="check-before-days">at least {{ checkBeforeDays }} {{ "day" | pluralise(checkBeforeDays) }} before the visit date.</span>
+            <span data-test="check-before-days">at least {{ checkBeforeDays }} full {{ "day" | pluralise(checkBeforeDays) }} before the visit date.</span>
           {% endif %}
           If not, they will be automatically rejected.
         </p>


### PR DESCRIPTION
When 0 days is the minimum booking window (policyNoticeDaysMin) - change the text displayed to: 'Requests need to checked before the visit date.'

When 1 or more, display original message

Tested in integration tests, as no template tests are currently built for this page, and is impractical to test in routes level test