### PR TITLE
VB-6783 Fix telemetry to ensure AppTraces is populated

### DIFF
--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -1,8 +1,3 @@
-/* eslint-disable import/first */
-import applicationInfoSupplier from '../applicationInfo'
-
-const applicationInfo = applicationInfoSupplier()
-
 import HmppsAuthClient from './hmppsAuthClient'
 import IncentivesApiClient from './incentivesApiClient'
 import OrchestrationApiClient from './orchestrationApiClient'
@@ -10,6 +5,9 @@ import PrisonerContactRegistryApiClient from './prisonerContactRegistryApiClient
 import PrisonerSearchClient from './prisonerSearchClient'
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
+import applicationInfoSupplier from '../applicationInfo'
+
+const applicationInfo = applicationInfoSupplier()
 
 export type RestClientBuilder<T> = (token: string) => T
 

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,6 +1,5 @@
 import { initialiseTelemetry, flushTelemetry, telemetry } from '@ministryofjustice/hmpps-azure-telemetry'
 import type { RequestHandler } from 'express'
-import logger from '../../logger'
 
 initialiseTelemetry({
   serviceName: 'book-a-prison-visit-staff-ui',
@@ -12,14 +11,13 @@ initialiseTelemetry({
   .addModifier(telemetry.processors.enrichSpanNameWithHttpRoute())
   .startRecording()
 
-const shutdown = async (signal: string) => {
-  logger.info(`${signal} received, shutting down...`)
+const shutdown = async () => {
   await flushTelemetry()
   process.exit(0)
 }
 
-process.on('SIGTERM', () => shutdown('SIGTERM'))
-process.on('SIGINT', () => shutdown('SIGINT'))
+process.on('SIGTERM', () => shutdown())
+process.on('SIGINT', () => shutdown())
 
 export default function addUsernameAndCaseloadToTelemetry(): RequestHandler {
   return (req, res, next) => {


### PR DESCRIPTION
Fix log data not appearing in `AppTraces` in Application Insights. Caused by Importing `logger` before `initialiseTelemetry()` was called.