### PR TITLE
VB-6834 Remove deprecated future exclude dates endpoint

### DIFF
--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -809,26 +809,6 @@ export default {
     })
   },
 
-  stubGetFutureBlockedDates: ({
-    prisonId = 'HEI',
-    blockedDates = [],
-  }: {
-    prisonId?: string
-    blockedDates: ExcludeDateDto[]
-  }): SuperAgentRequest => {
-    return stubFor({
-      request: {
-        method: 'GET',
-        url: `/orchestration/config/prisons/prison/${prisonId}/exclude-date/future`,
-      },
-      response: {
-        status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: blockedDates,
-      },
-    })
-  },
-
   stubIsBlockedDate: ({
     prisonId,
     excludeDate,

--- a/integration_tests/specs/blockDatesOrSessions/blockDatesAndSessions.spec.ts
+++ b/integration_tests/specs/blockDatesOrSessions/blockDatesAndSessions.spec.ts
@@ -49,7 +49,6 @@ test.describe('Block visit dates and sessions', () => {
       await blockDatesOrSessionsPage.datePicker.selectDay(1)
 
       // Stub booked visits count and no scheduled sessions for the selected date
-      await orchestrationApi.stubGetFutureBlockedDates({ blockedDates: [] }) // TODO this can be removed once this deprecated endpoint is replaced
       await orchestrationApi.stubGetBookedVisitCountByDate({
         date: firstOfNextMonthShort,
         count: 0,
@@ -160,7 +159,6 @@ test.describe('Block visit dates and sessions', () => {
       await blockDatesOrSessionsPage.datePicker.selectDay(1)
 
       // Stub booked visits count and no scheduled sessions for the selected date
-      await orchestrationApi.stubGetFutureBlockedDates({ blockedDates: [] }) // TODO this can be removed once this deprecated endpoint is replaced
       await orchestrationApi.stubGetBookedVisitCountByDate({ date: firstOfNextMonthShort, count: 0 })
       await orchestrationApi.stubSessionSchedule({
         date: firstOfNextMonthShort,

--- a/integration_tests/specs/blockDatesOrSessions/blockDatesAndSessions.spec.ts
+++ b/integration_tests/specs/blockDatesOrSessions/blockDatesAndSessions.spec.ts
@@ -33,6 +33,8 @@ test.describe('Block visit dates and sessions', () => {
   test.describe('Block visit dates', () => {
     test('should block a new date - where date has no sessions to block', async ({ page }) => {
       await orchestrationApi.stubGetFutureBlockedDatesAndSessions({ includeSessions: true })
+      await orchestrationApi.stubGetFutureBlockedDatesAndSessions({ includeSessions: false })
+
       await login(page)
       const homePage = await HomePage.verifyOnPage(page)
       await homePage.blockDatesTile.click()
@@ -143,6 +145,8 @@ test.describe('Block visit dates and sessions', () => {
 
     test('should block a visit session', async ({ page }) => {
       await orchestrationApi.stubGetFutureBlockedDatesAndSessions({ includeSessions: true })
+      await orchestrationApi.stubGetFutureBlockedDatesAndSessions({ includeSessions: false })
+
       await login(page)
       const homePage = await HomePage.verifyOnPage(page)
       await homePage.blockDatesTile.click()

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -883,21 +883,6 @@ describe('orchestrationApiClient', () => {
     })
   })
 
-  describe('getFutureBlockedDates', () => {
-    it('should return future blocked dates for given prison', async () => {
-      const results = [TestData.excludeDateDto()]
-
-      fakeOrchestrationApi
-        .get(`/config/prisons/prison/${prisonId}/exclude-date/future`)
-        .matchHeader('authorization', `Bearer ${token}`)
-        .reply(200, results)
-
-      const output = await orchestrationApiClient.getFutureBlockedDates(prisonId)
-
-      expect(output).toStrictEqual(results)
-    })
-  })
-
   describe('isBlockedDate', () => {
     it('should return boolean indicating whether given date is a blocked', async () => {
       const results = { isExcluded: true }

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -480,11 +480,6 @@ export default class OrchestrationApiClient {
     })
   }
 
-  // FIXME this endpoint is deprecated; remove this and wiremock stub and use call above with includeSessions=false instead
-  async getFutureBlockedDates(prisonId: string): Promise<ExcludeDateDto[]> {
-    return this.restClient.get({ path: `/config/prisons/prison/${prisonId}/exclude-date/future` })
-  }
-
   async isBlockedDate(prisonCode: string, excludeDate: string): Promise<boolean> {
     const { isExcluded } = await this.restClient.get<IsExcludeDateDto>({
       path: `/config/prisons/prison/${prisonCode}/exclude-date/${excludeDate}/isExcluded`,

--- a/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.test.ts
+++ b/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.test.ts
@@ -169,7 +169,10 @@ describe('Block visit dates and sessions listing page', () => {
       flashData = { errors: [], formValues: [] }
 
       sessionData = {} as SessionData
-      blockDatesOrSessionsService.getFutureBlockedDates.mockResolvedValue([])
+      blockDatesOrSessionsService.getFutureBlockedDatesAndSessions.mockResolvedValue({
+        fullDateExclusions: [],
+        sessionExclusions: [],
+      })
       visitSessionsService.getSessionSchedule.mockResolvedValue([])
 
       app = appWithAllRoutes({ services: { blockDatesOrSessionsService, visitSessionsService }, sessionData })
@@ -185,7 +188,11 @@ describe('Block visit dates and sessions listing page', () => {
         .expect(302)
         .expect('location', '/block-visit-dates-or-sessions/block-new-date')
         .expect(() => {
-          expect(blockDatesOrSessionsService.getFutureBlockedDates).toHaveBeenCalledWith('HEI', 'user1')
+          expect(blockDatesOrSessionsService.getFutureBlockedDatesAndSessions).toHaveBeenCalledWith({
+            prisonId: 'HEI',
+            includeSessions: false,
+            username: 'user1',
+          })
           expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
             username: 'user1',
             prisonId: 'HEI',
@@ -212,7 +219,11 @@ describe('Block visit dates and sessions listing page', () => {
         .expect(302)
         .expect('location', '/block-visit-dates-or-sessions/block-date-or-session')
         .expect(() => {
-          expect(blockDatesOrSessionsService.getFutureBlockedDates).toHaveBeenCalledWith('HEI', 'user1')
+          expect(blockDatesOrSessionsService.getFutureBlockedDatesAndSessions).toHaveBeenCalledWith({
+            prisonId: 'HEI',
+            includeSessions: false,
+            username: 'user1',
+          })
           expect(visitSessionsService.getSessionSchedule).toHaveBeenCalledWith({
             username: 'user1',
             prisonId: 'HEI',
@@ -251,7 +262,7 @@ describe('Block visit dates and sessions listing page', () => {
           .expect(302)
           .expect('location', '/block-visit-dates-or-sessions')
           .expect(() => {
-            expect(blockDatesOrSessionsService.getFutureBlockedDates).not.toHaveBeenCalled()
+            expect(blockDatesOrSessionsService.getFutureBlockedDatesAndSessions).not.toHaveBeenCalled()
             expect(sessionData.blockDateOrSession).toBe(undefined)
             expect(flashProvider).toHaveBeenCalledWith('errors', [expectedValidationError])
             expect(flashProvider).toHaveBeenCalledWith('formValues', { date: expected })
@@ -278,7 +289,7 @@ describe('Block visit dates and sessions listing page', () => {
         .expect(302)
         .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
-          expect(blockDatesOrSessionsService.getFutureBlockedDates).not.toHaveBeenCalled()
+          expect(blockDatesOrSessionsService.getFutureBlockedDatesAndSessions).not.toHaveBeenCalled()
           expect(sessionData.blockDateOrSession).toBe(undefined)
           expect(flashProvider).toHaveBeenCalledWith('errors', [expectedValidationError])
           expect(flashProvider).toHaveBeenCalledWith('formValues', { date: inputDate })
@@ -289,9 +300,10 @@ describe('Block visit dates and sessions listing page', () => {
       const inputDate = format(today, datePickerDateFormat)
       const expectedOutputDate = format(today, expectedDateFormat)
 
-      blockDatesOrSessionsService.getFutureBlockedDates.mockResolvedValue([
-        TestData.excludeDateDto({ excludeDate: expectedOutputDate }),
-      ])
+      blockDatesOrSessionsService.getFutureBlockedDatesAndSessions.mockResolvedValue({
+        fullDateExclusions: [TestData.excludeDateDto({ excludeDate: expectedOutputDate })],
+        sessionExclusions: [],
+      })
 
       const expectedValidationError: FieldValidationError = {
         location: 'body',
@@ -307,7 +319,11 @@ describe('Block visit dates and sessions listing page', () => {
         .expect(302)
         .expect('location', '/block-visit-dates-or-sessions')
         .expect(() => {
-          expect(blockDatesOrSessionsService.getFutureBlockedDates).toHaveBeenCalledWith('HEI', 'user1')
+          expect(blockDatesOrSessionsService.getFutureBlockedDatesAndSessions).toHaveBeenCalledWith({
+            prisonId: 'HEI',
+            includeSessions: false,
+            username: 'user1',
+          })
           expect(sessionData.blockDateOrSession).toBe(undefined)
           expect(flashProvider).toHaveBeenCalledWith('errors', [expectedValidationError])
           expect(flashProvider).toHaveBeenCalledWith('formValues', { date: inputDate })

--- a/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.ts
+++ b/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.ts
@@ -68,6 +68,7 @@ export default class BlockDatesOrSessionsController {
     return [
       // store pre-sanitised user-entered value as rawDate to show in field validation error
       body('rawDate').customSanitizer((_value, { req }) => (typeof req.body?.date === 'string' ? req.body.date : '')),
+
       body('date', 'Enter a valid date')
         .trim()
         // reformat to year-month-day (used by API)
@@ -83,12 +84,13 @@ export default class BlockDatesOrSessionsController {
         .bail()
         // date cannot be an existing blocked date
         .custom(async (date: string, { req }: Meta & { req: Express.Request }) => {
-          const blockedDates = await this.blockDatesOrSessionsService.getFutureBlockedDatesAndSessions({
+          const { fullDateExclusions } = await this.blockDatesOrSessionsService.getFutureBlockedDatesAndSessions({
             prisonId: req.session.selectedEstablishment.prisonId,
             includeSessions: false,
             username: req.user.username,
           })
-          if (blockedDates.fullDateExclusions.some(blockedDate => blockedDate.excludeDate === date)) {
+
+          if (fullDateExclusions.some(blockedDate => blockedDate.excludeDate === date)) {
             throw new Error('The full day is already blocked for the date entered')
           }
         }),

--- a/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.ts
+++ b/server/routes/blockDatesOrSessions/blockDatesOrSessionsController.ts
@@ -83,11 +83,12 @@ export default class BlockDatesOrSessionsController {
         .bail()
         // date cannot be an existing blocked date
         .custom(async (date: string, { req }: Meta & { req: Express.Request }) => {
-          const blockedDates = await this.blockDatesOrSessionsService.getFutureBlockedDates(
-            req.session.selectedEstablishment.prisonId,
-            req.user.username,
-          )
-          if (blockedDates.some(blockedDate => blockedDate.excludeDate === date)) {
+          const blockedDates = await this.blockDatesOrSessionsService.getFutureBlockedDatesAndSessions({
+            prisonId: req.session.selectedEstablishment.prisonId,
+            includeSessions: false,
+            username: req.user.username,
+          })
+          if (blockedDates.fullDateExclusions.some(blockedDate => blockedDate.excludeDate === date)) {
             throw new Error('The full day is already blocked for the date entered')
           }
         }),

--- a/server/services/blockDatesOrSessionsService.test.ts
+++ b/server/services/blockDatesOrSessionsService.test.ts
@@ -47,18 +47,6 @@ describe('Blocked dates or sessions service', () => {
     })
   })
 
-  describe('getFutureBlockedDates', () => {
-    it('should return future blocked dates for given prison', async () => {
-      const excludeDateDto = TestData.excludeDateDto()
-      orchestrationApiClient.getFutureBlockedDates.mockResolvedValue([excludeDateDto])
-
-      const result = await blockDatesOrSessionsService.getFutureBlockedDates(prisonId, username)
-
-      expect(orchestrationApiClient.getFutureBlockedDates).toHaveBeenCalledWith(prisonId)
-      expect(result).toStrictEqual([excludeDateDto])
-    })
-  })
-
   describe('isBlockedDate', () => {
     it('should return boolean indicating whether given date is a blocked date', async () => {
       const date = '2000-02-01'

--- a/server/services/blockDatesOrSessionsService.ts
+++ b/server/services/blockDatesOrSessionsService.ts
@@ -1,5 +1,5 @@
 import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
-import { ExcludeDateDto, PrisonAndSessionsExcludeDatesDto } from '../data/orchestrationApiTypes'
+import { PrisonAndSessionsExcludeDatesDto } from '../data/orchestrationApiTypes'
 
 export default class BlockDatesOrSessionsService {
   constructor(
@@ -17,12 +17,6 @@ export default class BlockDatesOrSessionsService {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
     await orchestrationApiClient.unblockVisitDate(prisonId, date, username)
-  }
-
-  async getFutureBlockedDates(prisonId: string, username: string): Promise<ExcludeDateDto[]> {
-    const token = await this.hmppsAuthClient.getSystemClientToken(username)
-    const orchestrationApiClient = this.orchestrationApiClientFactory(token)
-    return orchestrationApiClient.getFutureBlockedDates(prisonId)
   }
 
   async isBlockedDate(prisonId: string, excludedDate: string, username: string): Promise<boolean> {


### PR DESCRIPTION
Replace with V2 endpoint that returns future date and (optionally) session blocks.