### PR TITLE
VB-6840 Visit session blocks: include visit room name

### DIFF
--- a/integration_tests/specs/blockDatesOrSessions/blockDatesAndSessions.spec.ts
+++ b/integration_tests/specs/blockDatesOrSessions/blockDatesAndSessions.spec.ts
@@ -177,7 +177,7 @@ test.describe('Block visit dates and sessions', () => {
 
       // Choose which session to block page
       const blockSessionChoosePage = await BlockSessionChoosePage.verifyOnPage(page, firstOfNextMonthLong)
-      await blockSessionChoosePage.selectSession('2pm to 3:30pm, All prisoners') // afternoon session
+      await blockSessionChoosePage.selectSession('2pm to 3:30pm (Visits hall), All prisoners') // afternoon session
       await orchestrationApi.stubGetVisitsBySessionTemplate({
         reference: afternoonSession.sessionTemplateReference,
         sessionDate: firstOfNextMonthShort,
@@ -187,7 +187,7 @@ test.describe('Block visit dates and sessions', () => {
 
       // Confirmation page
       const blockSessionConfirmPage = await BlockSessionConfirmPage.verifyOnPage(page, firstOfNextMonthLong)
-      await expect(blockSessionConfirmPage.sessionDetails).toContainText('2pm to 3:30pm, All prisoners')
+      await expect(blockSessionConfirmPage.sessionDetails).toContainText('2pm to 3:30pm (Visits hall), All prisoners')
 
       // Stub adding session date block
       await orchestrationApi.stubBlockVisitSession({
@@ -215,7 +215,7 @@ test.describe('Block visit dates and sessions', () => {
       // Verify success message and blocked date exists
       await expect(blockDatesOrSessionsPage.messages).toBeVisible()
       await expect(blockDatesOrSessionsPage.messages).toContainText(
-        `Visits are blocked on ${firstOfNextMonthLong} for 2pm to 3:30pm, All prisoners`,
+        `Visits are blocked on ${firstOfNextMonthLong} for 2pm to 3:30pm (Visits hall), All prisoners`,
       )
 
       await expect(blockDatesOrSessionsPage.blockedDate(1)).toContainText(firstOfNextMonthLong)
@@ -250,6 +250,7 @@ test.describe('Block visit dates and sessions', () => {
       const blockDatesOrSessionsPage = await BlockDatesOrSessionsPage.verifyOnPage(page)
       await expect(blockDatesOrSessionsPage.blockedDate(1)).toContainText(firstOfNextMonthLong)
       await expect(blockDatesOrSessionsPage.blockedWhen(1)).toContainText('9am to 10am')
+      await expect(blockDatesOrSessionsPage.blockedWhen(1)).toContainText('Visits hall')
       await expect(blockDatesOrSessionsPage.blockedAttendees(1)).toContainText('All prisoners')
       await expect(blockDatesOrSessionsPage.blockedBy(1)).toContainText('User two')
       await expect(blockDatesOrSessionsPage.unblockLink(1)).toContainText('Unblock')
@@ -274,7 +275,7 @@ test.describe('Block visit dates and sessions', () => {
       // Verify success message
       await expect(blockDatesOrSessionsPage.messages).toBeVisible()
       await expect(blockDatesOrSessionsPage.messages).toContainText(
-        `Visits are unblocked on ${firstOfNextMonthLong} for 9am to 10am, All prisoners`,
+        `Visits are unblocked on ${firstOfNextMonthLong} for 9am to 10am (Visits hall), All prisoners`,
       )
 
       // Verify no upcoming blocked dates or sessions

--- a/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.test.ts
@@ -179,7 +179,8 @@ describe('Block visit dates and sessions listing page', () => {
 
           // Row 2
           expect($('[data-test="blocked-date-2"]').text()).toBe('Thursday 2 July 2026')
-          expect($('[data-test="blocked-when-2"]').text()).toBe('10am to 11:30am')
+          expect($('[data-test="blocked-when-2"]').text()).toContain('10am to 11:30am')
+          expect($('[data-test="blocked-when-2"]').text()).toContain('Visits hall')
           expect($('[data-test="blocked-attendees-2"]').text()).toBe('All prisoners')
           expect($('[data-test="unblock-2"]').text().trim()).toBe('Unblock')
           expect($('[data-test="unblock-2"]').parent().attr('action')).toBe(

--- a/server/routes/blockDatesOrSessions/blockSessions/blockSessionChooseController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/blockSessionChooseController.test.ts
@@ -66,10 +66,14 @@ describe('Choose which session to block', () => {
           expect($('input[name=sessionTemplateReference]:checked').length).toBe(0)
           // session 1
           expect($('input[name=sessionTemplateReference]').eq(0).val()).toBe('session-1')
-          expect($('label[for=sessionTemplateReference]').text().trim()).toBe('10am to 11am, All prisoners')
+          expect($('label[for=sessionTemplateReference]').text().trim()).toBe(
+            '10am to 11am (Visits hall), All prisoners',
+          )
           // session 2 (blocked)
           expect($('input[name=sessionTemplateReference]').eq(1).val()).toBe('session-2')
-          expect($('label[for=sessionTemplateReference-2]').text().trim()).toBe('2pm to 3pm, Prisoners on Standard')
+          expect($('label[for=sessionTemplateReference-2]').text().trim()).toBe(
+            '2pm to 3pm (Visits hall), Prisoners on Standard',
+          )
           expect($('input[name=sessionTemplateReference]').eq(1).prop('disabled')).toBe(true)
 
           expect($('[data-test=submit]').text().trim()).toBe('Continue')

--- a/server/routes/blockDatesOrSessions/blockSessions/blockSessionChooseController.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/blockSessionChooseController.ts
@@ -91,7 +91,7 @@ export default class BlockSessionChooseController {
       const attendees = buildAttendeesText({ ...session })
       return {
         value: session.sessionTemplateReference,
-        text: `${time}, ${attendees}`,
+        text: `${time} (${session.visitRoom}), ${attendees}`,
         ...(session.isSessionExcluded && { disabled: true }),
       }
     })

--- a/server/routes/blockDatesOrSessions/blockSessions/blockSessionConfirmController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/blockSessionConfirmController.test.ts
@@ -63,7 +63,7 @@ describe('Confirm session block', () => {
             'Are you sure you want to block visits for this session on Friday 6 September 2024?',
           )
 
-          expect($('[data-test=session-details]').text()).toBe('10am to 11am, All prisoners')
+          expect($('[data-test=session-details]').text()).toBe('10am to 11am (Visits hall), All prisoners')
 
           expect($('[data-test=no-existing-bookings]').length).toBe(1)
           expect($('[data-test=existing-bookings]').length).toBe(0)
@@ -166,7 +166,7 @@ describe('Confirm session block', () => {
           expect(flashProvider).toHaveBeenCalledWith('messages', {
             variant: 'success',
             title: 'Visit session blocked for date',
-            html: 'Visits are blocked on Friday 6 September 2024 for 10am to 11am, <br>All prisoners',
+            html: 'Visits are blocked on Friday 6 September 2024 for 10am to 11am (Visits hall), <br>All prisoners',
           })
           expect(sessionData.blockDateOrSession).toBe(undefined)
         })

--- a/server/routes/blockDatesOrSessions/blockSessions/blockSessionConfirmController.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/blockSessionConfirmController.ts
@@ -42,6 +42,7 @@ export default class BlockSessionConfirmController {
         errors: req.flash('errors'),
         date,
         time,
+        visitRoom: selectedSession.visitRoom,
         attendees,
         visitCount,
       })

--- a/server/routes/blockDatesOrSessions/blockSessions/blockSessionsMessages.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/blockSessionsMessages.ts
@@ -15,11 +15,12 @@ export const getSessionUnblockedMessage = ({ date, session }: { date: string; se
 const buildMessage = (date: string, session: SessionSchedule, type: 'blocked' | 'unblocked'): MoJAlert => {
   const formattedDate = format(parseISO(date), 'EEEE d MMMM yyyy')
   const time = formatStartToEndTime(session.sessionTimeSlot.startTime, session.sessionTimeSlot.endTime)
+  const visitRoom = escapeHtml(session.visitRoom)
   const attendees = escapeHtml(buildAttendeesText({ ...session }))
 
   return {
     variant: 'success',
     title: `Visit session ${type} for date`,
-    html: `Visits are ${type} on ${formattedDate} for ${time} (${session.visitRoom}), <br>${attendees}`,
+    html: `Visits are ${type} on ${formattedDate} for ${time} (${visitRoom}), <br>${attendees}`,
   }
 }

--- a/server/routes/blockDatesOrSessions/blockSessions/blockSessionsMessages.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/blockSessionsMessages.ts
@@ -20,6 +20,6 @@ const buildMessage = (date: string, session: SessionSchedule, type: 'blocked' | 
   return {
     variant: 'success',
     title: `Visit session ${type} for date`,
-    html: `Visits are ${type} on ${formattedDate} for ${time}, <br>${attendees}`,
+    html: `Visits are ${type} on ${formattedDate} for ${time} (${session.visitRoom}), <br>${attendees}`,
   }
 }

--- a/server/routes/blockDatesOrSessions/blockSessions/unblockSessionController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockSessions/unblockSessionController.test.ts
@@ -52,7 +52,7 @@ describe('Unblock visit session', () => {
           expect(flashProvider).toHaveBeenCalledWith('messages', {
             variant: 'success',
             title: 'Visit session unblocked for date',
-            html: 'Visits are unblocked on Friday 6 September 2024 for 1:45pm to 3:45pm, <br>All prisoners',
+            html: 'Visits are unblocked on Friday 6 September 2024 for 1:45pm to 3:45pm (Visits hall), <br>All prisoners',
           })
           expect(flashProvider).toHaveBeenCalledTimes(1)
         })

--- a/server/routes/blockDatesOrSessions/blockedDatesAndSessionsTableBuilder.test.ts
+++ b/server/routes/blockDatesOrSessions/blockedDatesAndSessionsTableBuilder.test.ts
@@ -34,6 +34,7 @@ describe('buildBlockedDatesAndSessionsTable', () => {
       {
         date: '2026-07-01',
         when: '10am to 11:30am',
+        where: 'Visits hall',
         attendees: 'All prisoners',
         actionedBy: 'User Three',
         sessionTemplateReference: 'session-1',
@@ -42,6 +43,7 @@ describe('buildBlockedDatesAndSessionsTable', () => {
       {
         date: '2026-07-03',
         when: '1pm to 2:30pm',
+        where: 'Visits hall',
         attendees: 'Category A and Category B prisoners',
         actionedBy: 'User Four',
         sessionTemplateReference: 'session-2',

--- a/server/routes/blockDatesOrSessions/blockedDatesAndSessionsTableBuilder.ts
+++ b/server/routes/blockDatesOrSessions/blockedDatesAndSessionsTableBuilder.ts
@@ -5,6 +5,7 @@ import { buildAttendeesText } from '../timetable/timetableItemBuilder'
 export type BlockedDateOrSessionRow = {
   date: string // YYYY-MM-DD
   when: string
+  where?: string
   attendees: string
   actionedBy: string
   sessionTemplateReference?: string
@@ -33,6 +34,7 @@ const buildBlockedDatesAndSessionsTable = ({
         sessionExclusion.sessionTimeSlot?.endTime,
       ),
       attendees: buildAttendeesText({ ...sessionExclusion }),
+      where: sessionExclusion.visitRoom,
       actionedBy: sessionExclusion.excludeDate.actionedBy,
       sessionTemplateReference: sessionExclusion.sessionTemplateReference,
     })

--- a/server/views/pages/blockDatesOrSessions/blockDatesOrSessions.njk
+++ b/server/views/pages/blockDatesOrSessions/blockDatesOrSessions.njk
@@ -41,7 +41,7 @@
       attributes: { "data-test": "blocked-date-" + loop.index }
     },
     {
-      text: blockedDateOrSession.when,
+      html: blockedDateOrSession.when + "<br>" + (blockedDateOrSession.where | escape),
       attributes: { "data-test": "blocked-when-" + loop.index }
     },
     {

--- a/server/views/pages/blockDatesOrSessions/blockSessions/blockSessionConfirm.njk
+++ b/server/views/pages/blockDatesOrSessions/blockSessions/blockSessionConfirm.njk
@@ -11,7 +11,7 @@
 
       <h1 class="govuk-heading-l">{{ pageHeaderTitle }}</h1>
 
-      <p data-test="session-details">{{ time }}, {{ attendees }}</p>
+      <p data-test="session-details">{{ time }} ({{ visitRoom }}), {{ attendees }}</p>
 
       {% if visitCount %}
         <p data-test="existing-bookings">


### PR DESCRIPTION
Some visit sessions have the same times but are in different rooms. To disambiguate these this change adds the visit room name alongside the time slot in the session block / unblock journeys.

**Blocked dates or sessions listing page:**

<img width="1204" height="242" alt="Screenshot 2026-07-16 at 12 45 45" src="https://github.com/user-attachments/assets/4a741296-f331-4ff1-9630-a1a4cb2ad720" />



**Choose which session to block page:**

<img width="771" height="362" alt="Screenshot 2026-07-16 at 12 46 24" src="https://github.com/user-attachments/assets/457d40a0-7641-400c-ab6f-8c1030147b76" />



**Success banner:**
<img width="822" height="110" alt="Screenshot 2026-07-16 at 12 47 33" src="https://github.com/user-attachments/assets/9461f984-8b1c-4ea1-b73b-13aea667c359" />
