### PR TITLE
VB-6674 Handle deleted visitor relationships

### DIFF
--- a/server/routes/visit/visitDetailsController.test.ts
+++ b/server/routes/visit/visitDetailsController.test.ts
@@ -145,6 +145,20 @@ describe('Visit details page', () => {
         })
     })
 
+    it('should handle a deleted visitor relationship', () => {
+      visitDetails.visitors[0].relationshipDescription = null
+
+      return request(app)
+        .get('/visit/ab-cd-ef-gh')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-test="visitor-name-1"]').text()).toBe('Jeanette Smith')
+          expect($('[data-test="visitor-relation-1"]').text()).toBe('Relationship deleted')
+        })
+    })
+
     it('should render visit request title for a visit request', () => {
       visitDetails.visitSubStatus = 'REQUESTED'
 

--- a/server/views/pages/visit/visitDetails.njk
+++ b/server/views/pages/visit/visitDetails.njk
@@ -248,7 +248,9 @@
             <h3 class="govuk-heading-m">
               <span data-test="visitor-name-{{ loop.index }}">{{ visitor.firstName }} {{ visitor.lastName }}</span>
               <span>
-                (<span data-test="visitor-relation-{{ loop.index }}">{{ visitor.relationshipDescription | lower }}</span>)
+                (<span data-test="visitor-relation-{{ loop.index }}">
+                  {{- (visitor.relationshipDescription | lower) | default("Relationship deleted", true) -}}
+                </span>)
               </span>
             </h3>
             <dl class="govuk-list bapv-visit-details__person-details">


### PR DESCRIPTION
On the visit details page, if a visitor relationship comes through as `null` then display `Relationship deleted` instead of empty string.