### PR TITLE
VB-6833 Block visit dates or sessions: update path

### DIFF
--- a/integration_tests/pages/homePage.ts
+++ b/integration_tests/pages/homePage.ts
@@ -32,7 +32,7 @@ export default class HomePage extends AbstractPage {
     this.needReviewBadgeCount = page.getByTestId('need-review-count')
     this.viewVisitsTile = page.getByTestId('view-visits-by-date')
     this.viewTimetableTile = page.getByTestId('view-timetable')
-    this.blockDatesTile = page.getByTestId('block-dates')
+    this.blockDatesTile = page.getByTestId('block-dates-or-sessions')
     this.bookerManagementTile = page.getByTestId('booker-management')
     this.viewVisitAllowancesTile = page.getByTestId('visit-allowances')
   }

--- a/integration_tests/specs/blockDatesOrSessions/blockDatesAndSessions.spec.ts
+++ b/integration_tests/specs/blockDatesOrSessions/blockDatesAndSessions.spec.ts
@@ -11,7 +11,7 @@ import ChooseDateOrSessionBlockPage from '../../pages/blockDatesOrSessions/choos
 import BlockSessionChoosePage from '../../pages/blockDatesOrSessions/blockSessions/blockSessionChoosePage'
 import BlockSessionConfirmPage from '../../pages/blockDatesOrSessions/blockSessions/blockSessionConfirmPage'
 
