### PR TITLE
VB-6645 Show outstanding visitor requests on booker details page

### DIFF
--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -5,6 +5,7 @@ import {
   ApplicationMethodType,
   ApplicationValidationErrorResponse,
   BookerDetailedInfoDto,
+  BookerPrisonerVisitorRequestDto,
   BookerSearchResultsDto,
   BookingRequestVisitorDetailsDto,
   CancelVisitOrchestrationDto,
@@ -591,6 +592,26 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: {},
+      },
+    })
+  },
+
+  stubGetBookerVisitorRequests: ({
+    bookerReference = TestData.bookerDetailedInfo().reference,
+    bookerVisitorRequests = [TestData.bookerPrisonerVisitorRequest()],
+  }: {
+    bookerReference?: string
+    bookerVisitorRequests?: BookerPrisonerVisitorRequestDto[]
+  } = {}): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        url: `/orchestration/public/booker/${bookerReference}/permitted/visitors/requests`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: bookerVisitorRequests,
       },
     })
   },

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -597,16 +597,16 @@ export default {
   },
 
   stubGetBookerVisitorRequests: ({
-    bookerReference = TestData.bookerDetailedInfo().reference,
+    reference = TestData.bookerDetailedInfo().reference,
     bookerVisitorRequests = [TestData.bookerPrisonerVisitorRequest()],
   }: {
-    bookerReference?: string
+    reference?: string
     bookerVisitorRequests?: BookerPrisonerVisitorRequestDto[]
   } = {}): SuperAgentRequest => {
     return stubFor({
       request: {
         method: 'GET',
-        url: `/orchestration/public/booker/${bookerReference}/permitted/visitors/requests`,
+        url: `/orchestration/public/booker/${reference}/permitted/visitors/requests`,
       },
       response: {
         status: 200,

--- a/integration_tests/pages/bookerManagement/booker/bookerDetailsPage.ts
+++ b/integration_tests/pages/bookerManagement/booker/bookerDetailsPage.ts
@@ -23,4 +23,16 @@ export default class BookerDetailsPage extends AbstractPage {
 
   unlinkPrisonerVisitor = (prisonerIndex: number, visitorIndex: number): Locator =>
     this.page.getByTestId(`prisoner-${prisonerIndex}-visitor-${visitorIndex}-unlink`)
+
+  // Visitor requests
+  visitorName = (prisonerIndex: number, visitorIndex: number): Locator =>
+    this.page.getByTestId(`prisoner-${prisonerIndex}-visitor-request-${visitorIndex}-name`)
+
+  requestedDate = (prisonerIndex: number, visitorIndex: number): Locator =>
+    this.page.getByTestId(`prisoner-${prisonerIndex}-visitor-request-${visitorIndex}-requested-date`)
+
+  viewRequestLink = (prisonerIndex: number, visitorIndex: number, visitorName: string): Locator =>
+    this.page
+      .getByTestId(`prisoner-${prisonerIndex}-visitor-request-${visitorIndex}-action`)
+      .getByRole('link', { name: `View request to add ${visitorName} as a visitor` })
 }

--- a/integration_tests/specs/bookerManagement/bookerManagement.spec.ts
+++ b/integration_tests/specs/bookerManagement/bookerManagement.spec.ts
@@ -33,17 +33,18 @@ test.describe('Booker management - search, manual link/unlink visitors', () => {
 
   test.describe('User has the booker admin role', () => {
     const email = 'booker@example.com'
+    const bookerSearchResult = TestData.bookerSearchResult({ email })
+    const bookerDetails = TestData.bookerDetailedInfo({ email })
 
     test.beforeEach(async ({ page }) => {
       await login(page, { roles: [bapvUserRoles.STAFF_USER, bapvUserRoles.BOOKER_ADMIN] })
+
+      await orchestrationApi.stubGetBookersByEmail({ email, bookers: [bookerSearchResult] })
+      await orchestrationApi.stubGetBookerDetails({ reference: bookerDetails.reference, booker: bookerDetails })
+      await orchestrationApi.stubGetBookerVisitorRequests()
     })
 
     test('should search for a booker and navigate to booker details page (single booker record)', async ({ page }) => {
-      const bookerSearchResult = TestData.bookerSearchResult({ email })
-      const bookerDetails = TestData.bookerDetailedInfo({ email })
-      await orchestrationApi.stubGetBookersByEmail({ email, bookers: [bookerSearchResult] })
-      await orchestrationApi.stubGetBookerDetails({ reference: bookerDetails.reference, booker: bookerDetails })
-
       // Home page - select booker management tile
       const homePage = await HomePage.verifyOnPage(page)
       await homePage.bookerManagementTile.click()
@@ -57,10 +58,11 @@ test.describe('Booker management - search, manual link/unlink visitors', () => {
       const bookerDetailsPage = await BookerDetailsPage.verifyOnPage(page)
       await expect(bookerDetailsPage.bookerEmail).toContainText(email)
       await expect(bookerDetailsPage.bookerReference).toContainText(bookerDetails.reference)
-      await expect(bookerDetailsPage.prisonerHeading(1)).toContainText(
-        'Visitors linked to John Smith (A1234BC) at Hewell (HMP)',
-      )
+      await expect(bookerDetailsPage.prisonerHeading(1)).toContainText('Visits to John Smith (A1234BC) at Hewell (HMP)')
       await expect(bookerDetailsPage.prisonerVisitorName(1, 1)).toContainText('Jeanette Smith')
+      await expect(bookerDetailsPage.visitorName(1, 1)).toContainText('Mike Jones')
+      await expect(bookerDetailsPage.requestedDate(1, 1)).toContainText('10/12/2025')
+      await expect(bookerDetailsPage.viewRequestLink(1, 1, 'Mike Jones')).toBeVisible()
     })
 
     test('should search for a booker and navigate to booker details page (multiple booker records)', async ({
@@ -102,18 +104,14 @@ test.describe('Booker management - search, manual link/unlink visitors', () => {
       const bookerDetailsPage = await BookerDetailsPage.verifyOnPage(page)
       await expect(bookerDetailsPage.bookerEmail).toContainText(email)
       await expect(bookerDetailsPage.bookerReference).toContainText(activeBookerDetails.reference)
-      await expect(bookerDetailsPage.prisonerHeading(1)).toContainText(
-        'Visitors linked to John Smith (A1234BC) at Hewell (HMP)',
-      )
+      await expect(bookerDetailsPage.prisonerHeading(1)).toContainText('Visits to John Smith (A1234BC) at Hewell (HMP)')
       await expect(bookerDetailsPage.prisonerVisitorName(1, 1)).toContainText('Jeanette Smith')
+      await expect(bookerDetailsPage.visitorName(1, 1)).toContainText('Mike Jones')
+      await expect(bookerDetailsPage.requestedDate(1, 1)).toContainText('10/12/2025')
+      await expect(bookerDetailsPage.viewRequestLink(1, 1, 'Mike Jones')).toBeVisible()
     })
 
     test('should link a visitor to a booker account', async ({ page }) => {
-      const bookerSearchResult = TestData.bookerSearchResult({ email })
-      const bookerDetails = TestData.bookerDetailedInfo({ email })
-      await orchestrationApi.stubGetBookersByEmail({ email, bookers: [bookerSearchResult] })
-      await orchestrationApi.stubGetBookerDetails({ reference: bookerDetails.reference, booker: bookerDetails })
-
       // Home page - select booker management tile
       const homePage = await HomePage.verifyOnPage(page)
       await homePage.bookerManagementTile.click()
@@ -127,9 +125,7 @@ test.describe('Booker management - search, manual link/unlink visitors', () => {
       const bookerDetailsPage = await BookerDetailsPage.verifyOnPage(page)
       await expect(bookerDetailsPage.bookerEmail).toContainText(email)
       await expect(bookerDetailsPage.bookerReference).toContainText(bookerDetails.reference)
-      await expect(bookerDetailsPage.prisonerHeading(1)).toContainText(
-        'Visitors linked to John Smith (A1234BC) at Hewell (HMP)',
-      )
+      await expect(bookerDetailsPage.prisonerHeading(1)).toContainText('Visits to John Smith (A1234BC) at Hewell (HMP)')
       await expect(bookerDetailsPage.prisonerVisitorName(1, 1)).toContainText('Jeanette Smith')
 
       const unlinkedContact = TestData.socialContact({
@@ -171,11 +167,6 @@ test.describe('Booker management - search, manual link/unlink visitors', () => {
     })
 
     test('should unlink a visitor from a booker account', async ({ page }) => {
-      const bookerSearchResult = TestData.bookerSearchResult({ email })
-      const bookerDetails = TestData.bookerDetailedInfo({ email })
-      await orchestrationApi.stubGetBookersByEmail({ email, bookers: [bookerSearchResult] })
-      await orchestrationApi.stubGetBookerDetails({ reference: bookerDetails.reference, booker: bookerDetails })
-
       // Home page - select booker management tile
       const homePage = await HomePage.verifyOnPage(page)
       await homePage.bookerManagementTile.click()
@@ -189,9 +180,7 @@ test.describe('Booker management - search, manual link/unlink visitors', () => {
       const bookerDetailsPage = await BookerDetailsPage.verifyOnPage(page)
       await expect(bookerDetailsPage.bookerEmail).toContainText(email)
       await expect(bookerDetailsPage.bookerReference).toContainText(bookerDetails.reference)
-      await expect(bookerDetailsPage.prisonerHeading(1)).toContainText(
-        'Visitors linked to John Smith (A1234BC) at Hewell (HMP)',
-      )
+      await expect(bookerDetailsPage.prisonerHeading(1)).toContainText('Visits to John Smith (A1234BC) at Hewell (HMP)')
       await expect(bookerDetailsPage.prisonerVisitorName(1, 1)).toContainText('Jeanette Smith')
 
       // Unlink visitor

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -36,6 +36,7 @@ export declare module 'express-session' {
     visitorRequestJourney?: {
       visitorRequest: VisitorRequestForReviewDto
       linkedVisitors: VisitorInfoDto[]
+      returnTo: 'booker-details' | 'manage-bookers'
     }
   }
 }

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -2751,10 +2751,10 @@ export interface components {
       sort?: components['schemas']['SortObject']
       /** Format: int32 */
       pageSize?: number
-      paged?: boolean
-      unpaged?: boolean
       /** Format: int32 */
       pageNumber?: number
+      paged?: boolean
+      unpaged?: boolean
     }
     SortObject: {
       empty?: boolean

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -668,6 +668,21 @@ describe('orchestrationApiClient', () => {
     })
   })
 
+  describe('getBookerVisitorRequests', () => {
+    it('should return all visitor requests for given booker', async () => {
+      const bookerReference = 'aaaa-bbbb-cccc'
+      const bookerVisitorRequests = [TestData.bookerPrisonerVisitorRequest()]
+
+      fakeOrchestrationApi
+        .get(`/public/booker/${bookerReference}/permitted/visitors/requests`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, bookerVisitorRequests)
+
+      const result = await orchestrationApiClient.getBookerVisitorRequests(bookerReference)
+      expect(result).toStrictEqual(bookerVisitorRequests)
+    })
+  })
+
   describe('getVisitorRequests', () => {
     it('should return all visitor requests for given prison', async () => {
       const visitorRequestListEntries = [TestData.visitorRequestListEntry()]

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -7,6 +7,7 @@ import {
   ApproveVisitorRequestDto,
   ApproveVisitRequestBodyDto,
   BookerDetailedInfoDto,
+  BookerPrisonerVisitorRequestDto,
   BookerSearchResultsDto,
   BookingOrchestrationRequestDto,
   BookingRequestVisitorDetailsDto,
@@ -395,6 +396,10 @@ export default class OrchestrationApiClient {
         throw error
       }
     }
+  }
+
+  async getBookerVisitorRequests(bookerReference: string): Promise<BookerPrisonerVisitorRequestDto[]> {
+    return this.restClient.get({ path: `/public/booker/${bookerReference}/permitted/visitors/requests` })
   }
 
   async getVisitorRequests(prisonId: string): Promise<PrisonVisitorRequestListEntryDto[]> {

--- a/server/data/orchestrationApiTypes.ts
+++ b/server/data/orchestrationApiTypes.ts
@@ -103,6 +103,7 @@ export type ApplicationValidationErrorResponse = components['schemas']['Applicat
 export type ApproveVisitorRequestDto = components['schemas']['ApproveVisitorRequestDto']
 export type BookerDetailedInfoDto = components['schemas']['BookerDetailedInfoDto']
 export type BookerSearchResultsDto = components['schemas']['BookerSearchResultsDto']
+export type BookerPrisonerVisitorRequestDto = components['schemas']['BookerPrisonerVisitorRequestDto']
 export type PrisonVisitorRequestDto = components['schemas']['PrisonVisitorRequestDto']
 export type PrisonVisitorRequestListEntryDto = components['schemas']['PrisonVisitorRequestListEntryDto']
 export type RegisterVisitorForBookerPrisonerDto = components['schemas']['RegisterVisitorForBookerPrisonerDto']

--- a/server/routes/bookerManagement/booker/bookerDetailsController.test.ts
+++ b/server/routes/bookerManagement/booker/bookerDetailsController.test.ts
@@ -49,9 +49,11 @@ describe('Booker management - booker details', () => {
       return request(app).get('/manage-bookers/INVALID-BOOKER-REFERENCE/booker-details').expect(400)
     })
 
-    it('should render booker details page - booker with single prisoner and visitors', () => {
+    it('should render booker details page - booker with single prisoner, visitors and visitor request', () => {
       const booker = TestData.bookerDetailedInfo()
+      const visitorRequest = TestData.bookerPrisonerVisitorRequest()
       bookerService.getBookerDetails.mockResolvedValue(booker)
+      bookerService.getBookerVisitorRequestsByPrisoner.mockResolvedValue({ A1234BC: [visitorRequest] })
       bookerService.getBookerStatus.mockResolvedValue({ active: true, emailHasMultipleAccounts: false })
 
       return request(app)
@@ -71,7 +73,7 @@ describe('Booker management - booker details', () => {
           expect($('[data-test=booker-reference]').text()).toBe(booker.reference)
 
           // Prisoner and visitors
-          expect($('[data-test=prisoner-1]').text()).toBe('Visitors linked to John Smith (A1234BC) at Hewell (HMP)')
+          expect($('[data-test=prisoner-1]').text().trim()).toBe('Visits to John Smith (A1234BC) at Hewell (HMP)')
           expect($('[data-test=prisoner-1-visitor-1-name]').text()).toBe('Jeanette Smith')
           expect($('[data-test=prisoner-1-visitor-1-relationship]').text()).toBe('Wife')
           expect($('[data-test=prisoner-1-visitor-1-dob]').text()).toBe('28 July 1986 (39 years old)')
@@ -86,7 +88,22 @@ describe('Booker management - booker details', () => {
             '/manage-bookers/aaaa-bbbb-cccc/prisoner/A1234BC/link-visitor',
           )
 
+          // Visitor requests
+          expect($('[data-test=prisoner-1-visitor-request-1-name]').text()).toBe('Mike Jones')
+          expect($('[data-test=prisoner-1-visitor-request-1-requested-date]').text()).toBe('10/12/2025')
+          expect($('[data-test=prisoner-1-visitor-request-1-action]').text()).toBe(
+            'View request to add Mike Jones as a visitor',
+          )
+          expect($('[data-test=prisoner-1-visitor-request-1-action] a').attr('href')).toBe(
+            `/manage-bookers/visitor-request/${visitorRequest.reference}/link-visitor?from=booker-details`,
+          )
+          expect($('[data-test=prisoner-1-no-visitor-requests]').length).toBe(0)
+
           expect(bookerService.getBookerDetails).toHaveBeenCalledWith({
+            username: 'user1',
+            reference: booker.reference,
+          })
+          expect(bookerService.getBookerVisitorRequestsByPrisoner).toHaveBeenCalledWith({
             username: 'user1',
             reference: booker.reference,
           })
@@ -107,6 +124,7 @@ describe('Booker management - booker details', () => {
     it('should render any alert messages set in flash', () => {
       const booker = TestData.bookerDetailedInfo()
       bookerService.getBookerDetails.mockResolvedValue(booker)
+      bookerService.getBookerVisitorRequestsByPrisoner.mockResolvedValue({})
       bookerService.getBookerStatus.mockResolvedValue({ active: true, emailHasMultipleAccounts: false })
 
       flashData.messages = [TestData.mojAlert({ title: 'test alert message' })]
@@ -142,6 +160,7 @@ describe('Booker management - booker details', () => {
         ],
       })
       bookerService.getBookerDetails.mockResolvedValue(booker)
+      bookerService.getBookerVisitorRequestsByPrisoner.mockResolvedValue({})
       bookerService.getBookerStatus.mockResolvedValue({ active: true, emailHasMultipleAccounts: false })
 
       return request(app)
@@ -152,7 +171,7 @@ describe('Booker management - booker details', () => {
 
           // Prisoner #1
           // Prisoner and visitors
-          expect($('[data-test=prisoner-1]').text()).toBe('Visitors linked to John Smith (A1234BC) at Hewell (HMP)')
+          expect($('[data-test=prisoner-1]').text().trim()).toBe('Visits to John Smith (A1234BC) at Hewell (HMP)')
           expect($('[data-test=prisoner-1-visitor-1-name]').text()).toBe('Jeanette Smith')
           expect($('[data-test=prisoner-1-visitor-1-relationship]').text()).toBe('Wife')
           expect($('[data-test=prisoner-1-visitor-1-dob]').text()).toBe('28 July 1986 (39 years old)')
@@ -165,9 +184,12 @@ describe('Booker management - booker details', () => {
             '/manage-bookers/aaaa-bbbb-cccc/prisoner/A1234BC/link-visitor',
           )
 
+          // Visitor requests
+          expect($('[data-test=prisoner-1-no-visitor-requests]').length).toBe(1)
+
           // Prisoner #2
           // Prisoner and visitors
-          expect($('[data-test=prisoner-2]').text()).toBe('Visitors linked to Fred Smith (B4567DE) at Bristol (HMP)')
+          expect($('[data-test=prisoner-2]').text().trim()).toBe('Visits to Fred Smith (B4567DE) at Bristol (HMP)')
           expect($('[data-test=prisoner-2-visitor-1-name]').text()).toBe('Alice Smith')
           expect($('[data-test=prisoner-2-visitor-1-relationship]').text()).toBe('Wife')
           expect($('[data-test=prisoner-2-visitor-1-dob]').text()).toBe('23 July 1990 (35 years old)')
@@ -179,8 +201,14 @@ describe('Booker management - booker details', () => {
           expect($('[data-test=prisoner-2-link-visitor]').attr('href')).toBe(
             '/manage-bookers/aaaa-bbbb-cccc/prisoner/B4567DE/link-visitor',
           )
+          // Visitor requests
+          expect($('[data-test=prisoner-1-no-visitor-requests]').length).toBe(1)
 
           expect(bookerService.getBookerDetails).toHaveBeenCalledWith({
+            username: 'user1',
+            reference: booker.reference,
+          })
+          expect(bookerService.getBookerVisitorRequestsByPrisoner).toHaveBeenCalledWith({
             username: 'user1',
             reference: booker.reference,
           })
@@ -213,6 +241,7 @@ describe('Booker management - booker details', () => {
         ],
       })
       bookerService.getBookerDetails.mockResolvedValue(booker)
+      bookerService.getBookerVisitorRequestsByPrisoner.mockResolvedValue({})
       bookerService.getBookerStatus.mockResolvedValue({ active: true, emailHasMultipleAccounts: false })
 
       return request(app)
@@ -223,7 +252,7 @@ describe('Booker management - booker details', () => {
 
           // Prisoner #1
           // Prisoner and visitors
-          expect($('[data-test=prisoner-1]').text()).toBe('Visitors linked to John Smith (A1234BC) at Hewell (HMP)')
+          expect($('[data-test=prisoner-1]').text().trim()).toBe('Visits to John Smith (A1234BC) at Hewell (HMP)')
           expect($('[data-test=prisoner-1-visitor-1-name]').text()).toBe('Jeanette Smith')
           expect($('[data-test=prisoner-1-visitor-1-relationship]').text()).toBe('Wife')
           expect($('[data-test=prisoner-1-visitor-1-dob]').text()).toBe('28 July 1986 (39 years old)')
@@ -238,7 +267,7 @@ describe('Booker management - booker details', () => {
 
           // Prisoner #2
           // Prisoner and visitors
-          expect($('[data-test=prisoner-2]').text()).toBe('Visitors linked to Fred Smith (B4567DE) at Bristol (HMP)')
+          expect($('[data-test=prisoner-2]').text().trim()).toBe('Visits to Fred Smith (B4567DE) at Bristol (HMP)')
           expect($('[data-test=prisoner-2-visitor-1-name]').text()).toBe('Alice Smith')
           expect($('[data-test=prisoner-2-visitor-1-relationship]').text()).toBe('Wife')
           expect($('[data-test=prisoner-2-visitor-1-dob]').text()).toBe('23 July 1990 (35 years old)')
@@ -256,6 +285,7 @@ describe('Booker management - booker details', () => {
     it('should render booker details page - booker with no prisoners', () => {
       const booker = TestData.bookerDetailedInfo({ permittedPrisoners: [] })
       bookerService.getBookerDetails.mockResolvedValue(booker)
+      bookerService.getBookerVisitorRequestsByPrisoner.mockResolvedValue({})
       bookerService.getBookerStatus.mockResolvedValue({ active: true, emailHasMultipleAccounts: false })
 
       return request(app)
@@ -278,6 +308,7 @@ describe('Booker management - booker details', () => {
         ],
       })
       bookerService.getBookerDetails.mockResolvedValue(booker)
+      bookerService.getBookerVisitorRequestsByPrisoner.mockResolvedValue({})
       bookerService.getBookerStatus.mockResolvedValue({ active: true, emailHasMultipleAccounts: false })
 
       return request(app)
@@ -286,7 +317,7 @@ describe('Booker management - booker details', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
           // Prisoner and no visitors message
-          expect($('[data-test=prisoner-1]').text()).toBe('Visitors linked to John Smith (A1234BC) at Hewell (HMP)')
+          expect($('[data-test=prisoner-1]').text().trim()).toBe('Visits to John Smith (A1234BC) at Hewell (HMP)')
           expect($('[data-test=prisoner-1-no-visitors]').text()).toContain('no linked visitors')
 
           expect($('[data-test=prisoner-1-link-visitor]').text().trim()).toBe('Link a visitor')
@@ -299,6 +330,7 @@ describe('Booker management - booker details', () => {
     it('should render booker details page - active booker when multiple accounts for email', () => {
       const booker = TestData.bookerDetailedInfo()
       bookerService.getBookerDetails.mockResolvedValue(booker)
+      bookerService.getBookerVisitorRequestsByPrisoner.mockResolvedValue({})
       bookerService.getBookerStatus.mockResolvedValue({ active: true, emailHasMultipleAccounts: true })
       sessionData.matchedBookers = [TestData.bookerSearchResult(), TestData.bookerSearchResult()]
 
@@ -317,6 +349,7 @@ describe('Booker management - booker details', () => {
     it('should render booker details page - inactive booker when multiple accounts for email', () => {
       const booker = TestData.bookerDetailedInfo()
       bookerService.getBookerDetails.mockResolvedValue(booker)
+      bookerService.getBookerVisitorRequestsByPrisoner.mockResolvedValue({})
       bookerService.getBookerStatus.mockResolvedValue({ active: false, emailHasMultipleAccounts: true })
 
       return request(app)
@@ -328,7 +361,7 @@ describe('Booker management - booker details', () => {
           expect($('.moj-alert').text()).toContain('This account is inactive')
 
           // Prisoner and visitors (with no 'Unlink' action)
-          expect($('[data-test=prisoner-1]').text()).toBe('Visitors linked to John Smith (A1234BC) at Hewell (HMP)')
+          expect($('[data-test=prisoner-1]').text().trim()).toBe('Visits to John Smith (A1234BC) at Hewell (HMP)')
           expect($('[data-test=prisoner-1-visitor-1-name]').text()).toBe('Jeanette Smith')
           expect($('[data-test=prisoner-1-visitor-1-relationship]').text()).toBe('Wife')
           expect($('[data-test=prisoner-1-visitor-1-dob]').text()).toBe('28 July 1986 (39 years old)')

--- a/server/routes/bookerManagement/booker/bookerDetailsController.ts
+++ b/server/routes/bookerManagement/booker/bookerDetailsController.ts
@@ -14,7 +14,11 @@ export default class BookerDetailsController {
       const { reference } = req.params
       const { username } = res.locals.user
 
-      const booker = await this.bookerService.getBookerDetails({ username, reference })
+      const [booker, visitorRequests] = await Promise.all([
+        this.bookerService.getBookerDetails({ username, reference }),
+        this.bookerService.getBookerVisitorRequestsByPrisoner({ username, reference }),
+      ])
+
       const { active, emailHasMultipleAccounts } = await this.bookerService.getBookerStatus({
         username,
         email: booker.email,
@@ -33,7 +37,13 @@ export default class BookerDetailsController {
 
       const messages = [...req.flash('messages'), ...this.getBookerDetailsMessages(active, emailHasMultipleAccounts)]
 
-      res.render('pages/bookerManagement/booker/bookerDetails', { backLinkHref, messages, active, booker })
+      res.render('pages/bookerManagement/booker/bookerDetails', {
+        backLinkHref,
+        messages,
+        active,
+        booker,
+        visitorRequests,
+      })
     }
   }
 

--- a/server/routes/bookerManagement/visitorRequests/checkLinkedVisitorsController.test.ts
+++ b/server/routes/bookerManagement/visitorRequests/checkLinkedVisitorsController.test.ts
@@ -131,7 +131,7 @@ describe('Booker management - visitor requests - check linked visitors', () => {
       return request(app).post('/manage-bookers/visitor-request/INVALID-REQUEST-REFERENCE/link-visitor').expect(400)
     })
 
-    it('should reject request, send audit, set message, clear session and redirect to manage bookers page - REJECT', () => {
+    it('should reject request, send audit, set message, clear session and redirect to manage bookers page - REJECT (returnTo = manage-bookers)', () => {
       const rejectedVisitorRequest = TestData.visitorRequest()
       bookerService.rejectVisitorRequest.mockResolvedValue(rejectedVisitorRequest)
 
@@ -149,7 +149,11 @@ describe('Booker management - visitor requests - check linked visitors', () => {
 
           expect(flashProvider).toHaveBeenCalledWith(
             'messages',
-            requestRejectedMessage(visitorRequestForReview, 'REJECT'),
+            requestRejectedMessage({
+              visitorRequest: visitorRequestForReview,
+              rejectionReason: 'REJECT',
+              includeBookerDetailsLink: true,
+            }),
           )
 
           expect(auditService.rejectedVisitorRequest).toHaveBeenCalledWith({
@@ -181,12 +185,53 @@ describe('Booker management - visitor requests - check linked visitors', () => {
 
           expect(flashProvider).toHaveBeenCalledWith(
             'messages',
-            requestRejectedMessage(visitorRequestForReview, 'ALREADY_LINKED'),
+            requestRejectedMessage({
+              visitorRequest: visitorRequestForReview,
+              rejectionReason: 'ALREADY_LINKED',
+              includeBookerDetailsLink: true,
+            }),
           )
 
           expect(auditService.rejectedVisitorRequest).toHaveBeenCalledWith({
             requestReference: visitorRequestForReview.reference,
             rejectionReason: 'ALREADY_LINKED',
+            username: 'user1',
+            operationId: undefined,
+          })
+
+          expect(sessionData.visitorRequestJourney).toBeUndefined()
+        })
+    })
+
+    it('should reject request, send audit, set message, clear session and redirect to manage bookers page - REJECT (returnTo = booker-details)', () => {
+      const rejectedVisitorRequest = TestData.visitorRequest()
+      bookerService.rejectVisitorRequest.mockResolvedValue(rejectedVisitorRequest)
+      sessionData.visitorRequestJourney.returnTo = 'booker-details'
+
+      return request(app)
+        .post(url)
+        .send({ rejectionReason: 'REJECT' })
+        .expect(302)
+        .expect('location', `/manage-bookers/${visitorRequestForReview.bookerReference}/booker-details`)
+        .expect(() => {
+          expect(bookerService.rejectVisitorRequest).toHaveBeenCalledWith({
+            username: 'user1',
+            requestReference: visitorRequestForReview.reference,
+            rejectionReason: 'REJECT',
+          })
+
+          expect(flashProvider).toHaveBeenCalledWith(
+            'messages',
+            requestRejectedMessage({
+              visitorRequest: visitorRequestForReview,
+              rejectionReason: 'REJECT',
+              includeBookerDetailsLink: false,
+            }),
+          )
+
+          expect(auditService.rejectedVisitorRequest).toHaveBeenCalledWith({
+            requestReference: visitorRequestForReview.reference,
+            rejectionReason: 'REJECT',
             username: 'user1',
             operationId: undefined,
           })

--- a/server/routes/bookerManagement/visitorRequests/checkLinkedVisitorsController.test.ts
+++ b/server/routes/bookerManagement/visitorRequests/checkLinkedVisitorsController.test.ts
@@ -22,6 +22,7 @@ const visitorRequestForReview = TestData.visitorRequestForReview()
 const linkedVisitors = [TestData.visitorInfo()]
 const url = `/manage-bookers/visitor-request/${visitorRequestForReview.reference}/check-linked-visitors`
 const fakeDateTime = new Date('2025-10-01T09:00')
+const returnTo = 'manage-bookers'
 
 beforeEach(() => {
   jest.useFakeTimers({ advanceTimers: true, now: new Date(fakeDateTime) })
@@ -33,6 +34,7 @@ beforeEach(() => {
     visitorRequestJourney: {
       visitorRequest: visitorRequestForReview,
       linkedVisitors,
+      returnTo,
     },
   } as SessionData
 
@@ -84,7 +86,7 @@ describe('Booker management - visitor requests - check linked visitors', () => {
           expect($('title').text()).toMatch(/^Check if the visitor is already linked -/)
           expect($('.govuk-breadcrumbs li').length).toBe(0)
           expect($('.govuk-back-link').attr('href')).toBe(
-            `/manage-bookers/visitor-request/${visitorRequestForReview.reference}/link-visitor`,
+            `/manage-bookers/visitor-request/${visitorRequestForReview.reference}/link-visitor?from=manage-bookers`,
           )
           expect($('h1').text().trim()).toBe('Check if the visitor is already linked')
 
@@ -232,6 +234,7 @@ describe('Booker management - visitor requests - check linked visitors', () => {
           expect(sessionData.visitorRequestJourney).toStrictEqual({
             visitorRequest: visitorRequestForReview,
             linkedVisitors,
+            returnTo,
           })
         })
     })

--- a/server/routes/bookerManagement/visitorRequests/checkLinkedVisitorsController.ts
+++ b/server/routes/bookerManagement/visitorRequests/checkLinkedVisitorsController.ts
@@ -22,12 +22,13 @@ export default class CheckLinkedVisitorsController {
         delete req.session.visitorRequestJourney
         return res.redirect('/manage-bookers')
       }
-      const { visitorRequest, linkedVisitors } = visitorRequestJourney
+      const { visitorRequest, linkedVisitors, returnTo } = visitorRequestJourney
 
       return res.render('pages/bookerManagement/visitorRequests/checkLinkedVisitors', {
         errors: req.flash('errors'),
         visitorRequest,
         linkedVisitors,
+        returnTo,
       })
     }
   }

--- a/server/routes/bookerManagement/visitorRequests/checkLinkedVisitorsController.ts
+++ b/server/routes/bookerManagement/visitorRequests/checkLinkedVisitorsController.ts
@@ -51,6 +51,8 @@ export default class CheckLinkedVisitorsController {
 
       const { rejectionReason } = matchedData<{ rejectionReason: RejectVisitorRequestDto['rejectionReason'] }>(req)
       const { username } = res.locals.user
+      const { returnTo } = visitorRequestJourney
+      const includeBookerDetailsLink = returnTo === 'manage-bookers'
 
       try {
         const rejectedVisitorRequest = await this.bookerService.rejectVisitorRequest({
@@ -59,7 +61,10 @@ export default class CheckLinkedVisitorsController {
           rejectionReason,
         })
 
-        req.flash('messages', requestRejectedMessage(rejectedVisitorRequest, rejectionReason))
+        req.flash(
+          'messages',
+          requestRejectedMessage({ visitorRequest: rejectedVisitorRequest, rejectionReason, includeBookerDetailsLink }),
+        )
 
         this.auditService.rejectedVisitorRequest({
           requestReference,
@@ -75,8 +80,12 @@ export default class CheckLinkedVisitorsController {
         req.flash('messages', requestAlreadyReviewedMessage())
       }
 
+      const { bookerReference } = visitorRequestJourney.visitorRequest
       delete req.session.visitorRequestJourney
-      return res.redirect(`/manage-bookers`)
+
+      return returnTo === 'manage-bookers'
+        ? res.redirect(`/manage-bookers`)
+        : res.redirect(`/manage-bookers/${bookerReference}/booker-details`)
     }
   }
 

--- a/server/routes/bookerManagement/visitorRequests/visitorRequestDetailsController.test.ts
+++ b/server/routes/bookerManagement/visitorRequests/visitorRequestDetailsController.test.ts
@@ -246,7 +246,7 @@ describe('Booker management - visitor requests - link a visitor', () => {
       return request(app).post('/manage-bookers/visitor-request/INVALID-REQUEST-REFERENCE/link-visitor').expect(400)
     })
 
-    it('should approve request, send audit, set message, clear session and redirect to manage bookers page if visitor selected', () => {
+    it('should approve request, send audit, set message, clear session and redirect to manage bookers page if visitor selected (returnTo = manage-bookers)', () => {
       const approvedVisitorRequest = TestData.visitorRequest()
       bookerService.approveVisitorRequest.mockResolvedValue(approvedVisitorRequest)
 
@@ -262,7 +262,43 @@ describe('Booker management - visitor requests - link a visitor', () => {
             visitorId: 4321,
           })
 
-          expect(flashProvider).toHaveBeenCalledWith('messages', requestApprovedMessage(visitorRequestForReview))
+          expect(flashProvider).toHaveBeenCalledWith(
+            'messages',
+            requestApprovedMessage({ visitorRequest: visitorRequestForReview, includeBookerDetailsLink: true }),
+          )
+
+          expect(auditService.approvedVisitorRequest).toHaveBeenCalledWith({
+            requestReference: visitorRequestForReview.reference,
+            visitorId: '4321',
+            username: 'user1',
+            operationId: undefined,
+          })
+
+          expect(sessionData.visitorRequestJourney).toBeUndefined()
+        })
+    })
+
+    it('should approve request, send audit, set message, clear session and redirect to booker details page if visitor selected (returnTo = booker-details)', () => {
+      const approvedVisitorRequest = TestData.visitorRequest()
+      bookerService.approveVisitorRequest.mockResolvedValue(approvedVisitorRequest)
+      sessionData.visitorRequestJourney.returnTo = 'booker-details'
+
+      return request(app)
+        .post(url)
+        .send({ visitorId: '4321' })
+        .expect(302)
+        .expect('location', `/manage-bookers/${visitorRequestForReview.bookerReference}/booker-details`)
+        .expect(() => {
+          expect(bookerService.approveVisitorRequest).toHaveBeenCalledWith({
+            username: 'user1',
+            requestReference: visitorRequestForReview.reference,
+            visitorId: 4321,
+          })
+
+          expect(flashProvider).toHaveBeenCalledWith(
+            'messages',
+            requestApprovedMessage({ visitorRequest: visitorRequestForReview, includeBookerDetailsLink: false }),
+          )
 
           expect(auditService.approvedVisitorRequest).toHaveBeenCalledWith({
             requestReference: visitorRequestForReview.reference,
@@ -311,7 +347,11 @@ describe('Booker management - visitor requests - link a visitor', () => {
 
           expect(flashProvider).toHaveBeenCalledWith(
             'messages',
-            requestRejectedMessage(visitorRequestForReview, rejectionReason),
+            requestRejectedMessage({
+              visitorRequest: visitorRequestForReview,
+              rejectionReason,
+              includeBookerDetailsLink: true,
+            }),
           )
 
           expect(auditService.rejectedVisitorRequest).toHaveBeenCalledWith({

--- a/server/routes/bookerManagement/visitorRequests/visitorRequestDetailsController.test.ts
+++ b/server/routes/bookerManagement/visitorRequests/visitorRequestDetailsController.test.ts
@@ -107,6 +107,25 @@ describe('Booker management - visitor requests - link a visitor', () => {
           expect(sessionData.visitorRequestJourney).toStrictEqual({
             visitorRequest: visitorRequestForReview,
             linkedVisitors,
+            returnTo: 'manage-bookers',
+          })
+        })
+    })
+
+    it('should correctly set back link and returnTo (in session data) if coming from booker details page', () => {
+      return request(app)
+        .get(`${url}?from=booker-details`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('.govuk-back-link').attr('href')).toBe(
+            `/manage-bookers/${visitorRequestForReview.bookerReference}/booker-details`,
+          )
+
+          expect(sessionData.visitorRequestJourney).toStrictEqual({
+            visitorRequest: visitorRequestForReview,
+            linkedVisitors,
+            returnTo: 'booker-details',
           })
         })
     })
@@ -211,7 +230,11 @@ describe('Booker management - visitor requests - link a visitor', () => {
 
   describe(`POST ${url}`, () => {
     beforeEach(() => {
-      sessionData.visitorRequestJourney = { visitorRequest: visitorRequestForReview, linkedVisitors }
+      sessionData.visitorRequestJourney = {
+        visitorRequest: visitorRequestForReview,
+        linkedVisitors,
+        returnTo: 'manage-bookers',
+      }
     })
 
     it('should require booker admin role', () => {
@@ -341,6 +364,7 @@ describe('Booker management - visitor requests - link a visitor', () => {
           expect(sessionData.visitorRequestJourney).toStrictEqual({
             visitorRequest: visitorRequestForReview,
             linkedVisitors,
+            returnTo: 'manage-bookers',
           })
         })
     })

--- a/server/routes/bookerManagement/visitorRequests/visitorRequestDetailsController.ts
+++ b/server/routes/bookerManagement/visitorRequests/visitorRequestDetailsController.ts
@@ -14,6 +14,7 @@ export default class VisitorRequestDetailsController {
     return async (req, res) => {
       const { requestReference } = req.params
       const { username } = res.locals.user
+      const returnTo = req.query?.from === 'booker-details' ? 'booker-details' : 'manage-bookers'
 
       const visitorRequest = await this.bookerService.getVisitorRequestForReview({ username, requestReference })
 
@@ -31,9 +32,15 @@ export default class VisitorRequestDetailsController {
       const showNoDobWarning = visitorRequest.socialContacts.some(contact => contact.dateOfBirth === null)
       const atLeastOneSelectableContact = visitorRequest.socialContacts.some(contact => contact.dateOfBirth?.length)
 
-      req.session.visitorRequestJourney = { visitorRequest, linkedVisitors }
+      req.session.visitorRequestJourney = { visitorRequest, linkedVisitors, returnTo }
+
+      const backLinkHref =
+        returnTo === 'booker-details'
+          ? `/manage-bookers/${visitorRequest.bookerReference}/booker-details`
+          : '/manage-bookers'
 
       return res.render('pages/bookerManagement/visitorRequests/visitorRequestDetails', {
+        backLinkHref,
         errors: req.flash('errors'),
         atLeastOneSelectableContact,
         showNoDobWarning,

--- a/server/routes/bookerManagement/visitorRequests/visitorRequestDetailsController.ts
+++ b/server/routes/bookerManagement/visitorRequests/visitorRequestDetailsController.ts
@@ -73,6 +73,9 @@ export default class VisitorRequestDetailsController {
         return res.redirect(`/manage-bookers/visitor-request/${requestReference}/check-linked-visitors`)
       }
 
+      const { returnTo } = visitorRequestJourney
+      const includeBookerDetailsLink = returnTo === 'manage-bookers'
+
       try {
         const { username } = res.locals.user
 
@@ -86,7 +89,14 @@ export default class VisitorRequestDetailsController {
             rejectionReason,
           })
 
-          req.flash('messages', requestRejectedMessage(rejectedVisitorRequest, rejectionReason))
+          req.flash(
+            'messages',
+            requestRejectedMessage({
+              visitorRequest: rejectedVisitorRequest,
+              rejectionReason,
+              includeBookerDetailsLink,
+            }),
+          )
 
           this.auditService.rejectedVisitorRequest({
             requestReference,
@@ -102,7 +112,10 @@ export default class VisitorRequestDetailsController {
             visitorId,
           })
 
-          req.flash('messages', requestApprovedMessage(approvedVisitorRequest))
+          req.flash(
+            'messages',
+            requestApprovedMessage({ visitorRequest: approvedVisitorRequest, includeBookerDetailsLink }),
+          )
 
           this.auditService.approvedVisitorRequest({
             requestReference,
@@ -119,8 +132,12 @@ export default class VisitorRequestDetailsController {
         req.flash('messages', requestAlreadyReviewedMessage())
       }
 
+      const { bookerReference } = visitorRequestJourney.visitorRequest
       delete req.session.visitorRequestJourney
-      return res.redirect(`/manage-bookers`)
+
+      return returnTo === 'manage-bookers'
+        ? res.redirect(`/manage-bookers`)
+        : res.redirect(`/manage-bookers/${bookerReference}/booker-details`)
     }
   }
 

--- a/server/routes/bookerManagement/visitorRequests/visitorRequestMessages.ts
+++ b/server/routes/bookerManagement/visitorRequests/visitorRequestMessages.ts
@@ -1,9 +1,12 @@
 import { MoJAlert } from '../../../@types/bapv'
 import { PrisonVisitorRequestDto, RejectVisitorRequestDto } from '../../../data/orchestrationApiTypes'
 
-const bookerNotifiedHtml = (bookerReference: string): string =>
-  'The booker has been notified by email. ' +
-  `You can <a href="/manage-bookers/${bookerReference}/booker-details">view the booker’s account</a>.`
+const bookerNotifiedHtml = (bookerReference: string, includeBookerDetailsLink: boolean): string =>
+  `The booker has been notified by email. ${
+    includeBookerDetailsLink
+      ? `You can <a href="/manage-bookers/${bookerReference}/booker-details">view the booker’s account</a>.`
+      : ''
+  }`
 
 export const requestAlreadyReviewedMessage = (): MoJAlert => ({
   variant: 'information',
@@ -11,18 +14,29 @@ export const requestAlreadyReviewedMessage = (): MoJAlert => ({
   text: 'The selected request has already been reviewed.',
 })
 
-export const requestApprovedMessage = (visitorRequest: PrisonVisitorRequestDto): MoJAlert => ({
+export const requestApprovedMessage = ({
+  visitorRequest,
+  includeBookerDetailsLink,
+}: {
+  visitorRequest: PrisonVisitorRequestDto
+  includeBookerDetailsLink: boolean
+}): MoJAlert => ({
   variant: 'success',
   title: `You approved the request and linked ${visitorRequest.firstName} ${visitorRequest.lastName}`,
   showTitleAsHeading: true,
-  html: bookerNotifiedHtml(visitorRequest.bookerReference),
+  html: bookerNotifiedHtml(visitorRequest.bookerReference, includeBookerDetailsLink),
   dismissible: true,
 })
 
-export const requestRejectedMessage = (
-  visitorRequest: PrisonVisitorRequestDto,
-  rejectionReason: RejectVisitorRequestDto['rejectionReason'],
-): MoJAlert => {
+export const requestRejectedMessage = ({
+  visitorRequest,
+  rejectionReason,
+  includeBookerDetailsLink,
+}: {
+  visitorRequest: PrisonVisitorRequestDto
+  rejectionReason: RejectVisitorRequestDto['rejectionReason']
+  includeBookerDetailsLink: boolean
+}): MoJAlert => {
   const title =
     rejectionReason === 'ALREADY_LINKED'
       ? `You confirmed that ${visitorRequest.firstName} ${visitorRequest.lastName} is already a linked visitor`
@@ -32,7 +46,7 @@ export const requestRejectedMessage = (
     variant: 'success',
     title,
     showTitleAsHeading: true,
-    html: bookerNotifiedHtml(visitorRequest.bookerReference),
+    html: bookerNotifiedHtml(visitorRequest.bookerReference, includeBookerDetailsLink),
     dismissible: true,
   }
 }

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -3,6 +3,7 @@ import {
   Alert,
   ApplicationDto,
   BookerDetailedInfoDto,
+  BookerPrisonerVisitorRequestDto,
   BookerSearchResultsDto,
   ExcludeDateDto,
   OffenderRestriction,
@@ -196,6 +197,22 @@ export default class TestData {
     lastName,
     dateOfBirth,
     relationshipDescription,
+  })
+
+  static bookerPrisonerVisitorRequest = ({
+    reference = 'dddd-eeee-ffff',
+    prisonerId = 'A1234BC',
+    firstName = 'Mike',
+    lastName = 'Jones',
+    dateOfBirth = '1999-11-10',
+    requestedOn = '2025-12-10',
+  }: Partial<BookerPrisonerVisitorRequestDto> = {}): BookerPrisonerVisitorRequestDto => ({
+    reference,
+    prisonerId,
+    firstName,
+    lastName,
+    dateOfBirth,
+    requestedOn,
   })
 
   static bookerSearchResult = ({

--- a/server/services/bookerService.test.ts
+++ b/server/services/bookerService.test.ts
@@ -163,7 +163,7 @@ describe('Booker service', () => {
 
   describe('getBookerVisitorRequestsByPrisoner', () => {
     it('should return visitor requests for given booker reference grouped by prisoner ID', async () => {
-      const bookerReference = 'aaaa-bbbb-cccc'
+      const reference = 'aaaa-bbbb-cccc'
       const visitorRequests = [
         TestData.bookerPrisonerVisitorRequest({ prisonerId: 'P1' }),
         TestData.bookerPrisonerVisitorRequest({ prisonerId: 'P2' }),
@@ -171,13 +171,13 @@ describe('Booker service', () => {
 
       orchestrationApiClient.getBookerVisitorRequests.mockResolvedValue(visitorRequests)
 
-      const result = await bookerService.getBookerVisitorRequestsByPrisoner({ username, bookerReference })
+      const result = await bookerService.getBookerVisitorRequestsByPrisoner({ username, reference })
 
       expect(result).toStrictEqual({
         P1: [visitorRequests[0]],
         P2: [visitorRequests[1]],
       })
-      expect(orchestrationApiClient.getBookerVisitorRequests).toHaveBeenCalledWith(bookerReference)
+      expect(orchestrationApiClient.getBookerVisitorRequests).toHaveBeenCalledWith(reference)
     })
   })
 

--- a/server/services/bookerService.test.ts
+++ b/server/services/bookerService.test.ts
@@ -161,6 +161,26 @@ describe('Booker service', () => {
     })
   })
 
+  describe('getBookerVisitorRequestsByPrisoner', () => {
+    it('should return visitor requests for given booker reference grouped by prisoner ID', async () => {
+      const bookerReference = 'aaaa-bbbb-cccc'
+      const visitorRequests = [
+        TestData.bookerPrisonerVisitorRequest({ prisonerId: 'P1' }),
+        TestData.bookerPrisonerVisitorRequest({ prisonerId: 'P2' }),
+      ]
+
+      orchestrationApiClient.getBookerVisitorRequests.mockResolvedValue(visitorRequests)
+
+      const result = await bookerService.getBookerVisitorRequestsByPrisoner({ username, bookerReference })
+
+      expect(result).toStrictEqual({
+        P1: [visitorRequests[0]],
+        P2: [visitorRequests[1]],
+      })
+      expect(orchestrationApiClient.getBookerVisitorRequests).toHaveBeenCalledWith(bookerReference)
+    })
+  })
+
   describe('getVisitorRequests', () => {
     it('should return visitor requests awaiting approval', async () => {
       const prisonId = 'HEI'

--- a/server/services/bookerService.ts
+++ b/server/services/bookerService.ts
@@ -134,15 +134,15 @@ export default class BookerService {
 
   async getBookerVisitorRequestsByPrisoner({
     username,
-    bookerReference,
+    reference,
   }: {
     username: string
-    bookerReference: string
+    reference: string
   }): Promise<Record<string, BookerPrisonerVisitorRequestDto[]>> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
-    const requests = await orchestrationApiClient.getBookerVisitorRequests(bookerReference)
+    const requests = await orchestrationApiClient.getBookerVisitorRequests(reference)
     return { ...Object.groupBy(requests, request => request.prisonerId) }
   }
 

--- a/server/services/bookerService.ts
+++ b/server/services/bookerService.ts
@@ -2,6 +2,7 @@ import { compareDesc } from 'date-fns'
 import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
 import {
   BookerDetailedInfoDto,
+  BookerPrisonerVisitorRequestDto,
   BookerSearchResultsDto,
   PrisonVisitorRequestDto,
   PrisonVisitorRequestListEntryDto,
@@ -129,6 +130,20 @@ export default class BookerService {
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
     await orchestrationApiClient.unlinkBookerVisitor({ reference, prisonerId, visitorId, username })
+  }
+
+  async getBookerVisitorRequestsByPrisoner({
+    username,
+    bookerReference,
+  }: {
+    username: string
+    bookerReference: string
+  }): Promise<Record<string, BookerPrisonerVisitorRequestDto[]>> {
+    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
+
+    const requests = await orchestrationApiClient.getBookerVisitorRequests(bookerReference)
+    return { ...Object.groupBy(requests, request => request.prisonerId) }
   }
 
   async getVisitorRequests({

--- a/server/views/pages/bookerManagement/booker/bookerDetails.njk
+++ b/server/views/pages/bookerManagement/booker/bookerDetails.njk
@@ -34,9 +34,12 @@
           {% set prisonerName = (prisoner.prisoner.firstName + " " + prisoner.prisoner.lastName) | properCaseFullName %}
           {% set prisonerNumber = prisoner.prisoner.prisonerNumber %}
 
-          <h2 class="govuk-heading-m" data-test="{{ prisonerIndex }}">Visitors linked to {{ prisonerName }} ({{ prisonerNumber }}) at {{ prisoner.registeredPrison.prisonName }}</h2>
+          <h2 class="govuk-heading-m" data-test="{{ prisonerIndex }}">
+            Visits to {{ prisonerName }} ({{ prisonerNumber }}) at {{ prisoner.registeredPrison.prisonName }}
+          </h2>
 
           {# Visitors #}
+          <h3 class="govuk-heading-s">Linked visitors</h3>
           {% if prisoner.permittedVisitors | length %}
 
             {# Build visitor table row items #}
@@ -105,6 +108,52 @@
             }) }}
           {% endif %}
 
+          {# Visitor requests #}
+          <h3 class="govuk-heading-s">Requests to link visitors</h3>
+
+          {% if visitorRequests[prisonerNumber] | length %}
+            {# Build visitor request table row items #}
+            {% set visitorRequestRowItems = [] %}
+            {%- for request in visitorRequests[prisonerNumber] %}
+              {% set requestIndex = prisonerIndex + "-visitor-request-" + loop.index %}
+              {% set visitorName %}{{ request.firstName }} {{ request.lastName }}{% endset %}
+
+              {%- set visitorRequestRowItems = (visitorRequestRowItems.push([
+                {
+                  text: visitorName | safe,
+                  attributes: { "data-test": requestIndex + "-name" }
+                },
+                {
+                  text: request.requestedOn | formatDate("d/M/yyyy"),
+                  attributes: { "data-test": requestIndex + "-requested-date" }
+                },
+                {
+                  html: '<a class="govuk-link--no-visited-state" 
+                        href="/manage-bookers/visitor-request/' + request.reference + '/link-visitor?from=booker-details" >' +
+                        'View<span class="govuk-visually-hidden"> request to add ' + (visitorName | escape) + ' as a visitor</span></a>',
+                  classes: "govuk-!-text-align-right",
+                  attributes: { "data-test": requestIndex + "-action" }
+                }
+                ]), visitorRequestRowItems) %}
+            {% endfor -%}
+
+            {{ govukTable({
+              classes: "govuk-!-margin-top-6",
+              firstCellIsHeader: true,
+              head: [
+                { text: "Name"},
+                { text: "Requested on"},
+                { text: "Action", classes: "govuk-!-text-align-right"}
+              ],
+              rows: visitorRequestRowItems
+            }) }}
+
+
+            {% else %}
+              <p data-test="{{ prisonerIndex }}-no-visitor-requests">
+                There are no requests to link visitors.
+              </p>
+          {% endif %}
         {% endfor %}
       {% else %}
         <p data-test="booker-no-prisoners">This booker has no prisoners.</p>

--- a/server/views/pages/bookerManagement/booker/bookerDetails.njk
+++ b/server/views/pages/bookerManagement/booker/bookerDetails.njk
@@ -116,11 +116,11 @@
             {% set visitorRequestRowItems = [] %}
             {%- for request in visitorRequests[prisonerNumber] %}
               {% set requestIndex = prisonerIndex + "-visitor-request-" + loop.index %}
-              {% set visitorName %}{{ request.firstName }} {{ request.lastName }}{% endset %}
+              {% set visitorName = request.firstName + " " + request.lastName %}
 
               {%- set visitorRequestRowItems = (visitorRequestRowItems.push([
                 {
-                  text: visitorName | safe,
+                  text: visitorName,
                   attributes: { "data-test": requestIndex + "-name" }
                 },
                 {

--- a/server/views/pages/bookerManagement/visitorRequests/checkLinkedVisitors.njk
+++ b/server/views/pages/bookerManagement/visitorRequests/checkLinkedVisitors.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% set pageHeaderTitle = "Check if the visitor is already linked" %}
-{% set backLinkHref = "/manage-bookers/visitor-request/" + visitorRequest.reference + "/link-visitor" %}
+{% set backLinkHref %}/manage-bookers/visitor-request/{{ visitorRequest.reference }}/link-visitor?from={{ returnTo }}{% endset %}
 
 {% set linkedVisitorRows = [] %}
 {% for visitor in linkedVisitors %}

--- a/server/views/pages/bookerManagement/visitorRequests/visitorRequestDetails.njk
+++ b/server/views/pages/bookerManagement/visitorRequests/visitorRequestDetails.njk
@@ -5,7 +5,6 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set pageHeaderTitle = "Link a visitor" %}
-{% set backLinkHref = "/manage-bookers" %}
 
 {% set contactRows = [] %}
 {% for contact in visitorRequest.socialContacts %}


### PR DESCRIPTION
* Show outstanding visitor requests on the booker details
* If a visitor request is actioned from the booker details page ensure that:
  * 'back' links go back to booker details (instead of manage bookers page)
  * flash confirmation messages (for approve/reject) don't contain link to booker details page