### PR TITLE
Fix localhost and staging environment tags

### DIFF
--- a/assets/sass/local.scss
+++ b/assets/sass/local.scss
@@ -191,16 +191,24 @@
   @include govuk-link-style-default;
 }
 
-.env--STAGING [data-qa=connect-dps-common-environment-tag] {
+.env--localhost [data-qa="cdps-header-environment-tag"],
+.env--staging [data-qa="cdps-header-environment-tag"] {
   padding-left: 0;
   visibility: hidden;
 
   &::before {
-    content: "STAGING";
+    float: left;
     visibility: visible;
     @extend .govuk-tag;
-    @extend .govuk-tag--orange;
   }
+}
+.env--localhost [data-qa="cdps-header-environment-tag"]::before {
+  content: "LOCALHOST";
+  @extend .govuk-tag--yellow;
+}
+.env--staging [data-qa="cdps-header-environment-tag"]::before {
+  content: "STAGING";
+  @extend .govuk-tag--orange;
 }
 
 // fix colour on MoJ sortable table for non-sortable headings

--- a/server/config.ts
+++ b/server/config.ts
@@ -12,14 +12,6 @@ function get<T>(name: string, fallback: T, options = { requireInProduction: fals
   throw new Error(`Missing env var ${name}`)
 }
 
-function translateEnvironment(gitHubEnvironmentName: string = ''): string {
-  if (gitHubEnvironmentName === 'staging') {
-    return gitHubEnvironmentName.toUpperCase()
-  }
-
-  return ''
-}
-
 const requiredInProduction = { requireInProduction: true }
 
 export class AgentConfig {
@@ -154,7 +146,7 @@ export default {
     printVisitPasses: get('FEATURE_PRINT_VISIT_PASSES', 'false') === 'true',
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
-  environmentName: translateEnvironment(get('ENVIRONMENT_NAME', '')),
+  environmentName: get('ENVIRONMENT_NAME', ''),
   maintenance: {
     enabled: get('MAINTENANCE_MODE', 'false') === 'true',
     endDateTime: get('MAINTENANCE_MODE_END_DATE_TIME', ''), // ISO format e.g. YYYY-MM-DDTHH:MM


### PR DESCRIPTION
* Fix CSS that adds a `STAGING` label to the header in that environment. (DPS doesn't have staging so this was achieved via CSS content; but broke as attribute names changed in DPS header.)
* Add `LOCALHOST` as an environment label (if `ENVIRONMENT_NAME=localhost` is set in `.env`).
