### PR TITLE
VB-6639 Add 'actionedBy' to booker/visitor operations

### DIFF
--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -372,10 +372,12 @@ export default {
     rejectionReason = 'REJECT',
     requestReference = TestData.visitorRequest().reference,
     visitorRequest = TestData.visitorRequest(),
+    username = 'USER1',
   }: {
     rejectionReason?: RejectVisitorRequestDto['rejectionReason']
     requestReference?: string
     visitorRequest?: PrisonVisitorRequestDto
+    username?: string
   } = {}): SuperAgentRequest => {
     return stubFor({
       request: {
@@ -383,7 +385,7 @@ export default {
         url: `/orchestration/visitor-requests/${requestReference}/reject`,
         bodyPatterns: [
           {
-            equalToJson: { rejectionReason },
+            equalToJson: { rejectionReason, actionedBy: username },
           },
         ],
       },
@@ -399,10 +401,12 @@ export default {
     visitorId = 4321,
     requestReference = TestData.visitorRequest().reference,
     visitorRequest = TestData.visitorRequest(),
+    username = 'USER1',
   }: {
     visitorId?: number
     requestReference?: string
     visitorRequest?: PrisonVisitorRequestDto
+    username?: string
   } = {}): SuperAgentRequest => {
     return stubFor({
       request: {
@@ -410,7 +414,7 @@ export default {
         url: `/orchestration/visitor-requests/${requestReference}/approve`,
         bodyPatterns: [
           {
-            equalToJson: { visitorId },
+            equalToJson: { visitorId, actionedBy: username },
           },
         ],
       },
@@ -532,11 +536,13 @@ export default {
     prisonerId,
     visitorId,
     sendNotification,
+    username = 'USER1',
   }: {
     reference: string
     prisonerId: string
     visitorId: number
     sendNotification: boolean
+    username?: string
   }): SuperAgentRequest => {
     return stubFor({
       request: {
@@ -546,8 +552,8 @@ export default {
           {
             equalToJson: {
               visitorId,
-              active: true,
               sendNotificationFlag: sendNotification,
+              actionedBy: username,
             },
           },
         ],

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -1843,6 +1843,7 @@ export interface components {
        * @enum {string}
        */
       rejectionReason: 'ALREADY_LINKED' | 'REJECT'
+      actionedBy: string
     }
     PrisonVisitorRequestDto: {
       /**
@@ -1901,6 +1902,7 @@ export interface components {
        * @example 5871791
        */
       visitorId: number
+      actionedBy: string
     }
     RetryDlqResult: {
       /** Format: int32 */
@@ -2013,6 +2015,7 @@ export interface components {
        * @example true
        */
       sendNotificationFlag: boolean
+      actionedBy: string
     }
     /** @description Permitted visitor associated with the permitted prisoner. */
     PermittedVisitorsForPermittedPrisonerBookerDto: {

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -461,13 +461,21 @@ describe('orchestrationApiClient', () => {
       const visitorRequest = TestData.visitorRequest()
       const requestReference = visitorRequest.reference
       const rejectionReason: RejectVisitorRequestDto['rejectionReason'] = 'REJECT'
+      const username = 'user1'
 
       fakeOrchestrationApi
-        .put(`/visitor-requests/${requestReference}/reject`, <RejectVisitorRequestDto>{ rejectionReason })
+        .put(`/visitor-requests/${requestReference}/reject`, <RejectVisitorRequestDto>{
+          rejectionReason,
+          actionedBy: username,
+        })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, visitorRequest)
 
-      const output = await orchestrationApiClient.rejectVisitorRequest({ requestReference, rejectionReason })
+      const output = await orchestrationApiClient.rejectVisitorRequest({
+        requestReference,
+        rejectionReason,
+        username,
+      })
 
       expect(output).toStrictEqual(visitorRequest)
     })
@@ -478,13 +486,17 @@ describe('orchestrationApiClient', () => {
       const visitorRequest = TestData.visitorRequest()
       const requestReference = visitorRequest.reference
       const visitorId = 123
+      const username = 'user1'
 
       fakeOrchestrationApi
-        .put(`/visitor-requests/${requestReference}/approve`, <ApproveVisitorRequestDto>{ visitorId })
+        .put(`/visitor-requests/${requestReference}/approve`, <ApproveVisitorRequestDto>{
+          visitorId,
+          actionedBy: username,
+        })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, visitorRequest)
 
-      const output = await orchestrationApiClient.approveVisitorRequest({ requestReference, visitorId })
+      const output = await orchestrationApiClient.approveVisitorRequest({ requestReference, visitorId, username })
 
       expect(output).toStrictEqual(visitorRequest)
     })
@@ -595,15 +607,16 @@ describe('orchestrationApiClient', () => {
       const reference = 'aaa-bbb-ccc'
       const visitorId = 123
       const sendNotification = true
+      const username = 'user1'
 
       fakeOrchestrationApi
         .post(`/public/booker/${reference}/permitted/prisoners/${prisonerId}/permitted/visitors`, <
           RegisterVisitorForBookerPrisonerDto
-        >{ visitorId, active: true, sendNotificationFlag: sendNotification })
+        >{ visitorId, sendNotificationFlag: sendNotification, actionedBy: username })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200)
 
-      await orchestrationApiClient.linkBookerVisitor({ reference, prisonerId, visitorId, sendNotification })
+      await orchestrationApiClient.linkBookerVisitor({ reference, prisonerId, visitorId, sendNotification, username })
 
       expect(fakeOrchestrationApi.isDone()).toBe(true)
     })

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -278,26 +278,30 @@ export default class OrchestrationApiClient {
   async rejectVisitorRequest({
     requestReference,
     rejectionReason,
+    username,
   }: {
     requestReference: string
     rejectionReason: RejectVisitorRequestDto['rejectionReason']
+    username: string
   }): Promise<PrisonVisitorRequestDto> {
     return this.restClient.put({
       path: `/visitor-requests/${requestReference}/reject`,
-      data: <RejectVisitorRequestDto>{ rejectionReason },
+      data: <RejectVisitorRequestDto>{ rejectionReason, actionedBy: username },
     })
   }
 
   async approveVisitorRequest({
     requestReference,
     visitorId,
+    username,
   }: {
     requestReference: string
     visitorId: number
+    username: string
   }): Promise<PrisonVisitorRequestDto> {
     return this.restClient.put({
       path: `/visitor-requests/${requestReference}/approve`,
-      data: <ApproveVisitorRequestDto>{ visitorId },
+      data: <ApproveVisitorRequestDto>{ visitorId, actionedBy: username },
     })
   }
 
@@ -350,18 +354,20 @@ export default class OrchestrationApiClient {
     prisonerId,
     visitorId,
     sendNotification,
+    username,
   }: {
     reference: string
     prisonerId: string
     visitorId: number
     sendNotification: boolean
+    username: string
   }): Promise<void> {
     await this.restClient.post({
       path: `/public/booker/${reference}/permitted/prisoners/${prisonerId}/permitted/visitors`,
       data: <RegisterVisitorForBookerPrisonerDto>{
         visitorId,
-        active: true,
         sendNotificationFlag: sendNotification,
+        actionedBy: username,
       },
     })
   }

--- a/server/services/bookerService.test.ts
+++ b/server/services/bookerService.test.ts
@@ -137,6 +137,7 @@ describe('Booker service', () => {
         prisonerId,
         visitorId,
         sendNotification,
+        username,
       })
     })
   })
@@ -210,7 +211,11 @@ describe('Booker service', () => {
       })
 
       expect(result).toStrictEqual(visitorRequest)
-      expect(orchestrationApiClient.approveVisitorRequest).toHaveBeenCalledWith({ requestReference, visitorId })
+      expect(orchestrationApiClient.approveVisitorRequest).toHaveBeenCalledWith({
+        requestReference,
+        visitorId,
+        username,
+      })
     })
   })
 
