### PR TITLE
VB-6637 Serve favicon at /favicon.ico

### DIFF
--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -10,6 +10,14 @@ export default function setUpStaticResources(): Router {
 
   router.use(compression())
 
+  // Rewrite /favicon.ico requests to the GOV.UK asset path otherwise they get an auth redirect and end up as 404s
+  // (Safari, for example, requests /favicon.ico even though a different path is specified in the HTML head)
+  router.get('/favicon.ico', (req, _res, next) => {
+    // TODO remove 'rebrand' from path when upgrading to govuk-frontend v6
+    req.url = '/assets/rebrand/images/favicon.ico'
+    next()
+  })
+
   //  Static Resources Configuration
   const cacheControl = { maxAge: config.staticResourceCacheDuration }
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -9,8 +9,7 @@ import {
   subWeeks,
   parse,
 } from 'date-fns'
-// eslint-disable-next-line import/no-named-as-default
-import parsePhoneNumber from 'libphonenumber-js/mobile'
+import { parsePhoneNumberFromString as parsePhoneNumber } from 'libphonenumber-js/mobile'
 import config from '../config'
 
 export const properCase = (word: string): string =>


### PR DESCRIPTION
Safari (WebKit) may initiate browser‑level requests to /favicon.ico independently of page navigation and before HTML parsing. This request gets caught in the authentication redirect. Because /favicon.ico doesn’t actually exist (GOV.UK template specifies a different path), the user then ends up on an error page (404 - ‘Sorry there is a problem with the service’).

This change serves the GOV.UK favicon at `/favicon.ico` to fix this.