### PR TITLE
VB-6270 Refactor visit details navigation

### DIFF
--- a/integration_tests/specs/prisoner/prisonerProfile.spec.ts
+++ b/integration_tests/specs/prisoner/prisonerProfile.spec.ts
@@ -96,7 +96,7 @@ test.describe('Prisoner profile page', () => {
     await expect(prisonerProfilePage.visitTabCaption(1)).toContainText('January 2022 (1 past visit)')
     await expect(prisonerProfilePage.visitTabReference(profile.visits[0].reference)).toHaveAttribute(
       'href',
-      `/visit/${profile.visits[0].reference}`,
+      `/visit/${profile.visits[0].reference}?from=prisoner`,
     )
     await expect(prisonerProfilePage.visitTabType.nth(0)).toContainText('Social')
     await expect(prisonerProfilePage.visitTabLocation.nth(0)).toContainText('Hewell (HMP)')

--- a/server/routes/prisoner/prisonerProfileController.test.ts
+++ b/server/routes/prisoner/prisonerProfileController.test.ts
@@ -250,6 +250,9 @@ describe('/prisoner/:offenderNo - Prisoner profile', () => {
           expect($('.prisoner-profile-visits:nth-child(1) [data-test="tab-visits-reference"]').eq(0).text()).toBe(
             upcomingVisit.reference,
           )
+          expect(
+            $('.prisoner-profile-visits:nth-child(1) [data-test="tab-visits-reference"] a').eq(0).attr('href'),
+          ).toBe(`/visit/${upcomingVisit.reference}?from=prisoner`)
           expect($('.prisoner-profile-visits:nth-child(1) [data-test="tab-visits-type"] > span').eq(0).html()).toBe(
             'Social<br>(Open)',
           )

--- a/server/routes/visit/cancelVisitController.test.ts
+++ b/server/routes/visit/cancelVisitController.test.ts
@@ -91,6 +91,18 @@ describe('GET /visit/:reference/cancel', () => {
       })
   })
 
+  it('should preserve navigation state in back link and form action', () => {
+    return request(app)
+      .get('/visit/ab-cd-ef-gh/cancel?from=visits&query=type%3DOPEN')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('.govuk-back-link').attr('href')).toBe('/visit/ab-cd-ef-gh?from=visits&query=type%3DOPEN')
+        expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh/cancel?from=visits&query=type%3DOPEN')
+      })
+  })
+
   it('should render the cancellation reasons page, showing validation errors and re-populating fields', () => {
     flashData.errors = <FieldValidationError[]>[
       { msg: 'No answer selected', path: 'cancel' },
@@ -229,6 +241,14 @@ describe('POST /visit/:reference/cancel', () => {
         expect(auditService.cancelledVisit).not.toHaveBeenCalled()
         expect(sessionData.cancelledVisitInfo).toBeUndefined()
       })
+  })
+
+  it('should preserve navigation state on validation redirect', () => {
+    return request(app)
+      .post('/visit/ab-cd-ef-gh/cancel?from=visits&query=type%3DOPEN')
+      .send({})
+      .expect(302)
+      .expect('location', '/visit/ab-cd-ef-gh/cancel?from=visits&query=type%3DOPEN')
   })
 
   it('should set validation errors in flash and redirect if VISITOR_CANCELLED and no method selected', () => {

--- a/server/routes/visit/cancelVisitController.ts
+++ b/server/routes/visit/cancelVisitController.ts
@@ -7,6 +7,7 @@ import { requestMethodsCancellation } from '../../constants/requestMethods'
 import { getFlashFormValues } from '../visitorUtils'
 import { visitCancellationReasons } from '../../constants/visitCancellation'
 import { isMobilePhoneNumber } from '../../utils/utils'
+import { appendNavStateToPath, extractVisitNavState } from './visitNavigationUtils'
 
 export default class CancelVisitController {
   public constructor(
@@ -29,9 +30,12 @@ export default class CancelVisitController {
   public showCancellationReasons(): RequestHandler<VisitReferenceParams> {
     return async (req, res) => {
       const { reference } = req.params
+      const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
 
       return res.render('pages/visit/cancel', {
         errors: req.flash('errors'),
+        backLinkHref: appendNavStateToPath(`/visit/${reference}`, navState),
+        formAction: appendNavStateToPath(`/visit/${reference}/cancel`, navState),
         reference,
         visitCancellationReasons,
         requestMethodsCancellation,
@@ -43,6 +47,7 @@ export default class CancelVisitController {
   public cancelVisit(): RequestHandler<VisitReferenceParams> {
     return async (req, res) => {
       const { reference } = req.params
+      const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
 
       const errors = validationResult(req)
       const { username } = res.locals.user
@@ -50,7 +55,7 @@ export default class CancelVisitController {
       if (!errors.isEmpty()) {
         req.flash('errors', errors.array() as [])
         req.flash('formValues', req.body)
-        return res.redirect(`/visit/${reference}/cancel`)
+        return res.redirect(appendNavStateToPath(`/visit/${reference}/cancel`, navState))
       }
 
       const outcomeStatus = req.body.cancel

--- a/server/routes/visit/clearNotificationsController.ts
+++ b/server/routes/visit/clearNotificationsController.ts
@@ -4,6 +4,7 @@ import { AuditService, VisitNotificationsService } from '../../services'
 import { VisitReferenceParams } from '../../@types/requestParameterTypes'
 import { IgnoreVisitNotificationsDto } from '../../data/orchestrationApiTypes'
 import { getFlashFormValues } from '../visitorUtils'
+import { extractVisitNavState, appendNavStateToPath } from './visitNavigationUtils'
 
 export default class ClearNotificationsController {
   public constructor(
@@ -14,11 +15,16 @@ export default class ClearNotificationsController {
   public view(): RequestHandler<VisitReferenceParams> {
     return async (req, res) => {
       const { reference } = req.params
+      const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
+
+      const backLinkHref = appendNavStateToPath(`/visit/${reference}`, navState)
+      const formAction = appendNavStateToPath(`/visit/${reference}/clear-notifications`, navState)
 
       return res.render('pages/visit/clearNotifications', {
         errors: req.flash('errors'),
         formValues: getFlashFormValues(req),
-        backLinkHref: `/visit/${reference}`,
+        backLinkHref,
+        formAction,
       })
     }
   }
@@ -28,11 +34,13 @@ export default class ClearNotificationsController {
       const errors = validationResult(req)
       const { reference } = req.params
       const { username } = res.locals.user
+      const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
 
       if (!errors.isEmpty()) {
         req.flash('errors', errors.array() as [])
         req.flash('formValues', req.body)
-        return res.redirect(`/visit/${reference}/clear-notifications`)
+        const redirectUrl = appendNavStateToPath(`/visit/${reference}/clear-notifications`, navState)
+        return res.redirect(redirectUrl)
       }
 
       if (req.body.clearNotifications === 'yes') {
@@ -63,7 +71,8 @@ export default class ClearNotificationsController {
         })
       }
 
-      return res.redirect(`/visit/${reference}`)
+      const redirectUrl = appendNavStateToPath(`/visit/${reference}`, navState)
+      return res.redirect(redirectUrl)
     }
   }
 

--- a/server/routes/visit/confirmUpdateController.test.ts
+++ b/server/routes/visit/confirmUpdateController.test.ts
@@ -42,6 +42,18 @@ describe('GET /visit/:reference/confirm-update', () => {
         expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh/confirm-update')
       })
   })
+
+  it('should preserve navigation state in back link and form action', () => {
+    return request(app)
+      .get('/visit/ab-cd-ef-gh/confirm-update?from=visits&query=type%3DOPEN')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('.govuk-back-link').attr('href')).toBe('/visit/ab-cd-ef-gh?from=visits&query=type%3DOPEN')
+        expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh/confirm-update?from=visits&query=type%3DOPEN')
+      })
+  })
 })
 
 describe('POST /visit/:reference/confirm-update', () => {
@@ -68,6 +80,14 @@ describe('POST /visit/:reference/confirm-update', () => {
       })
   })
 
+  it('should preserve navigation state when redirecting back to visit details', () => {
+    return request(app)
+      .post('/visit/ab-cd-ef-gh/confirm-update?from=visits&query=type%3DOPEN')
+      .send('confirmUpdate=no')
+      .expect(302)
+      .expect('location', '/visit/ab-cd-ef-gh?from=visits&query=type%3DOPEN')
+  })
+
   it('should redirect to select visitors page if choosing to proceed with update', () => {
     return request(app)
       .post('/visit/ab-cd-ef-gh/confirm-update')
@@ -91,5 +111,13 @@ describe('POST /visit/:reference/confirm-update', () => {
           { location: 'body', msg: 'No option selected', path: 'confirmUpdate', type: 'field' },
         ])
       })
+  })
+
+  it('should preserve navigation state when redirecting to self with validation errors', () => {
+    return request(app)
+      .post('/visit/ab-cd-ef-gh/confirm-update?from=visits&query=type%3DOPEN')
+      .send('confirmUpdate=')
+      .expect(302)
+      .expect('location', '/visit/ab-cd-ef-gh/confirm-update?from=visits&query=type%3DOPEN')
   })
 })

--- a/server/routes/visit/confirmUpdateController.ts
+++ b/server/routes/visit/confirmUpdateController.ts
@@ -2,6 +2,7 @@ import { RequestHandler, Request } from 'express'
 import { BadRequest } from 'http-errors'
 import { isValidVisitReference } from '../validationChecks'
 import { VisitReferenceParams } from '../../@types/requestParameterTypes'
+import { appendNavStateToPath, extractVisitNavState } from './visitNavigationUtils'
 
 export default class ConfirmUpdateController {
   public constructor() {}
@@ -10,10 +11,12 @@ export default class ConfirmUpdateController {
     return async (req, res) => {
       const reference = getVisitReference(req)
       const { policyNoticeDaysMin } = req.session.selectedEstablishment
+      const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
 
       return res.render('pages/visit/confirmUpdate', {
         errors: req.flash('errors'),
-        backLinkHref: `/visit/${reference}`,
+        backLinkHref: appendNavStateToPath(`/visit/${reference}`, navState),
+        formAction: appendNavStateToPath(`/visit/${reference}/confirm-update`, navState),
         policyNoticeDaysMin,
         reference,
       })
@@ -24,13 +27,14 @@ export default class ConfirmUpdateController {
     return async (req, res) => {
       const reference = getVisitReference(req)
       const { confirmUpdate } = req.body
+      const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
 
       if (confirmUpdate === 'yes') {
         req.session.visitSessionData.overrideBookingWindow = true
         return res.redirect('/update-a-visit/select-visitors')
       }
       if (confirmUpdate === 'no') {
-        return res.redirect(`/visit/${reference}`)
+        return res.redirect(appendNavStateToPath(`/visit/${reference}`, navState))
       }
 
       req.flash('errors', [
@@ -42,7 +46,7 @@ export default class ConfirmUpdateController {
         },
       ] as unknown as [])
 
-      return res.redirect(`/visit/${reference}/confirm-update`)
+      return res.redirect(appendNavStateToPath(`/visit/${reference}/confirm-update`, navState))
     }
   }
 }

--- a/server/routes/visit/processVisitRequestController.test.ts
+++ b/server/routes/visit/processVisitRequestController.test.ts
@@ -52,8 +52,7 @@ describe('Process a visit request (approve / reject)', () => {
 
     it('should approve visit request, set success message and redirect to visits page when coming from visits page', () => {
       return request(app)
-        .post('/visit/ab-cd-ef-gh/request/approve')
-        .send({ redirectTo: 'visits' })
+        .post('/visit/ab-cd-ef-gh/request/approve?from=visits')
         .expect(302)
         .expect('location', '/visits')
         .expect(() => {
@@ -70,10 +69,28 @@ describe('Process a visit request (approve / reject)', () => {
         })
     })
 
+    it('should approve visit request, set success message and redirect to visits page with query preserved when coming from visits page', () => {
+      return request(app)
+        .post('/visit/ab-cd-ef-gh/request/approve?from=visits&query=type%3DOPEN%26selectedDate%3D2024-02-01')
+        .expect(302)
+        .expect('location', '/visits?type=OPEN&selectedDate=2024-02-01')
+        .expect(() => {
+          expect(flashProvider).toHaveBeenCalledWith('messages', {
+            variant: 'success',
+            title: 'You approved the request and booked the visit with John Smith',
+            showTitleAsHeading: true,
+            html: 'The main contact has been notified. You can <a href="/visit/ab-cd-ef-gh">view this visit again</a>.',
+          })
+
+          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
+          expect(visitRequestsService.rejectVisitRequest).not.toHaveBeenCalled()
+          expect(visitService.getVisitDetailed).not.toHaveBeenCalled()
+        })
+    })
+
     it('should approve visit request, set success message and redirect to profile page when coming from profile page', () => {
       return request(app)
-        .post('/visit/ab-cd-ef-gh/request/approve')
-        .send({ redirectTo: 'profile', prisonerId: 'A1234BC' })
+        .post('/visit/ab-cd-ef-gh/request/approve?from=prisoner&prisonerId=A1234BC')
         .expect(302)
         .expect('location', '/prisoner/A1234BC')
         .expect(() => {
@@ -120,10 +137,34 @@ describe('Process a visit request (approve / reject)', () => {
       visitRequestsService.approveVisitRequest.mockRejectedValue(new BadRequest())
 
       return request(app)
-        .post('/visit/ab-cd-ef-gh/request/approve')
-        .send({ redirectTo: 'visits' })
+        .post('/visit/ab-cd-ef-gh/request/approve?from=visits')
         .expect(302)
         .expect('location', '/visits')
+        .expect(() => {
+          expect(flashProvider).toHaveBeenCalledWith('messages', {
+            variant: 'information',
+            title: 'The visit to John Smith has already been approved',
+            showTitleAsHeading: true,
+            html: 'The main contact has been notified. You can <a href="/visit/ab-cd-ef-gh">view this visit again</a>.',
+          })
+
+          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
+          expect(visitRequestsService.rejectVisitRequest).not.toHaveBeenCalled()
+          expect(visitService.getVisitDetailed).toHaveBeenCalledWith({
+            username: 'user1',
+            reference: visitDetails.reference,
+          })
+        })
+    })
+
+    it('should handle 400 Bad Request from API, set failure message and redirect to visits page with query preserved when coming from visits page', () => {
+      visitDetails.visitSubStatus = 'APPROVED'
+      visitRequestsService.approveVisitRequest.mockRejectedValue(new BadRequest())
+
+      return request(app)
+        .post('/visit/ab-cd-ef-gh/request/approve?from=visits&query=type%3DOPEN%26selectedDate%3D2024-02-01')
+        .expect(302)
+        .expect('location', '/visits?type=OPEN&selectedDate=2024-02-01')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledWith('messages', {
             variant: 'information',
@@ -146,8 +187,7 @@ describe('Process a visit request (approve / reject)', () => {
       visitRequestsService.approveVisitRequest.mockRejectedValue(new BadRequest())
 
       return request(app)
-        .post('/visit/ab-cd-ef-gh/request/approve')
-        .send({ redirectTo: 'profile', prisonerId: 'A1234BC' })
+        .post('/visit/ab-cd-ef-gh/request/approve?from=prisoner&prisonerId=A1234BC')
         .expect(302)
         .expect('location', '/prisoner/A1234BC')
         .expect(() => {

--- a/server/routes/visit/processVisitRequestController.ts
+++ b/server/routes/visit/processVisitRequestController.ts
@@ -5,7 +5,7 @@ import { VisitReferenceParams } from '../../@types/requestParameterTypes'
 import { convertToTitleCase } from '../../utils/utils'
 import { VisitBookingDetails, VisitRequestResponse } from '../../data/orchestrationApiTypes'
 import { isValidPrisonerNumber } from '../validationChecks'
-import { extractVisitNavState, VisitNavState } from './visitNavigationUtils'
+import { extractVisitNavState, type VisitNavState } from './visitNavigationUtils'
 
 type RequestAction = 'approve' | 'reject'
 

--- a/server/routes/visit/processVisitRequestController.ts
+++ b/server/routes/visit/processVisitRequestController.ts
@@ -5,6 +5,7 @@ import { VisitReferenceParams } from '../../@types/requestParameterTypes'
 import { convertToTitleCase } from '../../utils/utils'
 import { VisitBookingDetails, VisitRequestResponse } from '../../data/orchestrationApiTypes'
 import { isValidPrisonerNumber } from '../validationChecks'
+import { extractVisitNavState, VisitNavState } from './visitNavigationUtils'
 
 type RequestAction = 'approve' | 'reject'
 
@@ -18,17 +19,8 @@ export default class ProcessVisitRequestController {
     return async (req, res, next) => {
       const { reference } = req.params
       const { username } = res.locals.user
-      let redirectPath = '/requested-visits'
-
-      if (req.body?.redirectTo === 'visits') {
-        redirectPath = '/visits'
-      } else if (req.body?.redirectTo === 'profile') {
-        const prisonerId = req.body?.prisonerId
-
-        if (isValidPrisonerNumber(prisonerId)) {
-          redirectPath = `/prisoner/${prisonerId}`
-        }
-      }
+      const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
+      const redirectPath = this.getRedirectPath(navState, req.query?.prisonerId)
 
       try {
         const visitRequestResponse =
@@ -51,6 +43,21 @@ export default class ProcessVisitRequestController {
         return next(error)
       }
     }
+  }
+
+  private getRedirectPath(navState: VisitNavState, prisonerIdParam: unknown): string {
+    if (navState.fromPage === 'visits') {
+      return navState.fromPageQuery ? `/visits?${navState.fromPageQuery}` : '/visits'
+    }
+
+    if (navState.fromPage === 'prisoner') {
+      const prisonerId = typeof prisonerIdParam === 'string' ? prisonerIdParam : undefined
+      if (prisonerId && isValidPrisonerNumber(prisonerId)) {
+        return `/prisoner/${prisonerId}`
+      }
+    }
+
+    return '/requested-visits'
   }
 
   private getSuccessMessage(action: RequestAction, visitRequestResponse: VisitRequestResponse): MoJAlert {

--- a/server/routes/visit/updateVisitController.test.ts
+++ b/server/routes/visit/updateVisitController.test.ts
@@ -165,6 +165,15 @@ describe('Start a visit update journey', () => {
         .expect('location', '/visit/ab-cd-ef-gh/confirm-update')
     })
 
+    it('should preserve navigation state when redirecting to confirm-update', () => {
+      visitDetails.startTimestamp = '2022-01-03T10:00:00'
+
+      return request(app)
+        .post('/visit/ab-cd-ef-gh/update?from=visits&query=type%3DOPEN')
+        .expect(302)
+        .expect('location', '/visit/ab-cd-ef-gh/confirm-update?from=visits&query=type%3DOPEN')
+    })
+
     it('should render 400 Bad Request error for invalid visit reference', () => {
       return request(app)
         .post('/visit/12-34-56-78/update')

--- a/server/routes/visit/updateVisitController.ts
+++ b/server/routes/visit/updateVisitController.ts
@@ -6,6 +6,7 @@ import { clearSession } from '../visitorUtils'
 import { VisitSessionData } from '../../@types/bapv'
 import { convertToTitleCase } from '../../utils/utils'
 import { getIdsToFlag, getPrisonerLocation, isPublicBooking } from './visitUtils'
+import { appendNavStateToPath, extractVisitNavState } from './visitNavigationUtils'
 
 export default class UpdateVisitController {
   public constructor(private readonly visitService: VisitService) {}
@@ -14,6 +15,7 @@ export default class UpdateVisitController {
     return async (req, res) => {
       const { reference } = req.params
       const { username } = res.locals.user
+      const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
 
       const visitDetails = await this.visitService.getVisitDetailed({ username, reference })
       const { prison, prisoner } = visitDetails
@@ -21,7 +23,7 @@ export default class UpdateVisitController {
       const prisonerInVisitPrison = prison.prisonId === prisoner.prisonId
       const visitInSelectedEstablishment = prison.prisonId === req.session.selectedEstablishment.prisonId
       if (!prisonerInVisitPrison || !visitInSelectedEstablishment) {
-        return res.redirect(`/visit/${visitDetails.reference}`)
+        return res.redirect(appendNavStateToPath(`/visit/${visitDetails.reference}`, navState))
       }
 
       // clean session then pre-populate with visit to update
@@ -100,7 +102,7 @@ export default class UpdateVisitController {
       if (numberOfDays > policyNoticeDaysMin) {
         return res.redirect('/update-a-visit/select-visitors')
       }
-      return res.redirect(`/visit/${reference}/confirm-update`)
+      return res.redirect(appendNavStateToPath(`/visit/${reference}/confirm-update`, navState))
     }
   }
 }

--- a/server/routes/visit/visitDetailsController.test.ts
+++ b/server/routes/visit/visitDetailsController.test.ts
@@ -185,7 +185,7 @@ describe('Visit details page', () => {
         })
     })
 
-    it('should render hidden redirect-to field for a visit request when coming from visits page', () => {
+    it('should render process request action URLs with navigation state when coming from visits page', () => {
       availableVisitActions = {
         update: false,
         cancel: false,
@@ -201,11 +201,16 @@ describe('Visit details page', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('[data-test="redirect-to"]').val()).toBe('visits')
+          expect($('[data-test="approve-visit-request"]').parent('form').attr('action')).toBe(
+            '/visit/ab-cd-ef-gh/request/approve?from=visits',
+          )
+          expect($('[data-test="reject-visit-request"]').parent('form').attr('action')).toBe(
+            '/visit/ab-cd-ef-gh/request/reject?from=visits',
+          )
         })
     })
 
-    it('should render hidden redirect-to field and prisonerId for a visit request when coming from prisoner profile page', () => {
+    it('should render process request action URLs with prisonerId when coming from prisoner profile page', () => {
       setFeature('printVisitPasses', true)
       availableVisitActions = {
         update: false,
@@ -222,8 +227,12 @@ describe('Visit details page', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('[data-test="redirect-to"]').val()).toBe('profile')
-          expect($('[data-test="prisoner-id"]').val()).toBe('A1234BC')
+          expect($('[data-test="approve-visit-request"]').parent('form').attr('action')).toBe(
+            '/visit/ab-cd-ef-gh/request/approve?from=prisoner&prisonerId=A1234BC',
+          )
+          expect($('[data-test="reject-visit-request"]').parent('form').attr('action')).toBe(
+            '/visit/ab-cd-ef-gh/request/reject?from=prisoner&prisonerId=A1234BC',
+          )
         })
     })
 
@@ -406,6 +415,30 @@ describe('Visit details page', () => {
 
             expect($('[data-test=print-visit-pass]').text().trim()).toBe('Print visit pass')
             expect($('[data-test=print-visit-pass]').attr('href')).toBe('/visit/ab-cd-ef-gh/visit-pass?from=visit')
+          })
+      })
+
+      it('should preserve navigation state in update and cancel actions', () => {
+        availableVisitActions = {
+          update: true,
+          cancel: true,
+          clearNotifications: true,
+          print: true,
+          processRequest: false,
+        }
+
+        return request(app)
+          .get('/visit/ab-cd-ef-gh?from=visits&query=type%3DOPEN')
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            const $ = cheerio.load(res.text)
+            expect($('[data-test=visit-actions] form').attr('action')).toBe(
+              '/visit/ab-cd-ef-gh/update?from=visits&query=type%3DOPEN',
+            )
+            expect($('[data-test=cancel-visit]').attr('href')).toBe(
+              '/visit/ab-cd-ef-gh/cancel?from=visits&query=type%3DOPEN',
+            )
           })
       })
 

--- a/server/routes/visit/visitDetailsController.ts
+++ b/server/routes/visit/visitDetailsController.ts
@@ -9,6 +9,12 @@ import {
   getVisitAlerts,
   getHideAlertsInset,
 } from './visitUtils'
+import {
+  appendNavStateToPath,
+  extractVisitNavState,
+  getVisitDetailsBackLink,
+  type VisitNavState,
+} from './visitNavigationUtils'
 import visitEventsTimelineBuilder from './visitEventsTimelineBuilder'
 import { VisitBookingDetails } from '../../data/orchestrationApiTypes'
 
@@ -79,19 +85,34 @@ export default class VisitDetailsController {
         visitNotes: visitDetails.visitNotes,
       })
 
-      const fromPage = typeof req.query?.from === 'string' ? req.query.from : null
-      const fromPageQuery = typeof req.query?.query === 'string' ? req.query.query : null
+      const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
+      const { backLinkHref } = getVisitDetailsBackLink({
+        navState,
+        prisonerNumber: prisoner.prisonerNumber,
+      })
+      const cancelHref = appendNavStateToPath(`/visit/${reference}/cancel`, navState)
+      const clearNotificationsHref = appendNavStateToPath(`/visit/${reference}/clear-notifications`, navState)
+      const startUpdateAction = appendNavStateToPath(`/visit/${reference}/update`, navState)
+      const { processRequestApproveAction, processRequestRejectAction } = this.getProcessRequestActions(
+        reference,
+        navState,
+        navState.fromPage === 'prisoner' ? prisoner.prisonerNumber : undefined,
+      )
 
       const prisonerDpsAlertsUrl = getDpsPrisonerAlertsUrl(visitDetails.prisoner.prisonerNumber)
       const prisonerLocation = getPrisonerLocation(prisoner)
 
       return res.render('pages/visit/visitDetails', {
         pageHeaderTitle: this.getPageHeaderTitle(visitDetails.visitSubStatus),
+        backLinkHref,
         hideAlertsInset,
         availableVisitActions,
         eventsTimeline,
-        fromPage,
-        fromPageQuery,
+        cancelHref,
+        clearNotificationsHref,
+        startUpdateAction,
+        processRequestApproveAction,
+        processRequestRejectAction,
         messages,
         prisonerDpsAlertsUrl,
         prisonerLocation,
@@ -113,5 +134,30 @@ export default class VisitDetailsController {
       'WITHDRAWN',
     ]
     return requestTitleSubStatuses.includes(visitSubStatus) ? 'Visit request details' : 'Visit booking details'
+  }
+
+  private getProcessRequestActions(
+    reference: string,
+    navState: VisitNavState,
+    prisonerNumber?: string,
+  ): {
+    processRequestApproveAction: string
+    processRequestRejectAction: string
+  } {
+    const approveAction = appendNavStateToPath(`/visit/${reference}/request/approve`, navState)
+    const rejectAction = appendNavStateToPath(`/visit/${reference}/request/reject`, navState)
+
+    if (prisonerNumber) {
+      const separator = (url: string) => (url.includes('?') ? '&' : '?')
+      return {
+        processRequestApproveAction: `${approveAction}${separator(approveAction)}prisonerId=${prisonerNumber}`,
+        processRequestRejectAction: `${rejectAction}${separator(rejectAction)}prisonerId=${prisonerNumber}`,
+      }
+    }
+
+    return {
+      processRequestApproveAction: approveAction,
+      processRequestRejectAction: rejectAction,
+    }
   }
 }

--- a/server/routes/visit/visitNavigationUtils.test.ts
+++ b/server/routes/visit/visitNavigationUtils.test.ts
@@ -3,7 +3,7 @@ import {
   buildVisitNavQuery,
   extractVisitNavState,
   getVisitDetailsBackLink,
-  VisitNavState,
+  type VisitNavState,
 } from './visitNavigationUtils'
 
 describe('visitNavigationUtils', () => {

--- a/server/routes/visit/visitNavigationUtils.test.ts
+++ b/server/routes/visit/visitNavigationUtils.test.ts
@@ -1,0 +1,186 @@
+import {
+  appendNavStateToPath,
+  buildVisitNavQuery,
+  extractVisitNavState,
+  getVisitDetailsBackLink,
+  VisitNavState,
+} from './visitNavigationUtils'
+
+describe('visitNavigationUtils', () => {
+  describe('extractVisitNavState', () => {
+    it('should return fromPage and query when both are valid strings', () => {
+      expect(extractVisitNavState({ from: 'visits', query: 'type=OPEN' })).toStrictEqual({
+        fromPage: 'visits',
+        fromPageQuery: 'type=OPEN',
+      })
+    })
+
+    it('should retain only allowed query keys for visits', () => {
+      expect(
+        extractVisitNavState({
+          from: 'visits',
+          query: 'type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01&extra=drop-me',
+        }),
+      ).toStrictEqual({
+        fromPage: 'visits',
+        fromPageQuery: 'type=OPEN&sessionReference=-afe.dcc.0f&selectedDate=2024-02-01&firstTabDate=2024-02-01',
+      })
+    })
+
+    it('should retain only allowed query keys for visit search', () => {
+      expect(
+        extractVisitNavState({
+          from: 'visit-search',
+          query: 'searchBlock1=ab&searchBlock2=cd&searchBlock3=ef&searchBlock4=gh&unexpected=value',
+        }),
+      ).toStrictEqual({
+        fromPage: 'visit-search',
+        fromPageQuery: 'searchBlock1=ab&searchBlock2=cd&searchBlock3=ef&searchBlock4=gh',
+      })
+    })
+
+    it('should drop disallowed query keys for pages that do not use them', () => {
+      expect(extractVisitNavState({ from: 'request', query: 'type=OPEN&extra=drop-me' })).toStrictEqual({
+        fromPage: 'request',
+        fromPageQuery: undefined,
+      })
+    })
+
+    it('should return fromPage without query when query is missing', () => {
+      expect(extractVisitNavState({ from: 'request' })).toStrictEqual({
+        fromPage: 'request',
+        fromPageQuery: undefined,
+      })
+    })
+
+    it('should return fromPage without query when query exceeds the max length', () => {
+      const longQuery = 'x'.repeat(201)
+
+      expect(extractVisitNavState({ from: 'visits', query: longQuery })).toStrictEqual({
+        fromPage: 'visits',
+        fromPageQuery: undefined,
+      })
+    })
+
+    it('should retain query when it is exactly at the max length', () => {
+      const maxLengthQuery = `type=${'x'.repeat(195)}`
+
+      expect(maxLengthQuery.length).toBe(200)
+
+      expect(extractVisitNavState({ from: 'visits', query: maxLengthQuery })).toStrictEqual({
+        fromPage: 'visits',
+        fromPageQuery: maxLengthQuery,
+      })
+    })
+
+    it('should return empty navigation state when from value is not allowed', () => {
+      expect(extractVisitNavState({ from: 'something-else', query: 'a=1' })).toStrictEqual({})
+    })
+
+    it('should return empty navigation state when from is not a string', () => {
+      expect(extractVisitNavState({ from: 123, query: 'a=1' })).toStrictEqual({})
+    })
+  })
+
+  describe('buildVisitNavQuery', () => {
+    it('should return empty string when fromPage is missing', () => {
+      expect(buildVisitNavQuery({})).toBe('')
+    })
+
+    it('should build query with only from', () => {
+      expect(buildVisitNavQuery({ fromPage: 'visits' })).toBe('?from=visits')
+    })
+
+    it('should build query with encoded from and query values', () => {
+      expect(buildVisitNavQuery({ fromPage: 'visit-search', fromPageQuery: 'a=1&b=two words' })).toBe(
+        '?from=visit-search&query=a%3D1%26b%3Dtwo+words',
+      )
+    })
+  })
+
+  describe('appendNavStateToPath', () => {
+    it('should return original path when no navigation state exists', () => {
+      expect(appendNavStateToPath('/visit/ab-cd-ef-gh', {})).toBe('/visit/ab-cd-ef-gh')
+    })
+
+    it('should append query string when navigation state exists', () => {
+      expect(appendNavStateToPath('/visit/ab-cd-ef-gh', { fromPage: 'visits', fromPageQuery: 'type=OPEN' })).toBe(
+        '/visit/ab-cd-ef-gh?from=visits&query=type%3DOPEN',
+      )
+    })
+  })
+
+  describe('getVisitDetailsBackLink', () => {
+    const prisonerNumber = 'A1234BC'
+
+    it.each<{
+      navState: VisitNavState
+      expected: ReturnType<typeof getVisitDetailsBackLink>
+    }>([
+      {
+        navState: { fromPage: 'visit-search', fromPageQuery: 'a=1' },
+        expected: {
+          backLinkHref: '/search/visit/results?a=1',
+        },
+      },
+      {
+        navState: { fromPage: 'visits', fromPageQuery: 'type=OPEN' },
+        expected: {
+          backLinkHref: '/visits?type=OPEN',
+        },
+      },
+      {
+        navState: { fromPage: 'request' },
+        expected: {
+          backLinkHref: '/requested-visits',
+        },
+      },
+      {
+        navState: { fromPage: 'review' },
+        expected: {
+          backLinkHref: '/review',
+        },
+      },
+      {
+        navState: { fromPage: 'vo-history' },
+        expected: {
+          backLinkHref: `/prisoner/${prisonerNumber}/visiting-orders-history`,
+        },
+      },
+      {
+        navState: { fromPage: 'prisoner' },
+        expected: {
+          backLinkHref: `/prisoner/${prisonerNumber}`,
+        },
+      },
+      {
+        navState: {},
+        expected: {
+          backLinkHref: `/prisoner/${prisonerNumber}`,
+        },
+      },
+    ])('should resolve backlink for $navState.fromPage', ({ navState, expected }) => {
+      expect(getVisitDetailsBackLink({ navState, prisonerNumber })).toStrictEqual(expected)
+    })
+
+    it('should handle missing optional query for visit-search and visits', () => {
+      expect(
+        getVisitDetailsBackLink({
+          navState: { fromPage: 'visit-search' },
+          prisonerNumber,
+        }),
+      ).toStrictEqual({
+        backLinkHref: '/search/visit/results',
+      })
+
+      expect(
+        getVisitDetailsBackLink({
+          navState: { fromPage: 'visits' },
+          prisonerNumber,
+        }),
+      ).toStrictEqual({
+        backLinkHref: '/visits',
+      })
+    })
+  })
+})

--- a/server/routes/visit/visitNavigationUtils.ts
+++ b/server/routes/visit/visitNavigationUtils.ts
@@ -1,0 +1,109 @@
+const ALLOWED_FROM_PAGES = ['visit-search', 'visits', 'request', 'review', 'vo-history', 'prisoner'] as const
+const MAX_VISIT_NAV_QUERY_LENGTH = 200
+
+const VISIT_SEARCH_QUERY_KEYS = ['searchBlock1', 'searchBlock2', 'searchBlock3', 'searchBlock4'] as const
+const VISITS_QUERY_KEYS = ['type', 'sessionReference', 'selectedDate', 'firstTabDate'] as const
+
+const ALLOWED_FROM_PAGE_QUERY_KEYS: Partial<Record<VisitFromPage, readonly string[]>> = {
+  'visit-search': VISIT_SEARCH_QUERY_KEYS,
+  visits: VISITS_QUERY_KEYS,
+}
+
+export type VisitFromPage = (typeof ALLOWED_FROM_PAGES)[number]
+
+export type VisitNavState = {
+  fromPage?: VisitFromPage
+  fromPageQuery?: string
+}
+
+const isAllowedVisitFromPage = (value: string): value is VisitFromPage =>
+  (ALLOWED_FROM_PAGES as readonly string[]).includes(value)
+
+const buildAllowedVisitNavQuery = (fromPage: VisitFromPage, query: string): string | undefined => {
+  const allowedKeys = ALLOWED_FROM_PAGE_QUERY_KEYS[fromPage]
+  if (!allowedKeys) return undefined
+
+  const params = new URLSearchParams(query)
+  const filteredParams = new URLSearchParams()
+
+  for (const key of allowedKeys) {
+    const value = params.get(key)
+    if (value !== null && value !== '') {
+      filteredParams.set(key, value)
+    }
+  }
+
+  const queryString = filteredParams.toString()
+  return queryString || undefined
+}
+
+export function extractVisitNavState({ from, query }: { from?: unknown; query?: unknown }): VisitNavState {
+  const fromPage = typeof from === 'string' && isAllowedVisitFromPage(from) ? from : undefined
+  const queryString = typeof query === 'string' ? query : undefined
+
+  // Limit query string to prevent abuse, then keep only the keys relevant to the source page
+  const fromPageQuery =
+    queryString && queryString.length <= MAX_VISIT_NAV_QUERY_LENGTH && fromPage
+      ? buildAllowedVisitNavQuery(fromPage, queryString)
+      : undefined
+
+  if (!fromPage) return {}
+  return { fromPage, fromPageQuery }
+}
+
+export function buildVisitNavQuery(navState: VisitNavState): string {
+  if (!navState.fromPage) return ''
+  const params = new URLSearchParams({ from: navState.fromPage })
+  if (navState.fromPageQuery) params.set('query', navState.fromPageQuery)
+  return `?${params.toString()}`
+}
+
+export function appendNavStateToPath(path: string, navState: VisitNavState): string {
+  const qs = buildVisitNavQuery(navState)
+  return qs ? path + qs : path
+}
+
+export const getVisitDetailsBackLink = ({
+  navState,
+  prisonerNumber,
+}: {
+  navState: VisitNavState
+  prisonerNumber: string
+}): {
+  backLinkHref: string
+} => {
+  const { fromPage, fromPageQuery } = navState
+
+  switch (fromPage) {
+    case 'visit-search':
+      return {
+        backLinkHref: fromPageQuery ? `/search/visit/results?${fromPageQuery}` : '/search/visit/results',
+      }
+
+    case 'visits':
+      return {
+        backLinkHref: fromPageQuery ? `/visits?${fromPageQuery}` : '/visits',
+      }
+
+    case 'request':
+      return {
+        backLinkHref: '/requested-visits',
+      }
+
+    case 'review':
+      return {
+        backLinkHref: '/review',
+      }
+
+    case 'vo-history':
+      return {
+        backLinkHref: `/prisoner/${prisonerNumber}/visiting-orders-history`,
+      }
+
+    case 'prisoner':
+    default:
+      return {
+        backLinkHref: `/prisoner/${prisonerNumber}`,
+      }
+  }
+}

--- a/server/routes/visitJourney/selectVisitors.ts
+++ b/server/routes/visitJourney/selectVisitors.ts
@@ -39,7 +39,7 @@ export default class SelectVisitors {
       formValues.visitors = visitSessionData.visitorIds.map(id => id.toString())
     }
 
-    const returnAddress = isUpdate ? `/visit/${visitSessionData.visitReference}` : `/prisoner/${offenderNo}`
+    const backLinkHref = isUpdate ? `/visit/${visitSessionData.visitReference}` : `/prisoner/${offenderNo}`
 
     res.render('pages/bookAVisit/visitors', {
       errors: req.flash('errors'),
@@ -54,7 +54,7 @@ export default class SelectVisitors {
       formValues,
       prisonerDpsAlertsUrl: getDpsPrisonerAlertsUrl(offenderNo),
       urlPrefix: getUrlPrefix(isUpdate),
-      backLink: returnAddress,
+      backLinkHref,
     })
   }
 

--- a/server/views/pages/bookAVisit/visitors.njk
+++ b/server/views/pages/bookAVisit/visitors.njk
@@ -7,8 +7,6 @@
 
 {% set pageHeaderTitle = "Select visitors" %}
 
-{% set backLinkHref = backLink %}
-
 {% set visitors = [] %}
 {% set noVisitorsText = '' %}
 
@@ -136,11 +134,11 @@ You can also <a class="govuk-link--no-visited-state" href="{{ prisonerDpsAlertsU
             {# if no restrictions, show this under the restriction header #}
             <p data-test="restriction-description">There are no restrictions to review.</p>
           {% endif %}
-          
+
           <h2 class="govuk-heading-m">Alerts</h2>
 
           {% if alerts | length %}
-            
+
             <p data-test="alert-description">This table shows alerts that are relevant for social visits. {{ alertDpsContent | safe }}</p>
 
             {{ govukTable({
@@ -180,7 +178,7 @@ You can also <a class="govuk-link--no-visited-state" href="{{ prisonerDpsAlertsU
             <span class="govuk-visually-hidden">Error:</span> {{ errors[0].msg }}
           </p>
         {% endif %}
-    
+
         {% if atLeastOneAdult === false %}
           <p data-test="no-suitable-visitors">There are no approved visitors 18 years old or older for this prisoner. A booking cannot be made at this time.</p>
         {% elif atLeastOneAdult === true and eligibleVisitors === false %}
@@ -203,7 +201,7 @@ You can also <a class="govuk-link--no-visited-state" href="{{ prisonerDpsAlertsU
           </ul>
           <p>At least one visitor must be 18 years or older.</p>
         {% endif %}
-      
+
         <form action="{{ urlPrefix }}/select-visitors" method="POST" novalidate>
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -146,12 +146,12 @@
             {% endfor %}
 
             {% set visitStatus = combinedVisitStatus(visit.visitSubStatus, visit.visitStatus) %}
-            
+
             {% set visitRowsClass = 'bapv-secondary-text' if (visitStatus == 'Rejected') or (visitStatus == 'Cancelled') else '' %}
 
             {% set visitRows = (visitRows.push([
               {
-                html: '<a class="govuk-link--no-visited-state" href="/visit/' + visit.reference + '">' +  visit.reference + '</a>',
+                html: '<a class="govuk-link--no-visited-state" href="/visit/' + visit.reference + '?from=prisoner">' +  visit.reference + '</a>',
                 attributes: { "data-test": "tab-visits-reference" }
               },
               {

--- a/server/views/pages/visit/cancel.njk
+++ b/server/views/pages/visit/cancel.njk
@@ -5,15 +5,13 @@
 
 {% set pageHeaderTitle = "Why is this booking being cancelled?" %}
 
-{% set backLinkHref = "/visit/" + reference %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
       {% include "partials/errorSummary.njk" %}
 
-      <form action="/visit/{{ reference }}/cancel" method="POST" novalidate>
+      <form action="{{ formAction }}" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {% set requestMethods = [] %}
@@ -92,7 +90,7 @@
             "data-test": "cancel-booking"
           },
           preventDoubleClick: true
-        }) }} 
+        }) }}
       </form>
     </div>
   </div>

--- a/server/views/pages/visit/clearNotifications.njk
+++ b/server/views/pages/visit/clearNotifications.njk
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {% include "partials/errorSummary.njk" %}
-      <form action="{{ backLinkHref }}/clear-notifications" method="POST" novalidate>
+      <form action="{{ formAction }}" method="POST" novalidate>
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
           {% set clearReasonHtml %}
@@ -63,12 +63,12 @@
             ],
             errorMessage: errors | findError('clearNotifications')
           }) }}
-          
+
           {{ govukButton({
             text: "Continue",
             attributes: { "data-test": "submit" },
             preventDoubleClick: true
-          }) }} 
+          }) }}
       </form>
     </div>
   </div>

--- a/server/views/pages/visit/confirmUpdate.njk
+++ b/server/views/pages/visit/confirmUpdate.njk
@@ -21,7 +21,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <form action="/visit/{{ reference }}/confirm-update" method="POST" novalidate>
+      <form action="{{ formAction }}" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {{ govukRadios({

--- a/server/views/pages/visit/visitDetails.njk
+++ b/server/views/pages/visit/visitDetails.njk
@@ -6,23 +6,6 @@
 {% from "components/visitors.njk" import visitorDateOfBirth %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
-{% set fromPrisonerProfile = false %}
-
-{% if fromPage == "visit-search" %}
-  {% set backLinkHref = "/search/visit/results?" + fromPageQuery %}
-{% elseif fromPage == "visits" %}
-  {% set backLinkHref = "/visits?" + fromPageQuery %}
-{% elseif fromPage == "request" %}
-  {% set backLinkHref = "/requested-visits" %}
-{% elseif fromPage == "review" %}
-  {% set backLinkHref = "/review" %}
-{% elseif fromPage == "vo-history" %}
-  {% set backLinkHref = "/prisoner/" + visitDetails.prisoner.prisonerNumber + "/visiting-orders-history" %}
-{% else %}
-  {% set backLinkHref = "/prisoner/" + visitDetails.prisoner.prisonerNumber %}
-  {% set fromPrisonerProfile = true %}
-{% endif %}
-
 {% set mainClasses = "bapv-visit-details" %}
 
 {% block content %}
@@ -55,7 +38,7 @@
         <dl class="govuk-list">
           <dt>Main contact</dt>
           <dd data-test="visit-contact">{{ visitDetails.visitContact.name }}</dd>
-          
+
           <dt>Contact details</dt>
           <dd>
             {%- if visitDetails.visitContact.telephone -%}
@@ -85,7 +68,7 @@
       or availableVisitActions.clearNotifications
       or availableVisitActions.print %}
       <div class="govuk-button-group" data-test="visit-actions">
-        <form action="/visit/{{ visitDetails.reference }}/update" method="POST" novalidate>
+        <form action="{{ startUpdateAction }}" method="POST" novalidate>
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
           {{ govukButton({
@@ -98,7 +81,7 @@
           {{ govukButton({
             text: "Cancel booking",
             classes: "govuk-!-margin-top-5 govuk-button--secondary",
-            href: "/visit/" + visitDetails.reference + "/cancel",
+            href: cancelHref,
             attributes: { "data-test": "cancel-visit" },
             preventDoubleClick: true
           }) if availableVisitActions.cancel }}
@@ -106,7 +89,7 @@
           {{ govukButton({
             text: "Do not change",
             classes: "govuk-!-margin-top-5 govuk-button--secondary",
-            href: "/visit/" + visitDetails.reference + "/clear-notifications",
+            href: clearNotificationsHref,
             attributes: { "data-test": "clear-notifications" },
             preventDoubleClick: true
           }) if availableVisitActions.clearNotifications }}
@@ -126,13 +109,8 @@
     {# Visit request actions #}
     {% if availableVisitActions.processRequest %}
       <div class="govuk-button-group" data-test="visit-request-actions">
-        <form action="/visit/{{ visitDetails.reference }}/request/approve" method="POST" novalidate>
+        <form action="{{ processRequestApproveAction }}" method="POST" novalidate>
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-          {% if fromPage == "visits" %}<input type="hidden" name="redirectTo" value="visits" data-test="redirect-to">{% endif %}
-          {% if fromPrisonerProfile %}
-            <input type="hidden" name="redirectTo" value="profile" data-test="redirect-to">
-            <input type="hidden" name="prisonerId" value="{{ prisonerId }}" data-test="prisoner-id">
-          {% endif %}
           {{ govukButton({
             text: "Approve request",
             classes: "govuk-!-margin-top-5 govuk-button--secondary",
@@ -141,13 +119,8 @@
           }) }}
         </form>
 
-        <form action="/visit/{{ visitDetails.reference }}/request/reject" method="POST" novalidate>
+        <form action="{{ processRequestRejectAction }}" method="POST" novalidate>
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-          {% if fromPage == "visits" %}<input type="hidden" name="redirectTo" value="visits" data-test="redirect-to">{% endif %}
-          {% if fromPrisonerProfile %}
-            <input type="hidden" name="redirectTo" value="profile" data-test="redirect-to">
-            <input type="hidden" name="prisonerId" value="{{ prisonerId }}" data-test="prisoner-id">
-          {% endif %}
           {{ govukButton({
             text: "Reject request",
             classes: "govuk-!-margin-top-5 govuk-!-margin-left-6 govuk-button--secondary",


### PR DESCRIPTION
The visit details page is linked to from many other pages: prisoner profile, visit requests, visit reviews, visits by date, etc. 

Maintaining navigation state between these (for back links and redirects) had grown over time and become quite messy and inconsistent.

This change implements a more secure, allow-list based navigation state management. It is focussed on key journeys to/from the visit details page.