### PR TITLE
Tidy 'start-to-end time' formatting

### DIFF
--- a/integration_tests/specs/prisoner/prisonerProfile.spec.ts
+++ b/integration_tests/specs/prisoner/prisonerProfile.spec.ts
@@ -100,7 +100,7 @@ test.describe('Prisoner profile page', () => {
     )
     await expect(prisonerProfilePage.visitTabType.nth(0)).toContainText('Social')
     await expect(prisonerProfilePage.visitTabLocation.nth(0)).toContainText('Hewell (HMP)')
-    await expect(prisonerProfilePage.visitTabDateAndTime.nth(0)).toContainText(/(Friday 14 January 2022)(10am - 11am)/)
+    await expect(prisonerProfilePage.visitTabDateAndTime.nth(0)).toContainText(/(Friday 14 January 2022)(10am to 11am)/)
     await expect(prisonerProfilePage.visitTabVisitors.nth(0)).toContainText(/(Jeanette Smith)(Bob Smith)/)
     await expect(prisonerProfilePage.visitTabVisitStatus.nth(0)).toContainText('Booked')
     await expect(prisonerProfilePage.visitTabViewFullHistory).toHaveAttribute(

--- a/server/routes/prisoner/prisonerProfileController.test.ts
+++ b/server/routes/prisoner/prisonerProfileController.test.ts
@@ -260,7 +260,7 @@ describe('/prisoner/:offenderNo - Prisoner profile', () => {
             'Hewell (HMP)',
           )
           expect($('.prisoner-profile-visits:nth-child(1) [data-test="tab-visits-date-and-time"]').eq(0).html()).toBe(
-            'Thursday 2 March 2023<br>10am - 11am',
+            'Thursday 2 March 2023<br>10am to 11am',
           )
           expect($('.prisoner-profile-visits:nth-child(1) [data-test="tab-visits-visitors"]').eq(0).html()).toBe(
             'Jeanette Smith<br>Bob Smith',

--- a/server/routes/timetable/timetableController.ts
+++ b/server/routes/timetable/timetableController.ts
@@ -22,7 +22,7 @@ export default class TimetableController {
         includeExcludedSessions: false,
       })
 
-      const timetableItems = timetableItemBuilder({ schedules, selectedDate })
+      const timetableItems = timetableItemBuilder(schedules)
 
       return res.render('pages/timetable', {
         schedules,

--- a/server/routes/timetable/timetableItemBuilder.test.ts
+++ b/server/routes/timetable/timetableItemBuilder.test.ts
@@ -1,24 +1,22 @@
+import { SessionSchedule } from '../../data/orchestrationApiTypes'
 import TestData from '../testutils/testData'
 import timetableItemBuilder, { TimetableItem } from './timetableItemBuilder'
 
 describe('timetableItemBuilder - Build timetable rows from visit schedules', () => {
-  let params: Parameters<typeof timetableItemBuilder>[0]
+  let schedules: SessionSchedule[]
 
   beforeEach(() => {
-    params = {
-      schedules: [],
-      selectedDate: '2025-05-05',
-    }
+    schedules = []
   })
 
   it('should return an empty array of timetable items if no visit schedules found', () => {
     const expectedTimetable: TimetableItem[] = []
-    const timetable = timetableItemBuilder(params)
+    const timetable = timetableItemBuilder(schedules)
     expect(timetable).toStrictEqual(expectedTimetable)
   })
 
   it('should return "all prisoners" for who can attend, if no category group names present', () => {
-    params.schedules = [
+    schedules = [
       TestData.sessionSchedule({
         prisonerCategoryGroupNames: [],
         prisonerIncentiveLevelGroupNames: [],
@@ -36,12 +34,12 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
         endDate: 'Not entered',
       },
     ]
-    const timetable = timetableItemBuilder(params)
+    const timetable = timetableItemBuilder(schedules)
     expect(timetable).toStrictEqual(expectedTimetable)
   })
 
   it('should correctly concatenate group names, dependant on number of names present', () => {
-    params.schedules = [
+    schedules = [
       TestData.sessionSchedule({
         prisonerCategoryGroupNames: ['Category 1'],
         prisonerIncentiveLevelGroupNames: ['Incentive 1', 'Incentive 2'],
@@ -58,12 +56,12 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
         endDate: 'Not entered',
       },
     ]
-    const timetable = timetableItemBuilder(params)
+    const timetable = timetableItemBuilder(schedules)
     expect(timetable).toStrictEqual(expectedTimetable)
   })
 
   it('should correctly display different schedule frequency options', () => {
-    params.schedules = [
+    schedules = [
       TestData.sessionSchedule({
         sessionDateRange: {
           validToDate: '2025-05-05',
@@ -100,12 +98,12 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
         endDate: 'Not entered',
       },
     ]
-    const timetable = timetableItemBuilder(params)
+    const timetable = timetableItemBuilder(schedules)
     expect(timetable).toStrictEqual(expectedTimetable)
   })
 
   it('should correctly show capacity when both open and closed tables are available', () => {
-    params.schedules = [
+    schedules = [
       TestData.sessionSchedule({
         capacity: {
           open: 15,
@@ -131,7 +129,7 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
         capacity: '25 tables',
       },
     ]
-    const timetable = timetableItemBuilder(params)
+    const timetable = timetableItemBuilder(schedules)
     expect(timetable).toStrictEqual(expectedTimetable)
   })
 
@@ -141,7 +139,7 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
       prisonerIncentiveLevelGroupNames: ['Incentive'],
       prisonerLocationGroupNames: ['Location'],
     }
-    params.schedules = [
+    schedules = [
       TestData.sessionSchedule({
         ...groupNames,
         areCategoryGroupsInclusive: false,
@@ -222,7 +220,7 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
         attendees: 'Category prisoners on Incentive in Location',
       },
     ]
-    const timetable = timetableItemBuilder(params)
+    const timetable = timetableItemBuilder(schedules)
     expect(timetable).toStrictEqual(expectedTimetable)
   })
 
@@ -232,7 +230,7 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
       prisonerIncentiveLevelGroupNames: ['Incentive'],
       prisonerLocationGroupNames: [''],
     }
-    params.schedules = [
+    schedules = [
       TestData.sessionSchedule({
         ...groupNames,
         areCategoryGroupsInclusive: true,
@@ -282,7 +280,7 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
         attendees: 'All prisoners except Category prisoners and prisoners on Incentive',
       },
     ]
-    const timetable = timetableItemBuilder(params)
+    const timetable = timetableItemBuilder(schedules)
     expect(timetable).toStrictEqual(expectedTimetable)
   })
 
@@ -292,7 +290,7 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
       prisonerIncentiveLevelGroupNames: [''],
       prisonerLocationGroupNames: ['Location'],
     }
-    params.schedules = [
+    schedules = [
       TestData.sessionSchedule({
         ...groupNames,
         areCategoryGroupsInclusive: true,
@@ -339,7 +337,7 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
         attendees: 'All prisoners except Category prisoners and prisoners in Location',
       },
     ]
-    const timetable = timetableItemBuilder(params)
+    const timetable = timetableItemBuilder(schedules)
     expect(timetable).toStrictEqual(expectedTimetable)
   })
 
@@ -349,7 +347,7 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
       prisonerIncentiveLevelGroupNames: ['Incentive'],
       prisonerLocationGroupNames: ['Location'],
     }
-    params.schedules = [
+    schedules = [
       TestData.sessionSchedule({
         ...groupNames,
         areIncentiveGroupsInclusive: true,
@@ -396,12 +394,12 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
         attendees: 'All prisoners except prisoners on Incentive and prisoners in Location',
       },
     ]
-    const timetable = timetableItemBuilder(params)
+    const timetable = timetableItemBuilder(schedules)
     expect(timetable).toStrictEqual(expectedTimetable)
   })
 
   it('should display correct group name orders, when just one group name present', () => {
-    params.schedules = [
+    schedules = [
       TestData.sessionSchedule({
         prisonerCategoryGroupNames: ['Category'],
         prisonerIncentiveLevelGroupNames: [''],
@@ -472,7 +470,7 @@ describe('timetableItemBuilder - Build timetable rows from visit schedules', () 
         attendees: 'All prisoners except prisoners in Location',
       },
     ]
-    const timetable = timetableItemBuilder(params)
+    const timetable = timetableItemBuilder(schedules)
     expect(timetable).toStrictEqual(expectedTimetable)
   })
 })

--- a/server/routes/timetable/timetableItemBuilder.ts
+++ b/server/routes/timetable/timetableItemBuilder.ts
@@ -1,6 +1,6 @@
 import { format, parseISO } from 'date-fns'
 import { SessionSchedule } from '../../data/orchestrationApiTypes'
-import { prisonerTimePretty } from '../../utils/utils'
+import { formatStartToEndTime } from '../../utils/utils'
 
 export type TimetableItem = {
   time: string
@@ -18,20 +18,14 @@ const listFormatter = new Intl.ListFormat('en-GB', {
 })
 
 // Builds timetable rows, using all session schedules for the selected date
-export default ({
-  schedules,
-  selectedDate,
-}: {
-  schedules: SessionSchedule[]
-  selectedDate: string
-}): TimetableItem[] => {
+export default (schedules: SessionSchedule[]): TimetableItem[] => {
   const dateFormat = 'd MMMM yyyy'
   const timetableItems: TimetableItem[] = []
   schedules.forEach(schedule => {
     const { validToDate, validFromDate } = schedule.sessionDateRange
     const { startTime, endTime } = schedule.sessionTimeSlot
 
-    const time = `${prisonerTimePretty(`${selectedDate}T${startTime}`)} to ${prisonerTimePretty(`${selectedDate}T${endTime}`)}`
+    const time = formatStartToEndTime(startTime, endTime)
 
     const endDate = validToDate ? format(parseISO(validToDate), dateFormat) : 'Not entered'
 

--- a/server/routes/visitsByDate/visitsUtils.ts
+++ b/server/routes/visitsByDate/visitsUtils.ts
@@ -1,6 +1,6 @@
 import { format, parse, add } from 'date-fns'
 import { VisitsPageSideNav, VisitsPageSideNavItem } from '../../@types/bapv'
-import { getParsedDateFromQueryString, prisonerTimePretty } from '../../utils/utils'
+import { getParsedDateFromQueryString, formatStartToEndTime } from '../../utils/utils'
 import { SessionSchedule, VisitPreview } from '../../data/orchestrationApiTypes'
 
 export const getDateTabs = (
@@ -69,7 +69,7 @@ export function getSessionsSideNav(
     }
     const sideNavForRoom = sessionsSideNav.get(session.visitRoom)
 
-    const times = sessionTimeSlotToString(session.sessionTimeSlot)
+    const times = formatStartToEndTime(session.sessionTimeSlot.startTime, session.sessionTimeSlot.endTime)
 
     const queryParams = new URLSearchParams({
       sessionReference: session.sessionTemplateReference,
@@ -108,7 +108,7 @@ export function getSessionsSideNav(
 
       unknownVisitsNavItems.push({
         reference: timeSlotReference,
-        times: sessionTimeSlotToString(visit.visitTimeSlot),
+        times: formatStartToEndTime(visit.visitTimeSlot.startTime, visit.visitTimeSlot.endTime),
         queryParams,
         active: selectedReference === timeSlotReference,
       })
@@ -127,10 +127,4 @@ export function getSessionsSideNav(
   sessionsSideNav.set('All visits', unknownVisitsNavItems)
 
   return sessionsSideNav
-}
-
-function sessionTimeSlotToString(sessionTimeSlot: SessionSchedule['sessionTimeSlot']): string {
-  const startTime = prisonerTimePretty(parse(sessionTimeSlot.startTime, 'HH:mm', new Date()).toISOString())
-  const endTime = prisonerTimePretty(parse(sessionTimeSlot.endTime, 'HH:mm', new Date()).toISOString())
-  return `${startTime} to ${endTime}`
 }

--- a/server/services/visitService.ts
+++ b/server/services/visitService.ts
@@ -13,7 +13,7 @@ import {
 } from '../data/orchestrationApiTypes'
 import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
 import logger from '../../logger'
-import { prisonerDateTimePretty, prisonerTimePretty } from '../utils/utils'
+import { formatStartToEndTime, prisonerDateTimePretty } from '../utils/utils'
 
 export default class VisitService {
   constructor(
@@ -245,15 +245,13 @@ export default class VisitService {
   }
 
   private buildVisitInformation(visit: Visit): VisitInformation {
-    const visitTime = `${prisonerTimePretty(visit.startTimestamp)} to ${prisonerTimePretty(visit.endTimestamp)}`
-
     return {
       reference: visit.reference,
       prisonNumber: visit.prisonerId,
       prisonerName: '',
       mainContact: visit.visitContact?.name,
       visitDate: prisonerDateTimePretty(visit.startTimestamp),
-      visitTime,
+      visitTime: formatStartToEndTime(visit.startTimestamp, visit.endTimestamp),
       visitStatus: visit.visitStatus,
       visitSubStatus: visit.visitSubStatus,
     }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -197,7 +197,9 @@ describe('formatStartToEndTime', () => {
     ['13:00', '14:00', '1pm to 2pm'],
     ['13:15', '14:30', '1:15pm to 2:30pm'],
     ['23:00', '00:00', '11pm to 12am'],
+    ['2022-01-14T10:00:00', '2022-01-14T13:30:00', '10am to 1:30pm'],
     ['', '', ''],
+    ['123', 'abc', ''],
     [undefined, undefined, ''],
   ])('%s - %s - %s', (startTime: string, endTime: string, expected: string) => {
     expect(formatStartToEndTime(startTime, endTime)).toBe(expected)

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -171,11 +171,12 @@ export const isMobilePhoneNumber = (phoneNumber: string): boolean => {
 }
 
 // E.g. 10:00, 13:30 => "10am to 1:30pm"
+// Handles either 5-digit 24H times (HH:mm format) or ISO date strings
 export const formatStartToEndTime = (startTime: string, endTime: string): string => {
   try {
     const now = new Date()
-    const startTimeAsDate = parse(startTime, 'HH:mm', now)
-    const endTimeAsDate = parse(endTime, 'HH:mm', now)
+    const startTimeAsDate = startTime.length === 5 ? parse(startTime, 'HH:mm', now) : parseISO(startTime)
+    const endTimeAsDate = endTime.length === 5 ? parse(endTime, 'HH:mm', now) : parseISO(endTime)
     const startTimeAs12h = format(startTimeAsDate, 'h:mmaaa')
     const endTimeAs12h = format(endTimeAsDate, 'h:mmaaa')
 

--- a/server/views/pages/prisoner/profile.njk
+++ b/server/views/pages/prisoner/profile.njk
@@ -166,7 +166,7 @@
               },
               {
                 html: visit.startTimestamp | formatDate("EEEE d MMMM yyy") + '<br>' +
-                  visit.startTimestamp | formatTime + ' - ' + visit.endTimestamp | formatTime,
+                  ({ startTime: visit.startTimestamp, endTime: visit.endTimestamp} | formatStartToEndTime),
                 attributes: { "data-test": "tab-visits-date-and-time" },
                 classes: visitRowsClass
               },

--- a/server/views/pages/visit/cancelConfirmation.njk
+++ b/server/views/pages/visit/cancelConfirmation.njk
@@ -16,7 +16,9 @@
     <h2 class="govuk-heading-m govuk-!-margin-top-6">What happens next</h2>
     {% if startTimestamp and endTimestamp %}
       <p>The visit booking for
-        <span data-test="visit-details">{{ startTimestamp | formatTime }} to {{ endTimestamp | formatTime }} on {{ startTimestamp | formatDate('EEEE d MMMM yyyy') }}</span>
+        <span data-test="visit-details">
+          {{- { startTime: startTimestamp, endTime: endTimestamp } | formatStartToEndTime }} on {{ startTimestamp | formatDate('EEEE d MMMM yyyy') -}}
+        </span>
         has been cancelled.</p>
     {% endif %}
     {% if hasEmailAddress or hasMobileNumber %}

--- a/server/views/pages/visit/visitDetails.njk
+++ b/server/views/pages/visit/visitDetails.njk
@@ -26,7 +26,9 @@
           <li data-test="visit-date">{{ visitDetails.startTimestamp | formatDate("EEEE d MMMM yyyy") }}</li>
 
           <li>
-            <span data-test="visit-time">{{ visitDetails.startTimestamp | formatTime + " to " + visitDetails.endTimestamp | formatTime }}</span> –
+            <span data-test="visit-time">
+              {{- { startTime: visitDetails.startTimestamp, endTime: visitDetails.endTimestamp } | formatStartToEndTime -}}
+            </span>
             <span data-test="visit-room">{{ visitDetails.visitRoom }}</span>
           </li>
 


### PR DESCRIPTION
* Standardise various ways there were in the code for formatting start-to-end times, e.g. `10am to 11:30am`
* Change instances of time spans using `'-'` rather than `'to'` as a separator (in order to follow GDS guidelines)

