### PR TITLE
VB-6717 Refactor handling of alerts/restrictions skipped messages (Visit booking details page)

### DIFF
--- a/server/@types/bapv.d.ts
+++ b/server/@types/bapv.d.ts
@@ -12,7 +12,7 @@ import {
 import type { CalendarVisitSession } from '../services/visitSessionsService'
 import type { Restriction } from '../data/prisonerContactRegistryApiTypes'
 
-type TextOrHtml = { text: string; html?: never } | { text?: never; html: string }
+export type TextOrHtml = { text: string; html?: never } | { text?: never; html: string }
 
 export type FlashFormValues = Record<string, unknown>
 

--- a/server/@types/orchestration-api.d.ts
+++ b/server/@types/orchestration-api.d.ts
@@ -372,26 +372,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/visit-passes/prison/{prisonId}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /**
-     * Get visit passes for a prison on a given date.
-     * @description Get visit passes for a prison on a given date.
-     */
-    post: operations['getVisitPassesForPrisonOnDate']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/public/booker/{bookerReference}/permitted/prisoners/{prisonerId}/permitted/visitors': {
     parameters: {
       query?: never
@@ -490,6 +470,46 @@ export interface paths {
      * @description Search for all booker accounts that are registered to email
      */
     post: operations['searchForBooker']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/prison/{prisonId}/visit-passes': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Get visit passes for a prison on a given date.
+     * @description Get visit passes for a prison on a given date.
+     */
+    post: operations['getVisitPassesForPrisonOnDate']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/prison/{prisonId}/visit-passes/visit/{visitReference}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Get visit pass for an individual visit.
+     * @description Get visit pass for an individual visit.
+     */
+    post: operations['getVisitPassForVisitReference']
     delete?: never
     options?: never
     head?: never
@@ -2022,6 +2042,136 @@ export interface components {
       /** @description full name of user who added the exclude date or username if full name is not available. */
       actionedBy: string
     }
+    /** @description Details to register a visitor to a booker's prisoner. */
+    RegisterVisitorForBookerPrisonerDto: {
+      /**
+       * Format: int64
+       * @description Visitor Id
+       * @example 12345
+       */
+      visitorId: number
+      /**
+       * @description Flag to determine if the booker should be notified of the registration
+       * @example true
+       */
+      sendNotificationFlag: boolean | null
+      /**
+       * @description STAFF username who registered the visitor
+       * @example ABC123D
+       */
+      actionedBy: string
+    }
+    /** @description Permitted visitor associated with the permitted prisoner. */
+    PermittedVisitorsForPermittedPrisonerBookerDto: {
+      /**
+       * Format: int64
+       * @description Identifier for this contact (Person in NOMIS)
+       * @example 5871791
+       */
+      visitorId: number
+    }
+    /** @description Visit Pass request details. */
+    StaffUsernameDto: {
+      /**
+       * @description User Name for STAFF
+       * @example ALED
+       */
+      username: string
+    }
+    AddVisitorToBookerPrisonerRequestDto: {
+      /** @description First name of the visitor in request */
+      firstName: string
+      /** @description Last name of the visitor in request */
+      lastName: string
+      /**
+       * Format: date
+       * @description Date of birth of the visitor in request
+       */
+      dateOfBirth: string
+    }
+    BookerVisitorRequestValidationErrorResponse: {
+      /** Format: int32 */
+      status: number
+      /** Format: int32 */
+      errorCode?: number | null
+      userMessage?: string | null
+      developerMessage?: string | null
+      /** @enum {string} */
+      validationError:
+        | 'PRISONER_NOT_FOUND_FOR_BOOKER'
+        | 'MAX_IN_PROGRESS_REQUESTS_REACHED'
+        | 'REQUEST_ALREADY_EXISTS'
+        | 'VISITOR_ALREADY_EXISTS'
+    }
+    CreateVisitorRequestResponseDto: {
+      /**
+       * @description Reference of newly created visitor request
+       * @example abc-def-ghi
+       */
+      reference: string
+      /**
+       * @description Status of newly created visitor request
+       * @example REQUESTED or AUTO_APPROVED
+       * @enum {string}
+       */
+      status: 'REQUESTED' | 'APPROVED' | 'AUTO_APPROVED' | 'REJECTED'
+      /**
+       * @description Reference of booker who submitted the request
+       * @example abc-def-ghi
+       */
+      bookerReference: string
+      /**
+       * @description The id of the booker's prisoner for the visitor request
+       * @example AA123456
+       */
+      prisonerId: string
+    }
+    /** @description Details to register a prisoner to a booker. */
+    RegisterPrisonerForBookerDto: {
+      /**
+       * @description Prisoner Id
+       * @example A1234AA
+       */
+      prisonerId: string
+      /**
+       * @description Prisoner first name
+       * @example James
+       */
+      prisonerFirstName: string
+      /**
+       * @description Prisoner last name
+       * @example Smith
+       */
+      prisonerLastName: string
+      /**
+       * Format: date
+       * @description Prisoner date of birth
+       * @example 1960-01-30
+       */
+      prisonerDateOfBirth: string
+      /**
+       * @description Prison Id
+       * @example MDI
+       */
+      prisonId: string
+    }
+    /** @description Find a booker via search criteria */
+    SearchBookerDto: {
+      /** @description auth email */
+      email: string
+    }
+    /** @description Details of a found booker via booker search */
+    BookerSearchResultsDto: {
+      /** @description This is the booker reference, unique per booker */
+      reference: string
+      /** @description email registered to booker */
+      email: string
+      /**
+       * Format: date-time
+       * @description The time the booker account was created
+       */
+      createdTimestamp: string
+    }
     /** @description Visit Pass request details. */
     VisitPassRequestDto: {
       /**
@@ -2029,7 +2179,7 @@ export interface components {
        * @description Date for which visit passes are being sought.
        * @example 2025-01-01
        */
-      visitDate: string
+      date: string
       /**
        * @description STAFF username who triggered the visit passes endpoint.
        * @example ABC123D
@@ -2162,136 +2312,6 @@ export interface components {
        */
       dateOfBirth?: string | null
       address?: components['schemas']['AddressDto'] | null
-    }
-    /** @description Details to register a visitor to a booker's prisoner. */
-    RegisterVisitorForBookerPrisonerDto: {
-      /**
-       * Format: int64
-       * @description Visitor Id
-       * @example 12345
-       */
-      visitorId: number
-      /**
-       * @description Flag to determine if the booker should be notified of the registration
-       * @example true
-       */
-      sendNotificationFlag: boolean | null
-      /**
-       * @description STAFF username who registered the visitor
-       * @example ABC123D
-       */
-      actionedBy: string
-    }
-    /** @description Permitted visitor associated with the permitted prisoner. */
-    PermittedVisitorsForPermittedPrisonerBookerDto: {
-      /**
-       * Format: int64
-       * @description Identifier for this contact (Person in NOMIS)
-       * @example 5871791
-       */
-      visitorId: number
-    }
-    /** @description STAFF user details */
-    StaffUsernameDto: {
-      /**
-       * @description User Name for STAFF
-       * @example ALED
-       */
-      username: string
-    }
-    AddVisitorToBookerPrisonerRequestDto: {
-      /** @description First name of the visitor in request */
-      firstName: string
-      /** @description Last name of the visitor in request */
-      lastName: string
-      /**
-       * Format: date
-       * @description Date of birth of the visitor in request
-       */
-      dateOfBirth: string
-    }
-    BookerVisitorRequestValidationErrorResponse: {
-      /** Format: int32 */
-      status: number
-      /** Format: int32 */
-      errorCode?: number | null
-      userMessage?: string | null
-      developerMessage?: string | null
-      /** @enum {string} */
-      validationError:
-        | 'PRISONER_NOT_FOUND_FOR_BOOKER'
-        | 'MAX_IN_PROGRESS_REQUESTS_REACHED'
-        | 'REQUEST_ALREADY_EXISTS'
-        | 'VISITOR_ALREADY_EXISTS'
-    }
-    CreateVisitorRequestResponseDto: {
-      /**
-       * @description Reference of newly created visitor request
-       * @example abc-def-ghi
-       */
-      reference: string
-      /**
-       * @description Status of newly created visitor request
-       * @example REQUESTED or AUTO_APPROVED
-       * @enum {string}
-       */
-      status: 'REQUESTED' | 'APPROVED' | 'AUTO_APPROVED' | 'REJECTED'
-      /**
-       * @description Reference of booker who submitted the request
-       * @example abc-def-ghi
-       */
-      bookerReference: string
-      /**
-       * @description The id of the booker's prisoner for the visitor request
-       * @example AA123456
-       */
-      prisonerId: string
-    }
-    /** @description Details to register a prisoner to a booker. */
-    RegisterPrisonerForBookerDto: {
-      /**
-       * @description Prisoner Id
-       * @example A1234AA
-       */
-      prisonerId: string
-      /**
-       * @description Prisoner first name
-       * @example James
-       */
-      prisonerFirstName: string
-      /**
-       * @description Prisoner last name
-       * @example Smith
-       */
-      prisonerLastName: string
-      /**
-       * Format: date
-       * @description Prisoner date of birth
-       * @example 1960-01-30
-       */
-      prisonerDateOfBirth: string
-      /**
-       * @description Prison Id
-       * @example MDI
-       */
-      prisonId: string
-    }
-    /** @description Find a booker via search criteria */
-    SearchBookerDto: {
-      /** @description auth email */
-      email: string
-    }
-    /** @description Details of a found booker via booker search */
-    BookerSearchResultsDto: {
-      /** @description This is the booker reference, unique per booker */
-      reference: string
-      /** @description email registered to booker */
-      email: string
-      /**
-       * Format: date-time
-       * @description The time the booker account was created
-       */
-      createdTimestamp: string
     }
     /** @description AlertDto returned from orchestration, made of fields from AlertResponseDto from Alerts API call */
     AlertDto: {
@@ -2650,8 +2670,11 @@ export interface components {
       events: components['schemas']['EventAuditOrchestrationDto'][]
       /** @description Notifications tied to visit booking */
       notifications: components['schemas']['VisitNotificationDto'][]
-      /** @description Boolean to signify if alerts and restrictions retrieval was intentionally skipped */
-      skipAlertsAndRestrictions: boolean
+      /**
+       * @description Enum denoting why alerts and restrictions were skipped; absent if not skipped
+       * @enum {string|null}
+       */
+      skipAlertsAndRestrictionReason?: 'PRISONER_RELEASED' | 'PRISONER_TRANSFERRED' | 'VISIT_IN_PAST' | null
     }
     /** @description Visit notification details */
     VisitContactDto: {
@@ -2844,10 +2867,10 @@ export interface components {
         | 'CANCELLED'
     }
     PageVisitDto: {
-      /** Format: int32 */
-      totalPages?: number
       /** Format: int64 */
       totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitDto'][]
@@ -2874,8 +2897,8 @@ export interface components {
     }
     SortObject: {
       empty?: boolean
-      unsorted?: boolean
       sorted?: boolean
+      unsorted?: boolean
     }
     OrchestrationVisitRequestSummaryDto: {
       /** @description Visit reference */
@@ -3469,6 +3492,11 @@ export interface components {
        * @example Outside - released from Leeds
        */
       locationDescription?: string | null
+      /**
+       * @description Status of the prisoner
+       * @example ACTIVE IN
+       */
+      status: string
       /**
        * @description Convicted Status
        * @example Convicted
@@ -5667,81 +5695,6 @@ export interface operations {
       }
     }
   }
-  getVisitPassesForPrisonOnDate: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        /**
-         * @description Prison code.
-         * @example ABC
-         */
-        prisonId: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['VisitPassRequestDto']
-      }
-    }
-    responses: {
-      /** @description Return visit passes given a prison and visit date. */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          '*/*': components['schemas']['VisitPassDto'][]
-        }
-      }
-      /** @description Incorrect request to get visit passes for a prison on a given date. */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Unauthorized to access this endpoint */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Incorrect permissions to get visit passes for a prison on a given date. */
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Visit passes could not be found for the supplied prison and visit date. */
-      404: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Internal server error while retrieving visit passes. */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
   getPermittedVisitorsForPrisoner: {
     parameters: {
       query?: never
@@ -6041,6 +5994,157 @@ export interface operations {
       }
       /** @description Incorrect permissions for this action */
       403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getVisitPassesForPrisonOnDate: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /**
+         * @description Prison code.
+         * @example ABC
+         */
+        prisonId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['VisitPassRequestDto']
+      }
+    }
+    responses: {
+      /** @description Return visit passes given a prison and visit date. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['VisitPassDto'][]
+        }
+      }
+      /** @description Incorrect request to get visit passes for a prison on a given date. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to get visit passes for a prison on a given date. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Visit passes could not be found for the supplied prison and visit date. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Internal server error while retrieving visit passes. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getVisitPassForVisitReference: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /**
+         * @description Prison code.
+         * @example ABC
+         */
+        prisonId: string
+        visitReference: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['StaffUsernameDto']
+      }
+    }
+    responses: {
+      /** @description Return visit pass given a visit reference and prison. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['VisitPassDto']
+        }
+      }
+      /** @description Incorrect request to get a visit pass given a visit reference and prison. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Incorrect permissions to get a visit pass given a visit reference and prison. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Visit pass could not be found for the given visit reference. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Internal server error while retrieving visit pass for the given visit reference. */
+      500: {
         headers: {
           [name: string]: unknown
         }

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -864,7 +864,7 @@ describe('orchestrationApiClient', () => {
       const results = [TestData.visitPass()]
 
       fakeOrchestrationApi
-        .post(`/visit-passes/prison/${prisonId}`, <VisitPassRequestDto>{ visitDate: date, actionedBy: 'user1' })
+        .post(`/visit-passes/prison/${prisonId}`, <VisitPassRequestDto>{ date, actionedBy: 'user1' })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, results)
 

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -489,7 +489,7 @@ export default class OrchestrationApiClient {
   }): Promise<VisitPassDto[]> {
     return this.restClient.post({
       path: `/visit-passes/prison/${prisonId}`,
-      data: <VisitPassRequestDto>{ visitDate: date, actionedBy: username },
+      data: <VisitPassRequestDto>{ date, actionedBy: username },
     })
   }
 

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -165,6 +165,7 @@ export default class TestData {
     prisonName = 'Hewell (HMP)',
     cellLocation = '1-1-C-028',
     locationDescription = 'Hewell (HMP)',
+    status = 'ACTIVE IN',
     convictedStatus = 'Convicted',
   }: Partial<
     BookerDetailedInfoDto['permittedPrisoners'][0]['prisoner']
@@ -177,6 +178,7 @@ export default class TestData {
     prisonName,
     cellLocation,
     locationDescription,
+    status,
     convictedStatus,
   })
 
@@ -695,7 +697,7 @@ export default class TestData {
       },
     ],
     notifications = [],
-    skipAlertsAndRestrictions = false,
+    skipAlertsAndRestrictionReason = null,
   }: Partial<VisitBookingDetails> = {}): VisitBookingDetails => ({
     reference,
     visitRoom,
@@ -714,7 +716,7 @@ export default class TestData {
     visitors,
     events,
     notifications,
-    skipAlertsAndRestrictions,
+    skipAlertsAndRestrictionReason,
   })
 
   // raw data as returned from API
@@ -736,7 +738,7 @@ export default class TestData {
     visitors = this.visitBookingDetails().visitors,
     events = this.visitBookingDetails().events as VisitBookingDetailsRaw['events'],
     notifications = this.visitBookingDetails().notifications as VisitBookingDetailsRaw['notifications'],
-    skipAlertsAndRestrictions = this.visitBookingDetails().skipAlertsAndRestrictions,
+    skipAlertsAndRestrictionReason = this.visitBookingDetails().skipAlertsAndRestrictionReason,
   }: Partial<VisitBookingDetailsRaw> = {}): VisitBookingDetailsRaw => ({
     reference,
     visitRoom,
@@ -755,7 +757,7 @@ export default class TestData {
     visitors,
     events,
     notifications,
-    skipAlertsAndRestrictions,
+    skipAlertsAndRestrictionReason,
   })
 
   // data with notification types processed

--- a/server/routes/visit/visitDetailsController.ts
+++ b/server/routes/visit/visitDetailsController.ts
@@ -40,11 +40,8 @@ export default class VisitDetailsController {
       }
 
       const hideAlertsInset = getHideAlertsInset({
+        skipAlertsAndRestrictionReason: visitDetails.skipAlertsAndRestrictionReason,
         prisonerNumber: visitDetails.prisoner.prisonerNumber,
-        startTimestamp: visitDetails.startTimestamp,
-        visitPrisonId: visitDetails.prison.prisonId,
-        prisonerPrisonId: visitDetails.prisoner.prisonId,
-        inOutStatus: visitDetails.prisoner.inOutStatus,
       })
 
       const availableVisitActions = getAvailableVisitActions({

--- a/server/routes/visit/visitUtils.test.ts
+++ b/server/routes/visit/visitUtils.test.ts
@@ -581,121 +581,58 @@ describe('Visit utils', () => {
 
   describe('getHideAlertsInset', () => {
     const prisonerNumber = 'A1234BC'
+    let expected: ReturnType<typeof getHideAlertsInset>
 
-    it('should return "PAST" if startTimestamp is in the past (2AM visit, 2PM current time)', () => {
-      const fakeDate = new Date('2026-01-01T14:00:00') // 01-01-26 2PM
-      jest.useFakeTimers({ advanceTimers: true, now: fakeDate })
-      const startTimestamp = '2026-01-01T02:00:00' // 01-01-26 2AM
-
-      const visitPrisonId = 'HEI'
-      const prisonerPrisonId = 'HEI'
-      const inOutStatus = 'IN'
-
-      const expected = {
+    beforeEach(() => {
+      expected = {
         prisoner: {
-          html: `Alerts and restrictions are not shown for past visits.<br>You can view alerts and restrictions for past visits in the <a href="${config.dpsContacts}/prisoner/${prisonerNumber}/alerts-restrictions">contacts service</a>.`,
           attributes: { 'data-test': 'prisoner-inset' },
           classes: 'govuk-!-margin-bottom-1',
         },
         visitor: {
-          html: `Visitor restrictions are not shown for past visits.<br>You can view alerts and restrictions for past visits in the <a href="${config.dpsContacts}/prisoner/${prisonerNumber}/contacts/list">contacts service</a>.`,
           attributes: { 'data-test': 'visitor-inset' },
         },
-      }
+      } as ReturnType<typeof getHideAlertsInset>
+    })
+
+    it('should return past visit message if skipAlertsAndRestrictionReason is VISIT_IN_PAST', () => {
+      expected.prisoner.html = `Alerts and restrictions are not shown for past visits.<br>You can view alerts and restrictions for past visits in the <a href="${config.dpsContacts}/prisoner/${prisonerNumber}/alerts-restrictions">contacts service</a>.`
+      expected.visitor.html = `Visitor restrictions are not shown for past visits.<br>You can view alerts and restrictions for past visits in the <a href="${config.dpsContacts}/prisoner/${prisonerNumber}/contacts/list">contacts service</a>.`
+
+      const results = getHideAlertsInset({ skipAlertsAndRestrictionReason: 'VISIT_IN_PAST', prisonerNumber })
+      expect(results).toStrictEqual(expected)
+      jest.useRealTimers()
+    })
+
+    it('should return released prisoner message if skipAlertsAndRestrictionReason is PRISONER_RELEASED', () => {
+      expected.prisoner.text = 'Alerts and restrictions are not shown for released prisoners.'
+      expected.visitor.text = 'Visitor restrictions are not shown for released prisoners.'
+
+      const results = getHideAlertsInset({
+        skipAlertsAndRestrictionReason: 'PRISONER_RELEASED',
+        prisonerNumber,
+      })
+      expect(results).toStrictEqual(expected)
+    })
+
+    it('should return transferred prisoner message if skipAlertsAndRestrictionReason is PRISONER_TRANSFERRED', () => {
+      expected.prisoner.text = 'Alerts and restrictions are not shown for transferred prisoners.'
+      expected.visitor.text = 'Visitor restrictions are not shown for transferred prisoners.'
 
       const results = getHideAlertsInset({
         prisonerNumber,
-        startTimestamp,
-        visitPrisonId,
-        prisonerPrisonId,
-        inOutStatus,
+        skipAlertsAndRestrictionReason: 'PRISONER_TRANSFERRED',
       })
       expect(results).toStrictEqual(expected)
       jest.useRealTimers()
     })
 
-    it('should return "RELEASED" if prisoner prisonID is "OUT"', () => {
-      const fakeDate = new Date('2026-01-01T12:00:00') // 01-01-26 12PM
-      jest.useFakeTimers({ advanceTimers: true, now: fakeDate })
-      const startTimestamp = '2026-01-02T22:00:00' // 02-01-26 12PM
-
-      const visitPrisonId = 'HEI'
-      const prisonerPrisonId = 'OUT'
-      const inOutStatus = 'IN'
-
-      const expected = {
-        prisoner: {
-          text: 'Alerts and restrictions are not shown for released prisoners.',
-          attributes: { 'data-test': 'prisoner-inset' },
-          classes: 'govuk-!-margin-bottom-1',
-        },
-        visitor: {
-          html: 'Visitor restrictions are not shown for released prisoners.',
-          attributes: { 'data-test': 'visitor-inset' },
-        },
-      }
-
+    it('should return null if skipAlertsAndRestrictionReason is null', () => {
       const results = getHideAlertsInset({
         prisonerNumber,
-        startTimestamp,
-        visitPrisonId,
-        prisonerPrisonId,
-        inOutStatus,
-      })
-      expect(results).toStrictEqual(expected)
-      jest.useRealTimers()
-    })
-
-    it('should return "TRANSFER" if visit prison ID and prisoner prison ID do not match', () => {
-      const fakeDate = new Date('2026-01-01T12:00:00') // 01-01-26 12PM
-      jest.useFakeTimers({ advanceTimers: true, now: fakeDate })
-      const startTimestamp = '2026-01-02T22:00:00' // 02-01-26 12PM
-
-      const visitPrisonId = 'HEI'
-      const prisonerPrisonId = 'EYI'
-      const inOutStatus = 'IN'
-
-      const expected = {
-        prisoner: {
-          text: 'Alerts and restrictions are not shown for transferred prisoners.',
-          attributes: { 'data-test': 'prisoner-inset' },
-          classes: 'govuk-!-margin-bottom-1',
-        },
-        visitor: {
-          html: 'Visitor restrictions are not shown for transferred prisoners.',
-          attributes: { 'data-test': 'visitor-inset' },
-        },
-      }
-
-      const results = getHideAlertsInset({
-        prisonerNumber,
-        startTimestamp,
-        visitPrisonId,
-        prisonerPrisonId,
-        inOutStatus,
-      })
-      expect(results).toStrictEqual(expected)
-      jest.useRealTimers()
-    })
-
-    it('should return null if prisons do not match but currently in "Transfer"', () => {
-      const fakeDate = new Date('2026-01-01T10:00:00') // 01-01-26 2PM
-      jest.useFakeTimers({ advanceTimers: true, now: fakeDate })
-      const startTimestamp = '2026-01-01T22:00:00' // 01-01-26 2AM
-
-      const visitPrisonId = 'HEI'
-      const prisonerPrisonId = 'EYI'
-      const inOutStatus = 'TRN'
-
-      const results = getHideAlertsInset({
-        prisonerNumber,
-        startTimestamp,
-        visitPrisonId,
-        prisonerPrisonId,
-        inOutStatus,
+        skipAlertsAndRestrictionReason: null,
       })
       expect(results).toStrictEqual(null)
-      jest.useRealTimers()
     })
   })
 })

--- a/server/routes/visit/visitUtils.ts
+++ b/server/routes/visit/visitUtils.ts
@@ -318,10 +318,8 @@ export const getHideAlertsInset = ({
       }
       break
 
-    default: {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const unhandledCase: never = skipAlertsAndRestrictionReason
-    }
+    default:
+      return null
   }
 
   return {

--- a/server/routes/visit/visitUtils.ts
+++ b/server/routes/visit/visitUtils.ts
@@ -1,5 +1,5 @@
-import { isFuture, isPast } from 'date-fns'
-import { GOVUKInsetText, MoJAlert } from '../../@types/bapv'
+import { isFuture } from 'date-fns'
+import { GOVUKInsetText, MoJAlert, TextOrHtml } from '../../@types/bapv'
 import config from '../../config'
 import { notificationTypeAlerts } from '../../constants/notifications'
 import { visitCancellationAlerts } from '../../constants/visitCancellation'
@@ -277,60 +277,62 @@ export const isPublicBooking = (events: EventAudit[]): boolean => {
 }
 
 export const getHideAlertsInset = ({
+  skipAlertsAndRestrictionReason,
   prisonerNumber,
-  startTimestamp,
-  visitPrisonId,
-  prisonerPrisonId,
-  inOutStatus,
 }: {
+  skipAlertsAndRestrictionReason: VisitBookingDetails['skipAlertsAndRestrictionReason']
   prisonerNumber: string
-  startTimestamp: VisitBookingDetails['startTimestamp']
-  visitPrisonId: string
-  prisonerPrisonId: string
-  inOutStatus: VisitBookingDetails['prisoner']['inOutStatus']
 }): { prisoner: GOVUKInsetText; visitor: GOVUKInsetText } | null => {
-  const visitStartTime = new Date(startTimestamp)
+  if (!skipAlertsAndRestrictionReason) {
+    return null
+  }
 
-  if (isPast(visitStartTime)) {
-    return {
-      prisoner: {
+  let prisonerTextOrHtml: TextOrHtml
+  let visitorTextOrHtml: TextOrHtml
+
+  switch (skipAlertsAndRestrictionReason) {
+    case 'VISIT_IN_PAST':
+      prisonerTextOrHtml = {
         html: `Alerts and restrictions are not shown for past visits.<br>You can view alerts and restrictions for past visits in the <a href="${config.dpsContacts}/prisoner/${prisonerNumber}/alerts-restrictions">contacts service</a>.`,
-        attributes: { 'data-test': 'prisoner-inset' },
-        classes: 'govuk-!-margin-bottom-1',
-      },
-      visitor: {
+      }
+      visitorTextOrHtml = {
         html: `Visitor restrictions are not shown for past visits.<br>You can view alerts and restrictions for past visits in the <a href="${config.dpsContacts}/prisoner/${prisonerNumber}/contacts/list">contacts service</a>.`,
-        attributes: { 'data-test': 'visitor-inset' },
-      },
-    }
-  }
+      }
+      break
 
-  if (prisonerPrisonId === 'OUT') {
-    return {
-      prisoner: {
+    case 'PRISONER_RELEASED':
+      prisonerTextOrHtml = {
         text: 'Alerts and restrictions are not shown for released prisoners.',
-        attributes: { 'data-test': 'prisoner-inset' },
-        classes: 'govuk-!-margin-bottom-1',
-      },
-      visitor: {
-        html: 'Visitor restrictions are not shown for released prisoners.',
-        attributes: { 'data-test': 'visitor-inset' },
-      },
+      }
+      visitorTextOrHtml = {
+        text: 'Visitor restrictions are not shown for released prisoners.',
+      }
+      break
+
+    case 'PRISONER_TRANSFERRED':
+      prisonerTextOrHtml = {
+        text: 'Alerts and restrictions are not shown for transferred prisoners.',
+      }
+      visitorTextOrHtml = {
+        text: 'Visitor restrictions are not shown for transferred prisoners.',
+      }
+      break
+
+    default: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const unhandledCase: never = skipAlertsAndRestrictionReason
     }
   }
 
-  if (prisonerPrisonId !== visitPrisonId && inOutStatus !== 'TRN') {
-    return {
-      prisoner: {
-        text: 'Alerts and restrictions are not shown for transferred prisoners.',
-        attributes: { 'data-test': 'prisoner-inset' },
-        classes: 'govuk-!-margin-bottom-1',
-      },
-      visitor: {
-        html: 'Visitor restrictions are not shown for transferred prisoners.',
-        attributes: { 'data-test': 'visitor-inset' },
-      },
-    }
+  return {
+    prisoner: {
+      ...prisonerTextOrHtml,
+      attributes: { 'data-test': 'prisoner-inset' },
+      classes: 'govuk-!-margin-bottom-1',
+    },
+    visitor: {
+      ...visitorTextOrHtml,
+      attributes: { 'data-test': 'visitor-inset' },
+    },
   }
-  return null
 }


### PR DESCRIPTION
Visit booking details page: determine whether to show message about no alerts/restrictions for prisoners and visitors based on the `skipAlertsAndRestrictionReason` flag from the API - instead of attempting to determine this in the front-end.