### PR TITLE
Improve user journey for linking prisoners with no contacts

### DIFF
--- a/server/routes/bookerManagement/visitorRequests/visitorRequestDetailsController.test.ts
+++ b/server/routes/bookerManagement/visitorRequests/visitorRequestDetailsController.test.ts
@@ -182,7 +182,8 @@ describe('Booker management - visitor requests - link a visitor', () => {
           // Visitor list
           expect($('[data-test=no-dob-warning]').text()).toContain('must have a date of birth')
           expect($('[data-test=no-visitors-warning]').length).toBe(0)
-          expect($('[data-test=visitor-1-select] input').length).toBe(0)
+          expect($('[data-test=visitor-1-select] input').length).toBe(1)
+          expect($('[data-test=visitor-1-select] input').prop('disabled')).toBe(true)
           expect($('[data-test=visitor-1-name]').text()).toBe('Jeanette Smith')
           expect($('[data-test=visitor-1-dob]').text()).toBe('Not entered')
           expect($('[data-test=visitor-1-last-visit]').text()).toBe('None')

--- a/server/views/pages/bookerManagement/visitorRequests/visitorRequestDetails.njk
+++ b/server/views/pages/bookerManagement/visitorRequests/visitorRequestDetails.njk
@@ -11,7 +11,7 @@
   {# Radio input markup or blank for contacts with no DoB #}
   {% set selectContactInputHtml %}
     <div class="govuk-radios__item">
-      <input class="govuk-radios__input" id="visitor-{{ loop.index }}" name="visitorId" type="radio" value="{{ contact.visitorId }}">
+      <input class="govuk-radios__input" id="visitor-{{ loop.index }}" name="visitorId" type="radio" value="{{ contact.visitorId }}" {{"disabled" if not contact.dateOfBirth}}>
       <label class="govuk-label govuk-radios__label" for="visitor-{{ loop.index }}">
         <span class="govuk-visually-hidden">Select {{ contact.firstName }} {{ contact.lastName }}</span>
       </label>
@@ -20,7 +20,7 @@
 
   {% set contactRows = (contactRows.push([
     {
-      html: selectContactInputHtml if contact.dateOfBirth,
+      html: selectContactInputHtml,
       classes: "govuk-!-padding-top-6 govuk-!-padding-bottom-6" if not contact.dateOfBirth,
       attributes: { "data-test": "visitor-" + loop.index + "-select" }
     },

--- a/server/views/pages/bookerManagement/visitorRequests/visitorRequestDetails.njk
+++ b/server/views/pages/bookerManagement/visitorRequests/visitorRequestDetails.njk
@@ -65,7 +65,9 @@
         <span data-test="prisoner-name">{{ (visitorRequest.prisonerFirstName + " " + visitorRequest.prisonerLastName) | properCaseFullName }}</span>’s visitors
       </h2>
 
-      <p>Visitors already linked to this prisoner are not shown.</p>
+      {% if hasLinkedVisitors %}
+        <p>Visitors already linked to this prisoner are not shown.</p>
+      {% endif %}
 
       {{ govukWarningText({
         text: "Contacts must have a date of birth before they can be added as a visitor.",
@@ -73,8 +75,12 @@
         attributes: { "data-test": "no-dob-warning" }
       }) if showNoDobWarning }}
 
+      {% set extraText %}
+         {{ "that are not already " if hasLinkedVisitors else "" }}
+      {% endset %}
+
       {{ govukWarningText({
-        text: "The prisoner does not have any visitors that are not already linked to the booker’s account. " +
+        text: "The prisoner does not have any visitors " + extraText + "linked to the booker’s account. " +
           "Any new visitors will need to be added as social contacts before they can be linked.",
         iconFallbackText: "Warning",
         classes: "govuk-!-width-two-thirds",
@@ -135,11 +141,19 @@
             classes: "govuk-!-margin-top-3",
             preventDoubleClick: true
           }) }}
-        {% else %}
+        {% elif hasLinkedVisitors %}
           {{ govukButton({
             text: "Check linked visitors",
             href: "/manage-bookers/visitor-request/" + visitorRequest.reference + "/check-linked-visitors",
             attributes: { "data-test": "check-linked-visitors" },
+            classes: "govuk-!-margin-top-3",
+            preventDoubleClick: true
+          }) }}
+         {% else %}
+          <input id="visitor-none" name="visitorId" type="hidden" value="reject">
+          {{ govukButton({
+            text: "Reject the request",
+            attributes: { "data-test": "reject-visitor" },
             classes: "govuk-!-margin-top-3",
             preventDoubleClick: true
           }) }}


### PR DESCRIPTION
Standard flow. No changes.
<img width="624" height="459" alt="Screenshot 2026-07-15 at 16 13 39" src="https://github.com/user-attachments/assets/db72558d-8b60-4971-9fc6-9369cacbebec" />

Standard flow; no existing links (message removed).
<img width="616" height="445" alt="Screenshot 2026-07-15 at 16 14 37" src="https://github.com/user-attachments/assets/54857484-ec4a-4bbc-85e0-8adbaaf9d968" />

None of them have birthdays; existing links available. Guides admin to review.
<img width="592" height="440" alt="Screenshot 2026-07-15 at 16 14 06" src="https://github.com/user-attachments/assets/cd09f522-6dc6-4e59-990e-7378d8b34810" />

None of them have birthdays; no existing links. No further action can be taken. Guides admin to reject.
<img width="599" height="416" alt="Screenshot 2026-07-15 at 16 14 19" src="https://github.com/user-attachments/assets/9cd27bfa-9346-4258-877b-1c9fef36cd59" />


No unlinked visitors. Existing links available. Guides admin to review.
<img width="444" height="253" alt="Screenshot 2026-07-15 at 16 15 10" src="https://github.com/user-attachments/assets/4cddb32e-52b7-4862-9f0e-947e74433ddd" />

No unlinked visitors. No existing links available. Guides admin to reject.
<img width="441" height="271" alt="Screenshot 2026-07-15 at 16 15 38" src="https://github.com/user-attachments/assets/6b95b8b3-1d05-4388-b0e6-5e236434f417" />
