### PR TITLE
VB-6761 Add configurable feedback banner

### DIFF
--- a/assets/sass/application.scss
+++ b/assets/sass/application.scss
@@ -15,6 +15,7 @@ $govuk-page-width: $moj-page-width;
 @import './components/card';
 @import './components/expandable-comment';
 @import './components/block-background';
+@import './components/feedback-banner';
 @import './components/filter';
 @import './components/notification-types';
 @import './components/prisoner-profile';

--- a/assets/sass/components/_feedback-banner.scss
+++ b/assets/sass/components/_feedback-banner.scss
@@ -1,0 +1,18 @@
+// Adapted from https://design-patterns.service.justice.gov.uk/components/new-features-banner/
+
+.feedback-banner {
+  background-color: #44247b;
+}
+
+.feedback-content {
+  color: govuk-colour('white');
+  padding: govuk-spacing(2) govuk-spacing(5);
+
+  & strong {
+    margin-right: govuk-spacing(4);
+  }
+
+  & a {
+    @include govuk-link-style-inverse;
+  }
+}

--- a/helm_deploy/book-a-prison-visit-staff-ui/values.yaml
+++ b/helm_deploy/book-a-prison-visit-staff-ui/values.yaml
@@ -34,6 +34,9 @@ generic-service:
     # Optional maintenance end date (in ISO format, YYYY-MM-DDTHH:MM)
     MAINTENANCE_MODE_END_DATE_TIME: ""
 
+    FEATURE_FEEDBACK_BANNER_ENABLED: "true"
+    FEATURE_FEEDBACK_BANNER_URL: "https://forms.cloud.microsoft/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2AYNZK8DJCZBgXxIreDRN5tUQTIwNlJCU1IzSFVMU1JPMUdUVklRUTdNMS4u"
+
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
   #   [name of kubernetes secret]:

--- a/server/config.ts
+++ b/server/config.ts
@@ -135,6 +135,10 @@ export default {
     cancellationLimitDays: Number(get('CANCELLATION_LIMIT_DAYS', 28)),
   },
   features: {
+    feedbackBanner: {
+      enabled: get('FEATURE_FEEDBACK_BANNER_ENABLED', 'false') === 'true',
+      url: get('FEATURE_FEEDBACK_BANNER_URL', '#feedback'),
+    },
     notificationTypes: {
       enabledRawNotifications: <NotificationTypeRaw[]>(
         get(

--- a/server/routes/feedbackBanner.test.ts
+++ b/server/routes/feedbackBanner.test.ts
@@ -1,0 +1,40 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import * as cheerio from 'cheerio'
+import { appWithAllRoutes } from './testutils/appSetup'
+import { setFeature } from '../data/testutils/mockFeature'
+
+describe('Feedback banner', () => {
+  let app: Express
+
+  it('should render feedback banner when feature is enabled', () => {
+    setFeature('feedbackBanner', { enabled: true, url: 'feedback-url' })
+
+    app = appWithAllRoutes({})
+
+    return request(app)
+      .get('/')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+
+        expect($('[data-test=feedback-banner]').length).toBe(1)
+        expect($('.feedback-content a').attr('href')).toBe('feedback-url')
+      })
+  })
+
+  it('should not render feedback banner when feature is disabled', () => {
+    setFeature('feedbackBanner', { enabled: false, url: 'feedback-url' })
+
+    app = appWithAllRoutes({})
+
+    return request(app)
+      .get('/')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+
+        expect($('[data-test=feedback-banner]').length).toBe(0)
+      })
+  })
+})

--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -23,6 +23,10 @@
 
 {% block header %}
   {{ feComponents.header | safe }}
+
+  {% if features.feedbackBanner.enabled %}
+    {% include "partials/feedbackBanner.njk" %}
+  {% endif %}
 {% endblock %}
 
 {% block bodyStart %}

--- a/server/views/partials/feedbackBanner.njk
+++ b/server/views/partials/feedbackBanner.njk
@@ -3,8 +3,8 @@
   <div class="govuk-body feedback-content">
     <strong>Tell us what you think</strong>
     <span>
-        <a href="{{ features.feedbackBanner.url }}" target="_blank">Give feedback</a>
-        to help us improve the ‘Social visits’ service.
+        <a href="{{ features.feedbackBanner.url }}" rel="noreferrer noopener" target="_blank">Give feedback</a>
+        to help us improve the ‘{{ applicationName }}’ service.
     </span>
   </div>
 </section>

--- a/server/views/partials/feedbackBanner.njk
+++ b/server/views/partials/feedbackBanner.njk
@@ -1,0 +1,10 @@
+{# Adapted from https://design-patterns.service.justice.gov.uk/components/new-features-banner/ #}
+<section aria-label="Feedback" class="govuk-width-container feedback-banner" data-test="feedback-banner">
+  <div class="govuk-body feedback-content">
+    <strong>Tell us what you think</strong>
+    <span>
+        <a href="{{ features.feedbackBanner.url }}" target="_blank">Give feedback</a>
+        to help us improve the ‘Social visits’ service.
+    </span>
+  </div>
+</section>


### PR DESCRIPTION
Add a feedback banner in the page header. Based on the MoJ [New Features Banner component](https://design-patterns.service.justice.gov.uk/components/new-features-banner/).

Configurable via `values.yaml` in Helm config:
* `FEATURE_FEEDBACK_BANNER_ENABLED`
* `FEATURE_FEEDBACK_BANNER_URL`