-test.describe('Block visit dates or sessions', () => {
+test.describe('Block visit dates and sessions', () => {
   const shortDateFormat = 'yyyy-MM-dd'
   const longDateFormat = 'EEEE d MMMM yyyy'
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -75,7 +75,7 @@ export default function createApp(services: Services): express.Application {
   app.use('/', indexRoutes(services))
   app.use('/book-a-visit', visitJourneyRoutes(services, 'book'))
   app.use('/update-a-visit', visitJourneyRoutes(services, 'update'))
-  app.use('/block-visit-dates', blockVisitDatesRoutes(services))
+  app.use('/block-visit-dates-or-sessions', blockVisitDatesRoutes(services))
   app.use('/establishment-not-supported', establishmentNotSupportedRoutes(services))
   app.use('/manage-bookers', bookerManagementRoutes(services))
   app.use('/prisoner', prisonerRoutes(services))

--- a/server/routes/blockDatesOrSessions/blockDates/blockDateController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockDates/blockDateController.test.ts
@@ -18,7 +18,7 @@ const auditService = createMockAuditService()
 const blockDatesOrSessionsService = createMockBlockDatesOrSessionsService()
 const visitService = createMockVisitService()
 
-const url = '/block-visit-dates/block-new-date'
+const url = '/block-visit-dates-or-sessions/block-new-date'
 const date = '2024-09-06'
 
 beforeEach(() => {
@@ -34,7 +34,7 @@ describe('Block new visit date', () => {
   describe(`GET ${url}`, () => {
     it('should redirect to blocked dates listing page if no new block date in session', () => {
       sessionData.blockDateOrSession = undefined
-      return request(app).get(url).expect(302).expect('location', '/block-visit-dates')
+      return request(app).get(url).expect(302).expect('location', '/block-visit-dates-or-sessions')
     })
 
     it('should display block new date page - with one existing booking', () => {
@@ -51,7 +51,7 @@ describe('Block new visit date', () => {
           expect($('[data-test=existing-bookings]').text().trim()).toBe('There is 1 existing booking for this date.')
           expect($('[data-test=no-existing-bookings]').length).toBe(0)
 
-          expect($('form[action="/block-visit-dates/block-new-date"][method=POST]').length).toBe(1)
+          expect($('form[action="/block-visit-dates-or-sessions/block-new-date"][method=POST]').length).toBe(1)
           expect($('input[name=confirmBlockDate]').length).toBe(2)
           expect($('input[name=confirmBlockDate]:checked').length).toBe(0)
 
@@ -104,7 +104,7 @@ describe('Block new visit date', () => {
 
     it('should redirect to blocked dates listing page if no new block date in session', () => {
       sessionData.blockDateOrSession = undefined
-      return request(app).post(url).expect(302).expect('location', '/block-visit-dates')
+      return request(app).post(url).expect(302).expect('location', '/block-visit-dates-or-sessions')
     })
 
     it('should block date set, remove date from session, and redirect to blocked dates listing page if block confirmed', () => {
@@ -119,7 +119,7 @@ describe('Block new visit date', () => {
         .post(url)
         .send({ confirmBlockDate: 'yes' })
         .expect(302)
-        .expect('location', '/block-visit-dates')
+        .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
           expect(blockDatesOrSessionsService.blockVisitDate).toHaveBeenCalledWith('user1', 'HEI', date)
           expect(auditService.blockedVisitDate).toHaveBeenCalledWith({
@@ -139,7 +139,7 @@ describe('Block new visit date', () => {
         .post(url)
         .send({ confirmBlockDate: 'no' })
         .expect(302)
-        .expect('location', '/block-visit-dates')
+        .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
           expect(blockDatesOrSessionsService.blockVisitDate).not.toHaveBeenCalled()
           expect(auditService.blockedVisitDate).not.toHaveBeenCalled()
@@ -160,7 +160,7 @@ describe('Block new visit date', () => {
         .post(url)
         .send({ confirmBlockDate: 'invalid' })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-new-date')
+        .expect('location', '/block-visit-dates-or-sessions/block-new-date')
         .expect(() => {
           expect(blockDatesOrSessionsService.blockVisitDate).not.toHaveBeenCalled()
           expect(auditService.blockedVisitDate).not.toHaveBeenCalled()

--- a/server/routes/blockDatesOrSessions/blockDates/blockDateController.ts
+++ b/server/routes/blockDatesOrSessions/blockDates/blockDateController.ts
@@ -37,7 +37,7 @@ export default class BlockDateController {
       const errors = validationResult(req)
       if (!errors.isEmpty()) {
         req.flash('errors', errors.array())
-        return res.redirect('/block-visit-dates/block-new-date')
+        return res.redirect('/block-visit-dates-or-sessions/block-new-date')
       }
 
       const { blockDateOrSession } = req.session
@@ -68,7 +68,7 @@ export default class BlockDateController {
       }
 
       delete req.session.blockDateOrSession
-      return res.redirect('/block-visit-dates')
+      return res.redirect('/block-visit-dates-or-sessions')
     }
   }
 

--- a/server/routes/blockDatesOrSessions/blockDates/unblockDateController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockDates/unblockDateController.test.ts
@@ -9,7 +9,7 @@ let app: Express
 const auditService = createMockAuditService()
 const blockDatesOrSessionsService = createMockBlockDatesOrSessionsService()
 
-const url = '/block-visit-dates/unblock-date'
+const url = '/block-visit-dates-or-sessions/unblock-date'
 const unblockDate = '2024-09-06'
 
 beforeEach(() => {
@@ -34,7 +34,7 @@ describe('Unblock visit date', () => {
         .post(url)
         .send({ date: unblockDate })
         .expect(302)
-        .expect('location', '/block-visit-dates')
+        .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
           expect(blockDatesOrSessionsService.unblockVisitDate).toHaveBeenCalledWith('user1', 'HEI', unblockDate)
           expect(auditService.unblockedVisitDate).toHaveBeenCalledWith({
@@ -53,7 +53,7 @@ describe('Unblock visit date', () => {
         .post(url)
         .send({ date: 'invalid' })
         .expect(302)
-        .expect('location', '/block-visit-dates')
+        .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
           expect(blockDatesOrSessionsService.unblockVisitDate).not.toHaveBeenCalled()
           expect(auditService.unblockedVisitDate).not.toHaveBeenCalled()

--- a/server/routes/blockDatesOrSessions/blockDates/unblockDateController.ts
+++ b/server/routes/blockDatesOrSessions/blockDates/unblockDateController.ts
@@ -14,7 +14,7 @@ export default class UnblockDateController {
     return async (req, res) => {
       const errors = validationResult(req)
       if (!errors.isEmpty()) {
-        return res.redirect('/block-visit-dates')
+        return res.redirect('/block-visit-dates-or-sessions')
       }
 
       const { date } = matchedData<{ date: string }>(req)
@@ -39,7 +39,7 @@ export default class UnblockDateController {
         logger.error(error, `Could not unblock visit date ${date} for ${res.locals.user.username}`)
       }
 
-      return res.redirect('/block-visit-dates')
+      return res.redirect('/block-visit-dates-or-sessions')
     }
   }
 

--- a/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.test.ts
@@ -15,7 +15,7 @@ let sessionData: SessionData
 
 const blockDatesOrSessionsService = createMockBlockDatesOrSessionsService()
 const visitSessionsService = createMockVisitSessionsService()
-const url = '/block-visit-dates'
+const url = '/block-visit-dates-or-sessions'
 
 afterEach(() => {
   jest.resetAllMocks()
@@ -58,7 +58,7 @@ describe('Block visit dates and sessions listing page', () => {
 
             expect($('.moj-alert').length).toBe(0)
 
-            expect($('form[action="/block-visit-dates"][method=POST]').length).toBe(1)
+            expect($('form[action="/block-visit-dates-or-sessions"][method=POST]').length).toBe(1)
             expect($('.moj-datepicker').attr('data-min-date')).toBe(format(today, 'dd/MM/yyyy'))
             expect($('input[name=date]').val()).toBeFalsy()
 
@@ -169,7 +169,9 @@ describe('Block visit dates and sessions listing page', () => {
           expect($('[data-test="blocked-when-1"]').text()).toBe('All day')
           expect($('[data-test="blocked-attendees-1"]').text()).toBe('All prisoners')
           expect($('[data-test="unblock-1"]').text().trim()).toBe('Unblock')
-          expect($('[data-test="unblock-1"]').parent().attr('action')).toBe('/block-visit-dates/unblock-date')
+          expect($('[data-test="unblock-1"]').parent().attr('action')).toBe(
+            '/block-visit-dates-or-sessions/unblock-date',
+          )
           expect($('[data-test="unblock-1"]').siblings('input[type=hidden][name=date]').val()).toBe('2026-07-01')
           expect(
             $('[data-test="unblock-1"]').siblings('input[type=hidden][name=sessionTemplateReference]').length,
@@ -180,7 +182,9 @@ describe('Block visit dates and sessions listing page', () => {
           expect($('[data-test="blocked-when-2"]').text()).toBe('10am to 11:30am')
           expect($('[data-test="blocked-attendees-2"]').text()).toBe('All prisoners')
           expect($('[data-test="unblock-2"]').text().trim()).toBe('Unblock')
-          expect($('[data-test="unblock-2"]').parent().attr('action')).toBe('/block-visit-dates/unblock-session')
+          expect($('[data-test="unblock-2"]').parent().attr('action')).toBe(
+            '/block-visit-dates-or-sessions/unblock-session',
+          )
           expect($('[data-test="unblock-2"]').siblings('input[type=hidden][name=date]').val()).toBe('2026-07-02')
           expect($('[data-test="unblock-2"]').siblings('input[type=hidden][name=sessionTemplateReference]').val()).toBe(
             'session-1',
@@ -283,7 +287,7 @@ describe('Block visit dates and sessions listing page', () => {
         .post(url)
         .send({ date: inputDate })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-new-date')
+        .expect('location', '/block-visit-dates-or-sessions/block-new-date')
         .expect(() => {
           expect(blockDatesOrSessionsService.getFutureBlockedDates).toHaveBeenCalledWith('HEI', 'user1')
           expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
@@ -293,7 +297,7 @@ describe('Block visit dates and sessions listing page', () => {
             includeExcludedSessions: true,
           })
           expect(sessionData.blockDateOrSession).toStrictEqual({
-            backLinkHref: '/block-visit-dates',
+            backLinkHref: '/block-visit-dates-or-sessions',
             date: expectedOutputDate,
           })
           expect(flashProvider).not.toHaveBeenCalled()
@@ -310,7 +314,7 @@ describe('Block visit dates and sessions listing page', () => {
         .post(url)
         .send({ date: inputDate })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-date-or-session')
+        .expect('location', '/block-visit-dates-or-sessions/block-date-or-session')
         .expect(() => {
           expect(blockDatesOrSessionsService.getFutureBlockedDates).toHaveBeenCalledWith('HEI', 'user1')
           expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
@@ -320,7 +324,7 @@ describe('Block visit dates and sessions listing page', () => {
             includeExcludedSessions: true,
           })
           expect(sessionData.blockDateOrSession).toStrictEqual({
-            backLinkHref: '/block-visit-dates',
+            backLinkHref: '/block-visit-dates-or-sessions',
             date: expectedOutputDate,
           })
           expect(flashProvider).not.toHaveBeenCalled()
@@ -338,7 +342,7 @@ describe('Block visit dates and sessions listing page', () => {
         .post(url)
         .send({ date: inputDate })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-new-date')
+        .expect('location', '/block-visit-dates-or-sessions/block-new-date')
     })
 
     describe('should set error and redirect back to listing page for an invalid date', () => {
@@ -363,7 +367,7 @@ describe('Block visit dates and sessions listing page', () => {
           .post(url)
           .send({ date: input })
           .expect(302)
-          .expect('location', '/block-visit-dates')
+          .expect('location', '/block-visit-dates-or-sessions')
           .expect(() => {
             expect(blockDatesOrSessionsService.getFutureBlockedDates).not.toHaveBeenCalled()
             expect(sessionData.blockDateOrSession).toBe(undefined)
@@ -390,7 +394,7 @@ describe('Block visit dates and sessions listing page', () => {
         .post(url)
         .send({ date: inputDate })
         .expect(302)
-        .expect('location', '/block-visit-dates')
+        .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
           expect(blockDatesOrSessionsService.getFutureBlockedDates).not.toHaveBeenCalled()
           expect(sessionData.blockDateOrSession).toBe(undefined)
@@ -419,7 +423,7 @@ describe('Block visit dates and sessions listing page', () => {
         .post(url)
         .send({ date: inputDate })
         .expect(302)
-        .expect('location', '/block-visit-dates')
+        .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
           expect(blockDatesOrSessionsService.getFutureBlockedDates).toHaveBeenCalledWith('HEI', 'user1')
           expect(sessionData.blockDateOrSession).toBe(undefined)

--- a/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.ts
+++ b/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.ts
@@ -59,12 +59,12 @@ export default class BlockDatesOrSessionsController {
         req.flash('errors', errors.array())
         const { rawDate } = matchedData<{ rawDate: string }>(req)
         req.flash('formValues', { date: rawDate })
-        return res.redirect('/block-visit-dates')
+        return res.redirect('/block-visit-dates-or-sessions')
       }
 
       const { date } = matchedData<{ date: string }>(req)
       req.session.blockDateOrSession = {
-        backLinkHref: '/block-visit-dates',
+        backLinkHref: '/block-visit-dates-or-sessions',
         date,
       }
 
@@ -78,10 +78,10 @@ export default class BlockDatesOrSessionsController {
       const dateHasSessions = sessionSchedule.length > 0
 
       if (dateHasSessions && config.features.sessionDateBlocks) {
-        return res.redirect('/block-visit-dates/block-date-or-session')
+        return res.redirect('/block-visit-dates-or-sessions/block-date-or-session')
       }
 
-      return res.redirect('/block-visit-dates/block-new-date')
+      return res.redirect('/block-visit-dates-or-sessions/block-new-date')
     }
   }
 

--- a/server/routes/blockDatesOrSessions/blockSessions/blockSessionChooseController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/blockSessionChooseController.test.ts
@@ -13,7 +13,7 @@ let sessionData: SessionData
 
 const visitSessionsService = createMockVisitSessionsService()
 
-const url = '/block-visit-dates/block-new-session/choose'
+const url = '/block-visit-dates-or-sessions/block-new-session/choose'
 const date = '2024-09-06'
 
 const session1 = TestData.sessionSchedule({
@@ -47,7 +47,7 @@ describe('Choose which session to block', () => {
   describe(`GET ${url}`, () => {
     it('should redirect to blocked dates listing page if no new block date in session', () => {
       sessionData.blockDateOrSession = undefined
-      return request(app).get(url).expect(302).expect('location', '/block-visit-dates')
+      return request(app).get(url).expect(302).expect('location', '/block-visit-dates-or-sessions')
     })
 
     it('should display choose date or session block page', () => {
@@ -56,10 +56,12 @@ describe('Choose which session to block', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('.govuk-back-link').attr('href')).toBe('/block-visit-dates/block-date-or-session')
+          expect($('.govuk-back-link').attr('href')).toBe('/block-visit-dates-or-sessions/block-date-or-session')
           expect($('h1').text()).toBe('Which session would you like to block on Friday 6 September 2024?')
 
-          expect($('form[action="/block-visit-dates/block-new-session/choose"][method=POST]').length).toBe(1)
+          expect($('form[action="/block-visit-dates-or-sessions/block-new-session/choose"][method=POST]').length).toBe(
+            1,
+          )
           expect($('input[name=sessionTemplateReference]').length).toBe(2)
           expect($('input[name=sessionTemplateReference]:checked').length).toBe(0)
           // session 1
@@ -73,7 +75,9 @@ describe('Choose which session to block', () => {
           expect($('[data-test=submit]').text().trim()).toBe('Continue')
         })
         .expect(() => {
-          expect(sessionData.blockDateOrSession.backLinkHref).toBe('/block-visit-dates/block-date-or-session')
+          expect(sessionData.blockDateOrSession.backLinkHref).toBe(
+            '/block-visit-dates-or-sessions/block-date-or-session',
+          )
 
           expect(sessionData.blockDateOrSession.sessions).toEqual([session1, session2Blocked])
 
@@ -92,7 +96,7 @@ describe('Choose which session to block', () => {
       return request(app)
         .get(url)
         .expect(302)
-        .expect('location', '/block-visit-dates/block-date-or-session')
+        .expect('location', '/block-visit-dates-or-sessions/block-date-or-session')
 
         .expect(() => {
           expect(sessionData.blockDateOrSession.sessions).toBeUndefined()
@@ -132,7 +136,7 @@ describe('Choose which session to block', () => {
 
     it('should redirect to blocked dates listing page if no new block date in session', () => {
       sessionData.blockDateOrSession = undefined
-      return request(app).post(url).expect(302).expect('location', '/block-visit-dates')
+      return request(app).post(url).expect(302).expect('location', '/block-visit-dates-or-sessions')
     })
 
     it('should store selected session and redirect to confirmation page', () => {
@@ -140,10 +144,12 @@ describe('Choose which session to block', () => {
         .post(url)
         .send({ sessionTemplateReference: session1.sessionTemplateReference })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-new-session/confirm')
+        .expect('location', '/block-visit-dates-or-sessions/block-new-session/confirm')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledTimes(0)
-          expect(sessionData.blockDateOrSession.backLinkHref).toBe('/block-visit-dates/block-new-session/choose')
+          expect(sessionData.blockDateOrSession.backLinkHref).toBe(
+            '/block-visit-dates-or-sessions/block-new-session/choose',
+          )
           expect(sessionData.blockDateOrSession.selectedSession).toEqual(session1)
         })
     })
@@ -161,7 +167,7 @@ describe('Choose which session to block', () => {
         .post(url)
         .send({ sessionTemplateReference: 'invalid' })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-new-session/choose')
+        .expect('location', '/block-visit-dates-or-sessions/block-new-session/choose')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledWith('errors', [expectedValidationError])
           expect(flashProvider).toHaveBeenCalledTimes(1)
@@ -174,7 +180,7 @@ describe('Choose which session to block', () => {
         .post(url)
         .send({ sessionTemplateReference: session2Blocked.sessionTemplateReference })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-new-session/choose')
+        .expect('location', '/block-visit-dates-or-sessions/block-new-session/choose')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledWith('errors', expect.anything())
           expect(flashProvider).toHaveBeenCalledTimes(1)

--- a/server/routes/blockDatesOrSessions/blockSessions/blockSessionChooseController.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/blockSessionChooseController.ts
@@ -15,7 +15,7 @@ export default class BlockSessionChooseController {
       const { prisonId } = req.session.selectedEstablishment
       const { blockDateOrSession } = req.session
 
-      blockDateOrSession.backLinkHref = '/block-visit-dates/block-date-or-session'
+      blockDateOrSession.backLinkHref = '/block-visit-dates-or-sessions/block-date-or-session'
       const { backLinkHref, date } = blockDateOrSession
 
       const sessions = await this.visitSessionsService.getSessionSchedule({
@@ -37,7 +37,7 @@ export default class BlockSessionChooseController {
           },
         ])
         req.flash('formValues', { blockType: 'session' })
-        return res.redirect('/block-visit-dates/block-date-or-session')
+        return res.redirect('/block-visit-dates-or-sessions/block-date-or-session')
       }
 
       blockDateOrSession.sessions = sessions
@@ -56,7 +56,7 @@ export default class BlockSessionChooseController {
       const errors = validationResult(req)
       if (!errors.isEmpty()) {
         req.flash('errors', errors.array())
-        return res.redirect('/block-visit-dates/block-new-session/choose')
+        return res.redirect('/block-visit-dates-or-sessions/block-new-session/choose')
       }
 
       const { blockDateOrSession } = req.session
@@ -65,9 +65,9 @@ export default class BlockSessionChooseController {
       blockDateOrSession.selectedSession = blockDateOrSession.sessions.find(
         session => session.sessionTemplateReference === sessionTemplateReference,
       )
-      blockDateOrSession.backLinkHref = '/block-visit-dates/block-new-session/choose'
+      blockDateOrSession.backLinkHref = '/block-visit-dates-or-sessions/block-new-session/choose'
 
-      return res.redirect('/block-visit-dates/block-new-session/confirm')
+      return res.redirect('/block-visit-dates-or-sessions/block-new-session/confirm')
     }
   }
 

--- a/server/routes/blockDatesOrSessions/blockSessions/blockSessionConfirmController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/blockSessionConfirmController.test.ts
@@ -20,7 +20,7 @@ const auditService = createMockAuditService()
 const blockDatesOrSessionsService = createMockBlockDatesOrSessionsService()
 const visitService = createMockVisitService()
 
-const url = '/block-visit-dates/block-new-session/confirm'
+const url = '/block-visit-dates-or-sessions/block-new-session/confirm'
 const date = '2024-09-06'
 
 const selectedSession = TestData.sessionSchedule({
@@ -49,7 +49,7 @@ describe('Confirm session block', () => {
   describe(`GET ${url}`, () => {
     it('should redirect to blocked dates listing page if no new block date in session', () => {
       sessionData.blockDateOrSession = undefined
-      return request(app).get(url).expect(302).expect('location', '/block-visit-dates')
+      return request(app).get(url).expect(302).expect('location', '/block-visit-dates-or-sessions')
     })
 
     it('should display confirm session block page - no existing visits', () => {
@@ -58,7 +58,7 @@ describe('Confirm session block', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('.govuk-back-link').attr('href')).toBe('/block-visit-dates/block-new-session/choose')
+          expect($('.govuk-back-link').attr('href')).toBe('/block-visit-dates-or-sessions/block-new-session/choose')
           expect($('h1').text()).toBe(
             'Are you sure you want to block visits for this session on Friday 6 September 2024?',
           )
@@ -68,14 +68,18 @@ describe('Confirm session block', () => {
           expect($('[data-test=no-existing-bookings]').length).toBe(1)
           expect($('[data-test=existing-bookings]').length).toBe(0)
 
-          expect($('form[action="/block-visit-dates/block-new-session/confirm"][method=POST]').length).toBe(1)
+          expect($('form[action="/block-visit-dates-or-sessions/block-new-session/confirm"][method=POST]').length).toBe(
+            1,
+          )
           expect($('input[name=confirmBlockSession]').length).toBe(2)
           expect($('input[name=confirmBlockSession]:checked').length).toBe(0)
 
           expect($('[data-test=submit]').text().trim()).toBe('Continue')
         })
         .expect(() => {
-          expect(sessionData.blockDateOrSession.backLinkHref).toBe('/block-visit-dates/block-new-session/choose')
+          expect(sessionData.blockDateOrSession.backLinkHref).toBe(
+            '/block-visit-dates-or-sessions/block-new-session/choose',
+          )
 
           expect(visitService.getVisitsBySessionTemplate).toHaveBeenCalledWith({
             username: 'user1',
@@ -133,7 +137,7 @@ describe('Confirm session block', () => {
   describe(`POST ${url}`, () => {
     it('should redirect to blocked dates listing page if no new block date in session', () => {
       sessionData.blockDateOrSession = undefined
-      return request(app).post(url).expect(302).expect('location', '/block-visit-dates')
+      return request(app).post(url).expect(302).expect('location', '/block-visit-dates-or-sessions')
     })
 
     it('should block selected session for date and redirect to block visit dates or sessions page if confirmed', () => {
@@ -143,7 +147,7 @@ describe('Confirm session block', () => {
         .post(url)
         .send({ confirmBlockSession: 'yes' })
         .expect(302)
-        .expect('location', '/block-visit-dates')
+        .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
           expect(blockDatesOrSessionsService.blockVisitSession).toHaveBeenCalledWith({
             sessionTemplateReference: selectedSession.sessionTemplateReference,
@@ -173,7 +177,7 @@ describe('Confirm session block', () => {
         .post(url)
         .send({ confirmBlockSession: 'no' })
         .expect(302)
-        .expect('location', '/block-visit-dates')
+        .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
           expect(blockDatesOrSessionsService.blockVisitSession).not.toHaveBeenCalled()
           expect(auditService.blockedVisitSession).not.toHaveBeenCalled()
@@ -195,7 +199,7 @@ describe('Confirm session block', () => {
         .post(url)
         .send({ confirmBlockSession: 'invalid' })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-new-session/confirm')
+        .expect('location', '/block-visit-dates-or-sessions/block-new-session/confirm')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledWith('errors', [expectedValidationError])
           expect(flashProvider).toHaveBeenCalledTimes(1)

--- a/server/routes/blockDatesOrSessions/blockSessions/blockSessionConfirmController.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/blockSessionConfirmController.ts
@@ -19,7 +19,7 @@ export default class BlockSessionConfirmController {
       const { prisonId } = req.session.selectedEstablishment
       const { blockDateOrSession } = req.session
 
-      blockDateOrSession.backLinkHref = '/block-visit-dates/block-new-session/choose'
+      blockDateOrSession.backLinkHref = '/block-visit-dates-or-sessions/block-new-session/choose'
       const { backLinkHref, date, selectedSession } = blockDateOrSession
 
       const visitCount = (
@@ -53,7 +53,7 @@ export default class BlockSessionConfirmController {
       const errors = validationResult(req)
       if (!errors.isEmpty()) {
         req.flash('errors', errors.array())
-        return res.redirect('/block-visit-dates/block-new-session/confirm')
+        return res.redirect('/block-visit-dates-or-sessions/block-new-session/confirm')
       }
 
       const { confirmBlockSession } = matchedData<{ confirmBlockSession: 'yes' | 'no' }>(req)
@@ -86,7 +86,7 @@ export default class BlockSessionConfirmController {
       }
 
       delete req.session.blockDateOrSession
-      return res.redirect('/block-visit-dates')
+      return res.redirect('/block-visit-dates-or-sessions')
     }
   }
 

--- a/server/routes/blockDatesOrSessions/blockSessions/unblockSessionController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/unblockSessionController.test.ts
@@ -14,7 +14,7 @@ const auditService = createMockAuditService()
 const blockDatesOrSessionsService = createMockBlockDatesOrSessionsService()
 const visitSessionsService = createMockVisitSessionsService()
 
-const url = '/block-visit-dates/unblock-session'
+const url = '/block-visit-dates-or-sessions/unblock-session'
 const unblockDate = '2024-09-06'
 const session = TestData.sessionSchedule()
 
@@ -36,7 +36,7 @@ describe('Unblock visit session', () => {
         .post(url)
         .send({ date: unblockDate, sessionTemplateReference: session.sessionTemplateReference })
         .expect(302)
-        .expect('location', '/block-visit-dates')
+        .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
           expect(blockDatesOrSessionsService.unblockVisitSession).toHaveBeenCalledWith({
             sessionTemplateReference: session.sessionTemplateReference,
@@ -63,7 +63,7 @@ describe('Unblock visit session', () => {
         .post(url)
         .send({ date: 'invalid' })
         .expect(302)
-        .expect('location', '/block-visit-dates')
+        .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
           expect(blockDatesOrSessionsService.unblockVisitSession).not.toHaveBeenCalled()
           expect(auditService.unblockedVisitSession).not.toHaveBeenCalled()

--- a/server/routes/blockDatesOrSessions/blockSessions/unblockSessionController.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/unblockSessionController.ts
@@ -15,7 +15,7 @@ export default class UnblockSessionController {
     return async (req, res) => {
       const errors = validationResult(req)
       if (!errors.isEmpty()) {
-        return res.redirect('/block-visit-dates')
+        return res.redirect('/block-visit-dates-or-sessions')
       }
 
       const { date, sessionTemplateReference } = matchedData<{ date: string; sessionTemplateReference: string }>(req)
@@ -53,7 +53,7 @@ export default class UnblockSessionController {
         logger.error(error, `Could not unblock visit session ${date} for ${username}`)
       }
 
-      return res.redirect('/block-visit-dates')
+      return res.redirect('/block-visit-dates-or-sessions')
     }
   }
 

--- a/server/routes/blockDatesOrSessions/chooseDateOrSessionBlockController.test.ts
+++ b/server/routes/blockDatesOrSessions/chooseDateOrSessionBlockController.test.ts
@@ -9,7 +9,7 @@ let app: Express
 let flashData: FlashData
 let sessionData: SessionData
 
-const url = '/block-visit-dates/block-date-or-session'
+const url = '/block-visit-dates-or-sessions/block-date-or-session'
 const date = '2024-09-06'
 
 beforeEach(() => {
@@ -29,7 +29,7 @@ describe('Choose date or session block', () => {
   describe(`GET ${url}`, () => {
     it('should redirect to blocked dates listing page if no new block date in session', () => {
       sessionData.blockDateOrSession = undefined
-      return request(app).get(url).expect(302).expect('location', '/block-visit-dates')
+      return request(app).get(url).expect(302).expect('location', '/block-visit-dates-or-sessions')
     })
 
     it('should display choose date or session block page', () => {
@@ -38,10 +38,10 @@ describe('Choose date or session block', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('.govuk-back-link').attr('href')).toBe('/block-visit-dates')
+          expect($('.govuk-back-link').attr('href')).toBe('/block-visit-dates-or-sessions')
           expect($('h1').text()).toBe('What would you like to block on Friday 6 September 2024?')
 
-          expect($('form[action="/block-visit-dates/block-date-or-session"][method=POST]').length).toBe(1)
+          expect($('form[action="/block-visit-dates-or-sessions/block-date-or-session"][method=POST]').length).toBe(1)
           expect($('input[name=blockType]').length).toBe(2)
           expect($('input[name=blockType]').eq(0).val()).toBe('date')
           expect($('input[name=blockType]').eq(1).val()).toBe('session')
@@ -50,7 +50,7 @@ describe('Choose date or session block', () => {
           expect($('[data-test=submit]').text().trim()).toBe('Continue')
         })
         .expect(() => {
-          expect(sessionData.blockDateOrSession.backLinkHref).toBe('/block-visit-dates')
+          expect(sessionData.blockDateOrSession.backLinkHref).toBe('/block-visit-dates-or-sessions')
         })
     })
 
@@ -73,7 +73,7 @@ describe('Choose date or session block', () => {
   describe(`POST ${url}`, () => {
     it('should redirect to blocked dates listing page if no new block date in session', () => {
       sessionData.blockDateOrSession = undefined
-      return request(app).post(url).expect(302).expect('location', '/block-visit-dates')
+      return request(app).post(url).expect(302).expect('location', '/block-visit-dates-or-sessions')
     })
 
     it('should redirect to block new date page if this is selected', () => {
@@ -81,10 +81,12 @@ describe('Choose date or session block', () => {
         .post(url)
         .send({ blockType: 'date' })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-new-date')
+        .expect('location', '/block-visit-dates-or-sessions/block-new-date')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledTimes(0)
-          expect(sessionData.blockDateOrSession.backLinkHref).toBe('/block-visit-dates/block-date-or-session')
+          expect(sessionData.blockDateOrSession.backLinkHref).toBe(
+            '/block-visit-dates-or-sessions/block-date-or-session',
+          )
         })
     })
 
@@ -93,10 +95,12 @@ describe('Choose date or session block', () => {
         .post(url)
         .send({ blockType: 'session' })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-new-session/choose')
+        .expect('location', '/block-visit-dates-or-sessions/block-new-session/choose')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledTimes(0)
-          expect(sessionData.blockDateOrSession.backLinkHref).toBe('/block-visit-dates/block-date-or-session')
+          expect(sessionData.blockDateOrSession.backLinkHref).toBe(
+            '/block-visit-dates-or-sessions/block-date-or-session',
+          )
         })
     })
 
@@ -113,7 +117,7 @@ describe('Choose date or session block', () => {
         .post(url)
         .send({ blockType: 'invalid' })
         .expect(302)
-        .expect('location', '/block-visit-dates/block-date-or-session')
+        .expect('location', '/block-visit-dates-or-sessions/block-date-or-session')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledWith('errors', [expectedValidationError])
           expect(flashProvider).toHaveBeenCalledTimes(1)

--- a/server/routes/blockDatesOrSessions/chooseDateOrSessionBlockController.ts
+++ b/server/routes/blockDatesOrSessions/chooseDateOrSessionBlockController.ts
@@ -8,7 +8,7 @@ export default class ChooseDateOrSessionBlockController {
     return async (req, res) => {
       const { blockDateOrSession } = req.session
 
-      blockDateOrSession.backLinkHref = '/block-visit-dates'
+      blockDateOrSession.backLinkHref = '/block-visit-dates-or-sessions'
       const { backLinkHref, date } = blockDateOrSession
 
       return res.render('pages/blockDatesOrSessions/chooseDateOrSessionBlock', {
@@ -25,15 +25,17 @@ export default class ChooseDateOrSessionBlockController {
       const errors = validationResult(req)
       if (!errors.isEmpty()) {
         req.flash('errors', errors.array())
-        return res.redirect('/block-visit-dates/block-date-or-session')
+        return res.redirect('/block-visit-dates-or-sessions/block-date-or-session')
       }
 
       const { blockDateOrSession } = req.session
       const { blockType } = matchedData<{ blockType: 'date' | 'session' }>(req)
-      blockDateOrSession.backLinkHref = '/block-visit-dates/block-date-or-session'
+      blockDateOrSession.backLinkHref = '/block-visit-dates-or-sessions/block-date-or-session'
 
       return res.redirect(
-        blockType === 'date' ? '/block-visit-dates/block-new-date' : '/block-visit-dates/block-new-session/choose',
+        blockType === 'date'
+          ? '/block-visit-dates-or-sessions/block-new-date'
+          : '/block-visit-dates-or-sessions/block-new-session/choose',
       )
     }
   }

--- a/server/routes/blockDatesOrSessions/index.ts
+++ b/server/routes/blockDatesOrSessions/index.ts
@@ -43,13 +43,13 @@ export default function routes(services: Services): Router {
   // Middlewares to ensure route has required session data
   const checkSessionDataMiddleware: RequestHandler = (req, res, next) => {
     if (!req.session.blockDateOrSession) {
-      return res.redirect('/block-visit-dates')
+      return res.redirect('/block-visit-dates-or-sessions')
     }
     return next()
   }
   const checkSelectedSessionMiddleware: RequestHandler = (req, res, next) => {
     if (!req.session.blockDateOrSession?.selectedSession) {
-      return res.redirect('/block-visit-dates')
+      return res.redirect('/block-visit-dates-or-sessions')
     }
     return next()
   }

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -72,8 +72,10 @@ describe('GET /', () => {
         expect($('[data-test="view-timetable"] .card__link').text()).toBe('Visits timetable')
         expect($('[data-test="view-timetable"] .card__link').attr('href')).toBe('/timetable')
 
-        expect($('[data-test="block-dates"] .card__link').text()).toBe('Block visit dates or sessions')
-        expect($('[data-test="block-dates"] .card__link').attr('href')).toBe('/block-visit-dates')
+        expect($('[data-test="block-dates-or-sessions"] .card__link').text()).toBe('Block visit dates or sessions')
+        expect($('[data-test="block-dates-or-sessions"] .card__link').attr('href')).toBe(
+          '/block-visit-dates-or-sessions',
+        )
 
         expect(bookerService.getVisitorRequestCount).not.toHaveBeenCalled()
         expect(visitRequestsService.getVisitRequestCount).not.toHaveBeenCalled()
@@ -97,8 +99,7 @@ describe('GET /', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = cheerio.load(res.text)
-        expect($('[data-test="block-dates"] .card__link').text()).toBe('Block visit dates')
-        expect($('[data-test="block-dates"] .card__link').attr('href')).toBe('/block-visit-dates')
+        expect($('[data-test="block-dates-or-sessions"] .card__link').text()).toBe('Block visit dates')
       })
   })
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -110,7 +110,7 @@ function appSetup(
   app.use('/', indexRoutes(services))
   app.use('/book-a-visit', visitJourneyRoutes(services, 'book'))
   app.use('/update-a-visit', visitJourneyRoutes(services, 'update'))
-  app.use('/block-visit-dates', blockVisitDatesRoutes(services))
+  app.use('/block-visit-dates-or-sessions', blockVisitDatesRoutes(services))
   app.use('/establishment-not-supported', establishmentNotSupportedRoutes(services))
   app.use('/manage-bookers', bookerManagementRoutes(services))
   app.use('/prisoner', prisonerRoutes(services))

--- a/server/views/pages/blockDatesOrSessions/blockDates.njk
+++ b/server/views/pages/blockDatesOrSessions/blockDates.njk
@@ -30,7 +30,7 @@
 
   <h2 class="govuk-heading-m">Block a new date</h2>
 
-  <form action="/block-visit-dates" method="POST" novalidate>
+  <form action="/block-visit-dates-or-sessions" method="POST" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     {{ mojDatePicker({
@@ -63,7 +63,7 @@
       {% for blockedDate in blockedDates %}
 
         {%- set unblockButtonHtml -%}
-          <form action="/block-visit-dates/unblock-date" method="POST" novalidate>
+          <form action="/block-visit-dates-or-sessions/unblock-date" method="POST" novalidate>
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
             <input type="hidden" name="date" value="{{ blockedDate.excludeDate }}">
             {{ govukButton({

--- a/server/views/pages/blockDatesOrSessions/blockDates/blockDate.njk
+++ b/server/views/pages/blockDatesOrSessions/blockDates/blockDate.njk
@@ -22,7 +22,7 @@
         <p data-test="no-existing-bookings">There are no existing bookings for this date.</p>
       {% endif %}
 
-      <form action="/block-visit-dates/block-new-date" method="POST" novalidate>
+      <form action="/block-visit-dates-or-sessions/block-new-date" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {{ govukRadios({

--- a/server/views/pages/blockDatesOrSessions/blockDatesOrSessions.njk
+++ b/server/views/pages/blockDatesOrSessions/blockDatesOrSessions.njk
@@ -15,7 +15,7 @@
 
 {% for blockedDateOrSession in blockedDatesAndSessions %}
 
-  {% set actionUrl = "/block-visit-dates/unblock-" +
+  {% set actionUrl = "/block-visit-dates-or-sessions/unblock-" +
     ("session" if blockedDateOrSession.sessionTemplateReference else "date") %}
 
     {%- set unblockButtonHtml -%}
@@ -81,7 +81,7 @@
 
   <h2 class="govuk-heading-m">Block a new date or session</h2>
 
-  <form action="/block-visit-dates" method="POST" novalidate>
+  <form action="/block-visit-dates-or-sessions" method="POST" novalidate>
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     {{ mojDatePicker({

--- a/server/views/pages/blockDatesOrSessions/blockSessions/blockSessionChoose.njk
+++ b/server/views/pages/blockDatesOrSessions/blockSessions/blockSessionChoose.njk
@@ -11,7 +11,7 @@
 
       <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
 
-      <form action="/block-visit-dates/block-new-session/choose" method="POST" novalidate>
+      <form action="/block-visit-dates-or-sessions/block-new-session/choose" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {{ govukRadios({

--- a/server/views/pages/blockDatesOrSessions/blockSessions/blockSessionConfirm.njk
+++ b/server/views/pages/blockDatesOrSessions/blockSessions/blockSessionConfirm.njk
@@ -24,7 +24,7 @@
         <p data-test="no-existing-bookings">There are no existing bookings for this session.</p>
       {% endif %}
 
-      <form action="/block-visit-dates/block-new-session/confirm" method="POST" novalidate>
+      <form action="/block-visit-dates-or-sessions/block-new-session/confirm" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {{ govukRadios({

--- a/server/views/pages/blockDatesOrSessions/chooseDateOrSessionBlock.njk
+++ b/server/views/pages/blockDatesOrSessions/chooseDateOrSessionBlock.njk
@@ -11,7 +11,7 @@
 
       <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
 
-      <form action="/block-visit-dates/block-date-or-session" method="POST" novalidate>
+      <form action="/block-visit-dates-or-sessions/block-date-or-session" method="POST" novalidate>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {{ govukRadios({

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -103,27 +103,15 @@
           }) }}
         </li>
 
-        {% if features.sessionDateBlocks %}
-          <li class="govuk-grid-column-one-third card-group__item">
-            {{ card({
-              href: "/block-visit-dates",
-              clickable: "true",
-              heading: "Block visit dates or sessions",
-              description: "Block or unblock dates or sessions for social visits",
-              id: "block-dates"
-            }) }}
-          </li>
-        {% else %}
-          <li class="govuk-grid-column-one-third card-group__item">
-            {{ card({
-              href: "/block-visit-dates",
-              clickable: "true",
-              heading: "Block visit dates",
-              description: "Block or unblock dates for social visits",
-              id: "block-dates"
-            }) }}
-          </li>
-        {% endif %}
+        <li class="govuk-grid-column-one-third card-group__item">
+          {{ card({
+            href: "/block-visit-dates-or-sessions",
+            clickable: "true",
+            heading: "Block visit dates or sessions" if features.sessionDateBlocks else "Block visit dates",
+            description: "Block or unblock dates or sessions for social visits" if features.sessionDateBlocks else "Block or unblock dates for social visits",
+            id: "block-dates-or-sessions"
+          }) }}
+        </li>
 
         {% if showVisitAllowanceTile %}
           <li class="govuk-grid-column-one-third card-group__item">


### PR DESCRIPTION
* Update the path for 'Block visit dates or sessions' pages from `/block-visit-dates` to `/block-visit-dates-or-sessions`
* When the feature (`FEATURE_SESSION_DATE_BLOCKS`) is disabled the new path is used but the content only references date blocks and session blocking isn't available