@@ -228,7 +233,11 @@ describe('Booker service', () => {
       })
 
       expect(result).toStrictEqual(visitorRequest)
-      expect(orchestrationApiClient.rejectVisitorRequest).toHaveBeenCalledWith({ requestReference, rejectionReason })
+      expect(orchestrationApiClient.rejectVisitorRequest).toHaveBeenCalledWith({
+        requestReference,
+        rejectionReason,
+        username,
+      })
     })
   })
 })

--- a/server/services/bookerService.ts
+++ b/server/services/bookerService.ts
@@ -111,7 +111,7 @@ export default class BookerService {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
-    await orchestrationApiClient.linkBookerVisitor({ reference, prisonerId, visitorId, sendNotification })
+    await orchestrationApiClient.linkBookerVisitor({ reference, prisonerId, visitorId, sendNotification, username })
   }
 
   async unlinkBookerVisitor({
@@ -176,7 +176,7 @@ export default class BookerService {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
-    return orchestrationApiClient.approveVisitorRequest({ requestReference, visitorId })
+    return orchestrationApiClient.approveVisitorRequest({ requestReference, visitorId, username })
   }
 
   async rejectVisitorRequest({
@@ -191,6 +191,6 @@ export default class BookerService {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
-    return orchestrationApiClient.rejectVisitorRequest({ requestReference, rejectionReason })
+    return orchestrationApiClient.rejectVisitorRequest({ requestReference, rejectionReason, username })
   }
 }


### PR DESCRIPTION
Add `actionedBy` (populated with user's `username`) when:
* approving a visitor request
* rejecting a visitor request
* manually linking a visitor to a booker