### PR TITLE
Bug fix: helper function mutating arrays

### DIFF
--- a/server/routes/timetable/timetableItemBuilder.ts
+++ b/server/routes/timetable/timetableItemBuilder.ts
@@ -10,6 +10,13 @@ export type TimetableItem = {
   frequency: string
   endDate: string
 }
+
+// Formats as, e.g.  "A, B and C" (and handles cases of zero, one or two items)
+const listFormatter = new Intl.ListFormat('en-GB', {
+  style: 'long',
+  type: 'conjunction',
+})
+
 // Builds timetable rows, using all session schedules for the selected date
 export default ({
   schedules,
@@ -58,21 +65,6 @@ export default ({
   return timetableItems
 }
 
-// Takes all group names for particular type, and joins together
-const mergeGroupNames = (groupNames: string[]): string => {
-  if (groupNames.length === 0) {
-    return ''
-  }
-  if (groupNames.length === 1) {
-    return groupNames[0]
-  }
-
-  const lastItem = groupNames.pop()
-  const joined = groupNames.join(', ')
-
-  return `${joined} and ${lastItem}`
-}
-
 // Function to build description of groups included/excluded from this particular session
 export const buildAttendeesText = ({
   prisonerCategoryGroupNames,
@@ -98,9 +90,9 @@ export const buildAttendeesText = ({
     return 'All prisoners'
   }
 
-  const categoryNames = mergeGroupNames(prisonerCategoryGroupNames)
-  const incentiveNames = mergeGroupNames(prisonerIncentiveLevelGroupNames)
-  const locationNames = mergeGroupNames(prisonerLocationGroupNames)
+  const categoryNames = listFormatter.format(prisonerCategoryGroupNames)
+  const incentiveNames = listFormatter.format(prisonerIncentiveLevelGroupNames)
+  const locationNames = listFormatter.format(prisonerLocationGroupNames)
 
   if (categoryNames && incentiveNames && locationNames) {
     if (areCategoryGroupsInclusive && areIncentiveGroupsInclusive && areLocationGroupsInclusive) {


### PR DESCRIPTION
Helper function that builds lists of session template group names had a long-standing bug in that it mutated the data passed to it (because of using `Array.pop()`.

Didn't cause an issue previously but did affect new session template blocking feature that relied on this helper - the returned names would get shorter!