### PR TITLE
VB-6802, VB-6803 Add rejection reason screen for visit requests

### DIFF
--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -33,6 +33,7 @@ import {
   VisitPassDto,
   VisitPassRequestDto,
   VisitPreview,
+  VisitRequestRejectionReason,
   VisitRequestResponse,
   VisitRequestSummary,
   VisitSessionsAndScheduleDto,
@@ -896,12 +897,14 @@ export default {
 
   stubRejectVisitRequest: ({
     reference,
-    username,
-    visitRequestResponse,
+    visitRequestRejectionReason = null,
+    username = 'USER1',
+    visitRequestResponse = TestData.visitRequestResponse(),
   }: {
     reference: string
-    username: string
-    visitRequestResponse: VisitRequestResponse
+    visitRequestRejectionReason: VisitRequestRejectionReason
+    username?: string
+    visitRequestResponse?: VisitRequestResponse
   }): SuperAgentRequest => {
     return stubFor({
       request: {
@@ -912,6 +915,7 @@ export default {
             equalToJson: {
               visitReference: reference,
               actionedBy: username,
+              visitRequestRejectionReason,
             },
           },
         ],
@@ -926,12 +930,12 @@ export default {
 
   stubApproveVisitRequest: ({
     reference,
-    username,
-    visitRequestResponse,
+    username = 'USER1',
+    visitRequestResponse = TestData.visitRequestResponse(),
   }: {
     reference: string
-    username: string
-    visitRequestResponse: VisitRequestResponse
+    username?: string
+    visitRequestResponse?: VisitRequestResponse
   }): SuperAgentRequest => {
     return stubFor({
       request: {
@@ -958,7 +962,7 @@ export default {
     prisonId = 'HEI',
     visitRequests = [TestData.visitRequestSummary()],
   }: {
-    prisonId: string
+    prisonId?: string
     visitRequests: VisitRequestSummary[]
   }): SuperAgentRequest => {
     return stubFor({

--- a/integration_tests/mockApis/orchestration.ts
+++ b/integration_tests/mockApis/orchestration.ts
@@ -902,7 +902,7 @@ export default {
     visitRequestResponse = TestData.visitRequestResponse(),
   }: {
     reference: string
-    visitRequestRejectionReason: VisitRequestRejectionReason
+    visitRequestRejectionReason: VisitRequestRejectionReason | null
     username?: string
     visitRequestResponse?: VisitRequestResponse
   }): SuperAgentRequest => {

--- a/integration_tests/pages/visit/visitRequests/visitRequestRejectionReasonPage.ts
+++ b/integration_tests/pages/visit/visitRequests/visitRequestRejectionReasonPage.ts
@@ -13,7 +13,7 @@ export default class VisitRequestRejectionReasonPage extends AbstractPage {
     this.rejectButton = page.getByRole('button', { name: 'Confirm rejection' })
   }
 
-  async selectSingleSession(): Promise<void> {
+  async selectNoVisitAllowanceReason(): Promise<void> {
     await this.noAllowanceRadio.check()
   }
 

--- a/integration_tests/pages/visit/visitRequests/visitRequestRejectionReasonPage.ts
+++ b/integration_tests/pages/visit/visitRequests/visitRequestRejectionReasonPage.ts
@@ -1,0 +1,23 @@
+import { type Locator, type Page } from '@playwright/test'
+import AbstractPage from '../../abstractPage'
+
+export default class VisitRequestRejectionReasonPage extends AbstractPage {
+  readonly noAllowanceRadio: Locator
+
+  readonly rejectButton: Locator
+
+  constructor(page: Page) {
+    super(page, 'Rejection reason (optional)')
+
+    this.noAllowanceRadio = page.getByRole('radio', { name: 'The prisoner has used up their entitlement' })
+    this.rejectButton = page.getByRole('button', { name: 'Confirm rejection' })
+  }
+
+  async selectSingleSession(): Promise<void> {
+    await this.noAllowanceRadio.check()
+  }
+
+  async confirmRejection(): Promise<void> {
+    await this.rejectButton.click()
+  }
+}

--- a/integration_tests/specs/request/processVisitRequest.spec.ts
+++ b/integration_tests/specs/request/processVisitRequest.spec.ts
@@ -5,6 +5,7 @@ import VisitRequestsListingPage from '../../pages/request/visitRequestsListingPa
 import VisitDetailsPage from '../../pages/visit/details/visitDetailsPage'
 import orchestrationApi from '../../mockApis/orchestration'
 import { resetStubs, login } from '../../testUtils'
+import VisitRequestRejectionReasonPage from '../../pages/visit/visitRequests/visitRequestRejectionReasonPage'
 
 test.describe('Process a visit Request', () => {
   const prisonStaffAndPublic = TestData.prisonDto({
@@ -33,10 +34,7 @@ test.describe('Process a visit Request', () => {
     await expect(homePage.visitRequestsBadgeCount).toContainText('1')
 
     // Stub visit requests and navigate
-    await orchestrationApi.stubGetVisitRequests({
-      prisonId: 'HEI',
-      visitRequests: [visitRequest],
-    })
+    await orchestrationApi.stubGetVisitRequests({ visitRequests: [visitRequest] })
     await homePage.visitRequestsTile.click()
 
     const visitRequestsListingPage = await VisitRequestsListingPage.verifyOnPage(page)
@@ -71,14 +69,10 @@ test.describe('Process a visit Request', () => {
     await expect(visitDetailsPage.eventHeader(0)).toContainText('Requested')
 
     // Approve visit request
-    await orchestrationApi.stubGetVisitRequests({
-      prisonId: 'HEI',
-      visitRequests: [],
-    })
+    await orchestrationApi.stubGetVisitRequests({ visitRequests: [] })
     const visitRequestResponse = TestData.visitRequestResponse()
     await orchestrationApi.stubApproveVisitRequest({
       reference: visitRequest.visitReference,
-      username: 'USER1',
       visitRequestResponse,
     })
     await visitDetailsPage.approveRequest.click()
@@ -97,7 +91,6 @@ test.describe('Process a visit Request', () => {
     await expect(homePage.visitRequestsBadgeCount).toContainText('1')
 
     await orchestrationApi.stubGetVisitRequests({
-      prisonId: 'HEI',
       visitRequests: [visitRequest],
     })
     await homePage.visitRequestsTile.click()
@@ -122,28 +115,31 @@ test.describe('Process a visit Request', () => {
     const visitDetailsPage = await VisitDetailsPage.verifyOnPage(page, 'Visit request details')
     await expect(visitDetailsPage.messages.first()).toContainText('This request needs to be reviewed')
 
-    // Stub reject API call
-    const visitRequestResponse = TestData.visitRequestResponse({
-      visitReference: visitRequest.visitReference,
-    })
-    await orchestrationApi.stubRejectVisitRequest({
-      reference: visitRequest.visitReference,
-      username: 'USER1',
-      visitRequestResponse,
-    })
-
-    await orchestrationApi.stubGetVisitRequests({
-      prisonId: 'HEI',
-      visitRequests: [],
-    })
-
+    // Select 'Reject'
     await visitDetailsPage.rejectRequest.click()
 
-    const refreshedListingPage = await VisitRequestsListingPage.verifyOnPage(page)
+    // Rejection reason page
+    const visitRequestRejectionReasonPage = await VisitRequestRejectionReasonPage.verifyOnPage(page)
+    await visitRequestRejectionReasonPage.selectSingleSession()
 
-    await expect(refreshedListingPage.messages.first()).toContainText('You rejected the request to visit John Smith')
+    // Confirm rejection
+    await orchestrationApi.stubRejectVisitRequest({
+      reference: visitRequest.visitReference,
+      visitRequestRejectionReason: 'NO_VISIT_ALLOWANCE',
+    })
+
+    await orchestrationApi.stubGetVisitRequests({ visitRequests: [] })
+    await visitRequestRejectionReasonPage.confirmRejection()
+
+    // Returned to requested visits page
+    await VisitRequestsListingPage.verifyOnPage(page)
+
+    // Success message
+    await expect(visitRequestsListingPage.messages.first()).toContainText(
+      'You rejected the request to visit John Smith',
+    )
 
     //  Assert that table is empty (no requests message)
-    await expect(refreshedListingPage.getNoRequestsMessage()).toContainText('no visit requests')
+    await expect(visitRequestsListingPage.getNoRequestsMessage()).toContainText('no visit requests')
   })
 })

--- a/integration_tests/specs/request/processVisitRequest.spec.ts
+++ b/integration_tests/specs/request/processVisitRequest.spec.ts
@@ -120,7 +120,7 @@ test.describe('Process a visit Request', () => {
 
     // Rejection reason page
     const visitRequestRejectionReasonPage = await VisitRequestRejectionReasonPage.verifyOnPage(page)
-    await visitRequestRejectionReasonPage.selectSingleSession()
+    await visitRequestRejectionReasonPage.selectNoVisitAllowanceReason()
 
     // Confirm rejection
     await orchestrationApi.stubRejectVisitRequest({

--- a/server/constants/visitRequestRejection.ts
+++ b/server/constants/visitRequestRejection.ts
@@ -1,0 +1,7 @@
+import { VisitRequestRejectionReason } from '../data/orchestrationApiTypes'
+
+// eslint-disable-next-line import/prefer-default-export
+export const visitRequestRejectionReasons: Record<VisitRequestRejectionReason, string> = {
+  NO_VISIT_ALLOWANCE: 'The prisoner has used up their entitlement',
+  ALERT_OR_RESTRICTION: 'A restriction or an alert prevents this visit',
+}

--- a/server/constants/visitRequestRejection.ts
+++ b/server/constants/visitRequestRejection.ts
@@ -1,7 +1,21 @@
 import { VisitRequestRejectionReason } from '../data/orchestrationApiTypes'
 
-// eslint-disable-next-line import/prefer-default-export
+// Used for visit request rejection journey; order significant for radio button display
 export const visitRequestRejectionReasons: Record<VisitRequestRejectionReason, string> = {
   NO_VISIT_ALLOWANCE: 'The prisoner has used up their entitlement',
   ALERT_OR_RESTRICTION: 'A restriction or an alert prevents this visit',
+}
+
+// Used for visit request rejection alert on visit details page
+export const visitRequestRejectionAlerts: Record<VisitRequestRejectionReason, string> & { default: string } = {
+  default: 'Request rejected',
+
+  NO_VISIT_ALLOWANCE: 'Request rejected as the prisoner had used up their entitlement',
+  ALERT_OR_RESTRICTION: 'Request rejected due to a restriction or an alert',
+}
+
+// Used for visit request rejection timeline entry on visit details page
+export const visitRequestRejectionAuditEvents: Record<VisitRequestRejectionReason, string> = {
+  NO_VISIT_ALLOWANCE: 'Reason: The prisoner had used up their entitlement',
+  ALERT_OR_RESTRICTION: 'Reason: A restriction or an alert prevented this visit',
 }

--- a/server/data/orchestrationApiClient.test.ts
+++ b/server/data/orchestrationApiClient.test.ts
@@ -940,13 +940,18 @@ describe('orchestrationApiClient', () => {
         .put(`/visits/requests/${reference}/reject`, <RejectVisitRequestBodyDto>{
           visitReference: reference,
           actionedBy: 'user1',
+          visitRequestRejectionReason: null,
         })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, visitRequestResponse)
 
-      expect(await orchestrationApiClient.rejectVisitRequest({ reference, username: 'user1' })).toStrictEqual(
-        visitRequestResponse,
-      )
+      expect(
+        await orchestrationApiClient.rejectVisitRequest({
+          reference,
+          username: 'user1',
+          visitRequestRejectionReason: null,
+        }),
+      ).toStrictEqual(visitRequestResponse)
     })
   })
 

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -528,7 +528,7 @@ export default class OrchestrationApiClient {
     username,
   }: {
     reference: string
-    visitRequestRejectionReason: VisitRequestRejectionReason
+    visitRequestRejectionReason: VisitRequestRejectionReason | null
     username: string
   }): Promise<VisitRequestResponse> {
     return this.restClient.put({

--- a/server/data/orchestrationApiClient.ts
+++ b/server/data/orchestrationApiClient.ts
@@ -50,6 +50,7 @@ import {
   VisitPassDto,
   VisitPassRequestDto,
   VisitPreview,
+  VisitRequestRejectionReason,
   VisitRequestResponse,
   VisitRequestsCountDto,
   VisitRequestSummary,
@@ -523,14 +524,16 @@ export default class OrchestrationApiClient {
 
   async rejectVisitRequest({
     reference,
+    visitRequestRejectionReason,
     username,
   }: {
     reference: string
+    visitRequestRejectionReason: VisitRequestRejectionReason
     username: string
   }): Promise<VisitRequestResponse> {
     return this.restClient.put({
       path: `/visits/requests/${reference}/reject`,
-      data: <RejectVisitRequestBodyDto>{ visitReference: reference, actionedBy: username },
+      data: <RejectVisitRequestBodyDto>{ visitReference: reference, actionedBy: username, visitRequestRejectionReason },
     })
   }
 

--- a/server/data/orchestrationApiTypes.ts
+++ b/server/data/orchestrationApiTypes.ts
@@ -102,6 +102,8 @@ export type IsExcludeDateDto = components['schemas']['IsExcludeDateDto']
 
 export type ApproveVisitRequestBodyDto = components['schemas']['ApproveVisitRequestBodyDto']
 export type RejectVisitRequestBodyDto = components['schemas']['RejectVisitRequestBodyDto']
+export type VisitRequestRejectionReason =
+  components['schemas']['RejectVisitRequestBodyDto']['visitRequestRejectionReason']
 export type VisitRequestResponse = components['schemas']['OrchestrationApproveRejectVisitRequestResponseDto']
 export type VisitRequestSummary = components['schemas']['OrchestrationVisitRequestSummaryDto']
 export type VisitRequestsCountDto = components['schemas']['VisitRequestsCountDto']

--- a/server/data/orchestrationApiTypes.ts
+++ b/server/data/orchestrationApiTypes.ts
@@ -102,8 +102,10 @@ export type IsExcludeDateDto = components['schemas']['IsExcludeDateDto']
 
 export type ApproveVisitRequestBodyDto = components['schemas']['ApproveVisitRequestBodyDto']
 export type RejectVisitRequestBodyDto = components['schemas']['RejectVisitRequestBodyDto']
-export type VisitRequestRejectionReason =
-  components['schemas']['RejectVisitRequestBodyDto']['visitRequestRejectionReason']
+export type VisitRequestRejectionReason = Exclude<
+  components['schemas']['RejectVisitRequestBodyDto']['visitRequestRejectionReason'],
+  undefined | null
+> // Exclude undefined/null as this type is used as a key in constants/visitRequestRejection.ts
 export type VisitRequestResponse = components['schemas']['OrchestrationApproveRejectVisitRequestResponseDto']
 export type VisitRequestSummary = components['schemas']['OrchestrationVisitRequestSummaryDto']
 export type VisitRequestsCountDto = components['schemas']['VisitRequestsCountDto']

--- a/server/routes/visit/details/buildVisitEventsTimeline.test.ts
+++ b/server/routes/visit/details/buildVisitEventsTimeline.test.ts
@@ -326,6 +326,33 @@ describe('buildVisitEventsTimeline - Build MoJ Timeline items from visit event h
     expect(timeline).toStrictEqual(expectedTimeline)
   })
 
+  it('should return a timeline with an event for Request "Rejected" - with a rejection reason', () => {
+    params.events = [
+      {
+        type: 'REQUESTED_VISIT_REJECTED',
+        applicationMethodType: 'WEBSITE',
+        actionedByFullName: 'User One',
+        userType: 'STAFF',
+        text: 'ALERT_OR_RESTRICTION',
+        createTimestamp: '2022-01-01T09:00:00',
+      },
+    ]
+
+    const expectedTimeline: MojTimelineItem[] = [
+      {
+        label: { text: 'Rejected' },
+        text: 'Reason: A restriction or an alert prevented this visit',
+        datetime: { timestamp: '2022-01-01T09:00:00', type: 'datetime' },
+        byline: { text: 'User One' },
+        attributes: { 'data-test': 'timeline-entry-0' },
+      },
+    ]
+
+    const timeline = buildVisitEventsTimeline(params)
+
+    expect(timeline).toStrictEqual(expectedTimeline)
+  })
+
   it('should return a timeline with an event for "Withdrawn - Method: GOV.UK"', () => {
     params.events = [
       {

--- a/server/routes/visit/details/buildVisitEventsTimeline.ts
+++ b/server/routes/visit/details/buildVisitEventsTimeline.ts
@@ -1,7 +1,8 @@
 import eventAuditTypes from '../../../constants/eventAudit'
 import { notificationTypes } from '../../../constants/notifications'
 import { requestMethodDescriptions } from '../../../constants/requestMethods'
-import { EventAudit, VisitBookingDetails } from '../../../data/orchestrationApiTypes'
+import { visitRequestRejectionAuditEvents } from '../../../constants/visitRequestRejection'
+import { EventAudit, VisitBookingDetails, VisitRequestRejectionReason } from '../../../data/orchestrationApiTypes'
 
 export type MojTimelineItem = {
   label: { text: string }
@@ -56,6 +57,13 @@ export default ({
         case 'REQUESTED_VISIT':
         case 'REQUESTED_VISIT_WITHDRAWN':
           timelineItem.text = 'Method: GOV.UK'
+          break
+
+        case 'REQUESTED_VISIT_REJECTED':
+          timelineItem.text =
+            event.text in visitRequestRejectionAuditEvents
+              ? visitRequestRejectionAuditEvents[event.text as VisitRequestRejectionReason]
+              : ''
           break
 
         default:

--- a/server/routes/visit/details/buildVisitEventsTimeline.ts
+++ b/server/routes/visit/details/buildVisitEventsTimeline.ts
@@ -59,12 +59,14 @@ export default ({
           timelineItem.text = 'Method: GOV.UK'
           break
 
-        case 'REQUESTED_VISIT_REJECTED':
+        case 'REQUESTED_VISIT_REJECTED': {
+          const rejectionReason = event.text
           timelineItem.text =
-            event.text in visitRequestRejectionAuditEvents
-              ? visitRequestRejectionAuditEvents[event.text as VisitRequestRejectionReason]
+            typeof rejectionReason === 'string' && rejectionReason in visitRequestRejectionAuditEvents
+              ? visitRequestRejectionAuditEvents[rejectionReason as VisitRequestRejectionReason]
               : ''
           break
+        }
 
         default:
           timelineItem.text = isANotificationType(event.type) ? `Reason: ${notificationTypes[event.type]}` : ''

--- a/server/routes/visit/details/getVisitAlerts.test.ts
+++ b/server/routes/visit/details/getVisitAlerts.test.ts
@@ -44,7 +44,7 @@ describe('getVisitAlerts', () => {
   })
 
   describe('Visit request REJECTED', () => {
-    it('should return an alert if visit request is REJECTED', () => {
+    it('should return an alert if visit request is REJECTED (with no rejection reason)', () => {
       const visitDetails = TestData.visitBookingDetails({
         visitStatus: 'CANCELLED',
         visitSubStatus: 'REJECTED',
@@ -64,6 +64,33 @@ describe('getVisitAlerts', () => {
         {
           variant: 'information',
           title: 'Request rejected',
+          showTitleAsHeading: true,
+          text: 'This visit request was rejected by User One',
+        },
+      ])
+    })
+
+    it('should return an alert if visit request is REJECTED (with a rejection reason)', () => {
+      const visitDetails = TestData.visitBookingDetails({
+        visitStatus: 'CANCELLED',
+        visitSubStatus: 'REJECTED',
+        outcomeStatus: 'ESTABLISHMENT_CANCELLED',
+        events: [
+          {
+            type: 'REQUESTED_VISIT_REJECTED',
+            applicationMethodType: 'WEBSITE',
+            actionedByFullName: 'User One',
+            userType: 'STAFF',
+            text: 'NO_VISIT_ALLOWANCE',
+            createTimestamp: '',
+          },
+        ],
+      })
+
+      expect(getVisitAlerts(visitDetails)).toStrictEqual<MoJAlert[]>([
+        {
+          variant: 'information',
+          title: 'Request rejected as the prisoner had used up their entitlement',
           showTitleAsHeading: true,
           text: 'This visit request was rejected by User One',
         },

--- a/server/routes/visit/details/getVisitAlerts.ts
+++ b/server/routes/visit/details/getVisitAlerts.ts
@@ -1,7 +1,8 @@
 import type { MoJAlert } from '../../../@types/bapv'
 import { notificationTypeAlerts } from '../../../constants/notifications'
 import { visitCancellationAlerts } from '../../../constants/visitCancellation'
-import type { VisitBookingDetails } from '../../../data/orchestrationApiTypes'
+import { visitRequestRejectionAlerts } from '../../../constants/visitRequestRejection'
+import type { VisitBookingDetails, VisitRequestRejectionReason } from '../../../data/orchestrationApiTypes'
 import { getIdsToFlag } from '../visitUtils'
 
 const getVisitCancelledAlert = ({
@@ -44,13 +45,20 @@ const getVisitRequestAlert = ({
   }
 
   if (visitStatus === 'CANCELLED' && visitSubStatus === 'REJECTED') {
-    const username = events.find(event => event.type === 'REQUESTED_VISIT_REJECTED')?.actionedByFullName
+    const rejectionEvent = events.find(event => event.type === 'REQUESTED_VISIT_REJECTED')
+
+    const title =
+      rejectionEvent?.text in visitRequestRejectionAlerts
+        ? visitRequestRejectionAlerts[rejectionEvent.text as VisitRequestRejectionReason]
+        : visitRequestRejectionAlerts.default
 
     return {
       variant: 'information',
-      title: 'Request rejected',
+      title,
       showTitleAsHeading: true,
-      text: `This visit request was rejected by ${username}`,
+      text: rejectionEvent?.actionedByFullName
+        ? `This visit request was rejected by ${rejectionEvent.actionedByFullName}`
+        : 'This visit request was rejected',
     }
   }
 

--- a/server/routes/visit/details/getVisitAlerts.ts
+++ b/server/routes/visit/details/getVisitAlerts.ts
@@ -46,10 +46,11 @@ const getVisitRequestAlert = ({
 
   if (visitStatus === 'CANCELLED' && visitSubStatus === 'REJECTED') {
     const rejectionEvent = events.find(event => event.type === 'REQUESTED_VISIT_REJECTED')
+    const rejectionReason = rejectionEvent?.text
 
     const title =
-      rejectionEvent?.text in visitRequestRejectionAlerts
-        ? visitRequestRejectionAlerts[rejectionEvent.text as VisitRequestRejectionReason]
+      typeof rejectionReason === 'string' && rejectionReason in visitRequestRejectionAlerts
+        ? visitRequestRejectionAlerts[rejectionReason as VisitRequestRejectionReason]
         : visitRequestRejectionAlerts.default
 
     return {

--- a/server/routes/visit/details/visitDetailsController.test.ts
+++ b/server/routes/visit/details/visitDetailsController.test.ts
@@ -196,8 +196,8 @@ describe('Visit details page', () => {
           expect($('[data-test="approve-visit-request"]').parent('form').attr('action')).toBe(
             '/visit/ab-cd-ef-gh/request/approve?from=visits',
           )
-          expect($('[data-test="reject-visit-request"]').parent('form').attr('action')).toBe(
-            '/visit/ab-cd-ef-gh/request/reject?from=visits',
+          expect($('[data-test="reject-visit-request"]').attr('href')).toBe(
+            '/visit/ab-cd-ef-gh/request/reject/reason?from=visits',
           )
         })
     })
@@ -221,8 +221,8 @@ describe('Visit details page', () => {
           expect($('[data-test="approve-visit-request"]').parent('form').attr('action')).toBe(
             '/visit/ab-cd-ef-gh/request/approve?from=prisoner&prisonerId=A1234BC',
           )
-          expect($('[data-test="reject-visit-request"]').parent('form').attr('action')).toBe(
-            '/visit/ab-cd-ef-gh/request/reject?from=prisoner&prisonerId=A1234BC',
+          expect($('[data-test="reject-visit-request"]').attr('href')).toBe(
+            '/visit/ab-cd-ef-gh/request/reject/reason?from=prisoner&prisonerId=A1234BC',
           )
         })
     })
@@ -459,9 +459,7 @@ describe('Visit details page', () => {
             )
 
             expect($('[data-test=reject-visit-request]').text().trim()).toBe('Reject request')
-            expect($('[data-test=reject-visit-request]').parent('form').attr('action')).toBe(
-              '/visit/ab-cd-ef-gh/request/reject',
-            )
+            expect($('[data-test=reject-visit-request]').attr('href')).toBe('/visit/ab-cd-ef-gh/request/reject/reason')
           })
       })
     })

--- a/server/routes/visit/details/visitDetailsController.ts
+++ b/server/routes/visit/details/visitDetailsController.ts
@@ -146,7 +146,7 @@ export default class VisitDetailsController {
     processRequestRejectAction: string
   } {
     const approveAction = appendNavStateToPath(`/visit/${reference}/request/approve`, navState)
-    const rejectAction = appendNavStateToPath(`/visit/${reference}/request/reject`, navState)
+    const rejectAction = appendNavStateToPath(`/visit/${reference}/request/reject/reason`, navState)
 
     if (prisonerNumber) {
       const separator = (url: string) => (url.includes('?') ? '&' : '?')

--- a/server/routes/visit/index.ts
+++ b/server/routes/visit/index.ts
@@ -9,6 +9,7 @@ import ConfirmUpdateController from './update/confirmUpdateController'
 import UpdateVisitController from './update/updateVisitController'
 import ProcessVisitRequestController from './visitRequests/processVisitRequestController'
 import VisitPassesController from '../visitPasses/visitPassesController'
+import VisitRequestRejectionReasonController from './visitRequests/visitRequestRejectionReasonController'
 
 export default function routes(services: Services): Router {
   const router = Router()
@@ -18,7 +19,12 @@ export default function routes(services: Services): Router {
   const clearNotifications = new ClearNotificationsController(services.auditService, services.visitNotificationsService)
   const confirmUpdate = new ConfirmUpdateController()
   const updateVisit = new UpdateVisitController(services.visitService)
-  const processVisitRequest = new ProcessVisitRequestController(services.visitRequestsService, services.visitService)
+  const processVisitRequest = new ProcessVisitRequestController(
+    services.auditService,
+    services.visitRequestsService,
+    services.visitService,
+  )
+  const visitRequestRejectionReason = new VisitRequestRejectionReasonController()
   const visitPassesController = new VisitPassesController(services.auditService, services.visitService)
 
   // middleware to ensure valid visit reference for all /visit/:reference routes
@@ -47,6 +53,7 @@ export default function routes(services: Services): Router {
   router.post('/:reference/confirm-update', confirmUpdate.submitConfirmUpdate())
 
   router.post('/:reference/request/approve', processVisitRequest.processRequest('approve'))
+  router.get('/:reference/request/reject/reason', visitRequestRejectionReason.view())
   router.post('/:reference/request/reject', processVisitRequest.processRequest('reject'))
 
   return router

--- a/server/routes/visit/index.ts
+++ b/server/routes/visit/index.ts
@@ -54,7 +54,11 @@ export default function routes(services: Services): Router {
 
   router.post('/:reference/request/approve', processVisitRequest.processRequest('approve'))
   router.get('/:reference/request/reject/reason', visitRequestRejectionReason.view())
-  router.post('/:reference/request/reject', processVisitRequest.processRequest('reject'))
+  router.post(
+    '/:reference/request/reject',
+    processVisitRequest.validate(),
+    processVisitRequest.processRequest('reject'),
+  )
 
   return router
 }

--- a/server/routes/visit/visitRequests/processVisitRequestController.test.ts
+++ b/server/routes/visit/visitRequests/processVisitRequestController.test.ts
@@ -3,11 +3,16 @@ import request from 'supertest'
 import { BadRequest, InternalServerError } from 'http-errors'
 import { appWithAllRoutes, flashProvider } from '../../testutils/appSetup'
 import TestData from '../../testutils/testData'
-import { createMockVisitRequestsService, createMockVisitService } from '../../../services/testutils/mocks'
+import {
+  createMockAuditService,
+  createMockVisitRequestsService,
+  createMockVisitService,
+} from '../../../services/testutils/mocks'
 import { VisitBookingDetails } from '../../../data/orchestrationApiTypes'
 
 let app: Express
 
+const auditService = createMockAuditService()
 const visitRequestsService = createMockVisitRequestsService()
 const visitService = createMockVisitService()
 
@@ -22,7 +27,7 @@ beforeEach(() => {
 
   visitService.getVisitDetailed.mockResolvedValue(visitDetails)
 
-  app = appWithAllRoutes({ services: { visitRequestsService, visitService } })
+  app = appWithAllRoutes({ services: { auditService, visitRequestsService, visitService } })
 })
 
 afterEach(() => {
@@ -44,67 +49,33 @@ describe('Process a visit request (approve / reject)', () => {
             html: 'The main contact has been notified. You can <a href="/visit/ab-cd-ef-gh">view this visit again</a>.',
           })
 
-          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
+          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith({
+            username: 'user1',
+            reference: visitDetails.reference,
+          })
+          expect(auditService.approvedVisitRequest).toHaveBeenCalledWith({
+            visitReference: visitDetails.reference,
+            operationId: undefined,
+            username: 'user1',
+          })
           expect(visitRequestsService.rejectVisitRequest).not.toHaveBeenCalled()
           expect(visitService.getVisitDetailed).not.toHaveBeenCalled()
         })
     })
 
-    it('should approve visit request, set success message and redirect to visits page when coming from visits page', () => {
+    it.each([
+      ['visits page', '?from=visits', '/visits'],
+      [
+        'visits page with query preserved',
+        '?from=visits&query=type%3DOPEN%26selectedDate%3D2024-02-01',
+        '/visits?type=OPEN&selectedDate=2024-02-01',
+      ],
+      ['profile page', '?from=prisoner&prisonerId=A1234BC', '/prisoner/A1234BC'],
+    ])('should approve visit request and redirect to %s', (_description, queryString, expectedLocation) => {
       return request(app)
-        .post('/visit/ab-cd-ef-gh/request/approve?from=visits')
+        .post(`/visit/ab-cd-ef-gh/request/approve${queryString}`)
         .expect(302)
-        .expect('location', '/visits')
-        .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('messages', {
-            variant: 'success',
-            title: 'You approved the request and booked the visit with John Smith',
-            showTitleAsHeading: true,
-            html: 'The main contact has been notified. You can <a href="/visit/ab-cd-ef-gh">view this visit again</a>.',
-          })
-
-          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
-          expect(visitRequestsService.rejectVisitRequest).not.toHaveBeenCalled()
-          expect(visitService.getVisitDetailed).not.toHaveBeenCalled()
-        })
-    })
-
-    it('should approve visit request, set success message and redirect to visits page with query preserved when coming from visits page', () => {
-      return request(app)
-        .post('/visit/ab-cd-ef-gh/request/approve?from=visits&query=type%3DOPEN%26selectedDate%3D2024-02-01')
-        .expect(302)
-        .expect('location', '/visits?type=OPEN&selectedDate=2024-02-01')
-        .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('messages', {
-            variant: 'success',
-            title: 'You approved the request and booked the visit with John Smith',
-            showTitleAsHeading: true,
-            html: 'The main contact has been notified. You can <a href="/visit/ab-cd-ef-gh">view this visit again</a>.',
-          })
-
-          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
-          expect(visitRequestsService.rejectVisitRequest).not.toHaveBeenCalled()
-          expect(visitService.getVisitDetailed).not.toHaveBeenCalled()
-        })
-    })
-
-    it('should approve visit request, set success message and redirect to profile page when coming from profile page', () => {
-      return request(app)
-        .post('/visit/ab-cd-ef-gh/request/approve?from=prisoner&prisonerId=A1234BC')
-        .expect(302)
-        .expect('location', '/prisoner/A1234BC')
-        .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('messages', {
-            variant: 'success',
-            title: 'You approved the request and booked the visit with John Smith',
-            showTitleAsHeading: true,
-            html: 'The main contact has been notified. You can <a href="/visit/ab-cd-ef-gh">view this visit again</a>.',
-          })
-
-          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
-          expect(visitRequestsService.rejectVisitRequest).not.toHaveBeenCalled()
-          expect(visitService.getVisitDetailed).not.toHaveBeenCalled()
-        })
+        .expect('location', expectedLocation)
     })
 
     it('should handle 400 Bad Request from API, set failure message and redirect to requests listing page', () => {
@@ -123,7 +94,11 @@ describe('Process a visit request (approve / reject)', () => {
             html: 'The main contact has been notified. You can <a href="/visit/ab-cd-ef-gh">view this visit again</a>.',
           })
 
-          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
+          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith({
+            username: 'user1',
+            reference: visitDetails.reference,
+          })
+          expect(auditService.approvedVisitRequest).not.toHaveBeenCalled()
           expect(visitRequestsService.rejectVisitRequest).not.toHaveBeenCalled()
           expect(visitService.getVisitDetailed).toHaveBeenCalledWith({
             username: 'user1',
@@ -132,80 +107,26 @@ describe('Process a visit request (approve / reject)', () => {
         })
     })
 
-    it('should handle 400 Bad Request from API, set failure message and redirect to visits page when coming from visits page', () => {
-      visitDetails.visitSubStatus = 'APPROVED'
-      visitRequestsService.approveVisitRequest.mockRejectedValue(new BadRequest())
+    it.each([
+      ['visits page', '?from=visits', '/visits'],
+      [
+        'visits page with query preserved',
+        '?from=visits&query=type%3DOPEN%26selectedDate%3D2024-02-01',
+        '/visits?type=OPEN&selectedDate=2024-02-01',
+      ],
+      ['profile page', '?from=prisoner&prisonerId=A1234BC', '/prisoner/A1234BC'],
+    ])(
+      'should handle 400 Bad Request from API, set failure message and redirect to %s',
+      (_description, queryString, expectedLocation) => {
+        visitDetails.visitSubStatus = 'APPROVED'
+        visitRequestsService.approveVisitRequest.mockRejectedValue(new BadRequest())
 
-      return request(app)
-        .post('/visit/ab-cd-ef-gh/request/approve?from=visits')
-        .expect(302)
-        .expect('location', '/visits')
-        .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('messages', {
-            variant: 'information',
-            title: 'The visit to John Smith has already been approved',
-            showTitleAsHeading: true,
-            html: 'The main contact has been notified. You can <a href="/visit/ab-cd-ef-gh">view this visit again</a>.',
-          })
-
-          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
-          expect(visitRequestsService.rejectVisitRequest).not.toHaveBeenCalled()
-          expect(visitService.getVisitDetailed).toHaveBeenCalledWith({
-            username: 'user1',
-            reference: visitDetails.reference,
-          })
-        })
-    })
-
-    it('should handle 400 Bad Request from API, set failure message and redirect to visits page with query preserved when coming from visits page', () => {
-      visitDetails.visitSubStatus = 'APPROVED'
-      visitRequestsService.approveVisitRequest.mockRejectedValue(new BadRequest())
-
-      return request(app)
-        .post('/visit/ab-cd-ef-gh/request/approve?from=visits&query=type%3DOPEN%26selectedDate%3D2024-02-01')
-        .expect(302)
-        .expect('location', '/visits?type=OPEN&selectedDate=2024-02-01')
-        .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('messages', {
-            variant: 'information',
-            title: 'The visit to John Smith has already been approved',
-            showTitleAsHeading: true,
-            html: 'The main contact has been notified. You can <a href="/visit/ab-cd-ef-gh">view this visit again</a>.',
-          })
-
-          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
-          expect(visitRequestsService.rejectVisitRequest).not.toHaveBeenCalled()
-          expect(visitService.getVisitDetailed).toHaveBeenCalledWith({
-            username: 'user1',
-            reference: visitDetails.reference,
-          })
-        })
-    })
-
-    it('should handle 400 Bad Request from API, set failure message and redirect to profile page when coming from profile page', () => {
-      visitDetails.visitSubStatus = 'APPROVED'
-      visitRequestsService.approveVisitRequest.mockRejectedValue(new BadRequest())
-
-      return request(app)
-        .post('/visit/ab-cd-ef-gh/request/approve?from=prisoner&prisonerId=A1234BC')
-        .expect(302)
-        .expect('location', '/prisoner/A1234BC')
-        .expect(() => {
-          expect(flashProvider).toHaveBeenCalledWith('messages', {
-            variant: 'information',
-            title: 'The visit to John Smith has already been approved',
-            showTitleAsHeading: true,
-            html: 'The main contact has been notified. You can <a href="/visit/ab-cd-ef-gh">view this visit again</a>.',
-          })
-
-          expect(visitRequestsService.approveVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
-          expect(visitRequestsService.rejectVisitRequest).not.toHaveBeenCalled()
-          expect(visitService.getVisitDetailed).toHaveBeenCalledWith({
-            username: 'user1',
-            reference: visitDetails.reference,
-          })
-        })
-    })
+        return request(app)
+          .post(`/visit/ab-cd-ef-gh/request/approve${queryString}`)
+          .expect(302)
+          .expect('location', expectedLocation)
+      },
+    )
 
     it('should propagate other API errors', () => {
       visitRequestsService.approveVisitRequest.mockRejectedValue(new InternalServerError())
@@ -218,7 +139,7 @@ describe('Process a visit request (approve / reject)', () => {
   })
 
   describe('POST /visit/:reference/request/reject', () => {
-    it('should reject visit request, set success message and redirect to requests listing page', () => {
+    it('should reject visit request, set success message and redirect to requests listing page (no reason given)', () => {
       return request(app)
         .post('/visit/ab-cd-ef-gh/request/reject')
         .expect(302)
@@ -232,8 +153,60 @@ describe('Process a visit request (approve / reject)', () => {
           })
 
           expect(visitRequestsService.approveVisitRequest).not.toHaveBeenCalled()
-          expect(visitRequestsService.rejectVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
+          expect(visitRequestsService.rejectVisitRequest).toHaveBeenCalledWith({
+            username: 'user1',
+            reference: visitDetails.reference,
+            visitRequestRejectionReason: null,
+          })
+          expect(auditService.rejectedVisitRequest).toHaveBeenCalledWith({
+            visitReference: visitDetails.reference,
+            rejectionReason: null,
+            operationId: undefined,
+            username: 'user1',
+          })
           expect(visitService.getVisitDetailed).not.toHaveBeenCalled()
+        })
+    })
+
+    it('should reject visit request (rejection reason given)', () => {
+      return request(app)
+        .post('/visit/ab-cd-ef-gh/request/reject')
+        .send({ rejectionReason: 'NO_VISIT_ALLOWANCE' })
+        .expect(302)
+        .expect('location', '/requested-visits')
+        .expect(() => {
+          expect(visitRequestsService.rejectVisitRequest).toHaveBeenCalledWith({
+            username: 'user1',
+            reference: visitDetails.reference,
+            visitRequestRejectionReason: 'NO_VISIT_ALLOWANCE',
+          })
+          expect(auditService.rejectedVisitRequest).toHaveBeenCalledWith({
+            visitReference: visitDetails.reference,
+            rejectionReason: 'NO_VISIT_ALLOWANCE',
+            operationId: undefined,
+            username: 'user1',
+          })
+        })
+    })
+
+    it('should reject visit request (invalid rejection reason ignored)', () => {
+      return request(app)
+        .post('/visit/ab-cd-ef-gh/request/reject')
+        .send({ rejectionReason: 'INVALID_REASON' })
+        .expect(302)
+        .expect('location', '/requested-visits')
+        .expect(() => {
+          expect(visitRequestsService.rejectVisitRequest).toHaveBeenCalledWith({
+            username: 'user1',
+            reference: visitDetails.reference,
+            visitRequestRejectionReason: null,
+          })
+          expect(auditService.rejectedVisitRequest).toHaveBeenCalledWith({
+            visitReference: visitDetails.reference,
+            rejectionReason: null,
+            operationId: undefined,
+            username: 'user1',
+          })
         })
     })
 
@@ -254,7 +227,12 @@ describe('Process a visit request (approve / reject)', () => {
           })
 
           expect(visitRequestsService.approveVisitRequest).not.toHaveBeenCalled()
-          expect(visitRequestsService.rejectVisitRequest).toHaveBeenCalledWith('user1', visitDetails.reference)
+          expect(visitRequestsService.rejectVisitRequest).toHaveBeenCalledWith({
+            username: 'user1',
+            reference: visitDetails.reference,
+            visitRequestRejectionReason: null,
+          })
+          expect(auditService.rejectedVisitRequest).not.toHaveBeenCalled()
           expect(visitService.getVisitDetailed).toHaveBeenCalledWith({
             username: 'user1',
             reference: visitDetails.reference,

--- a/server/routes/visit/visitRequests/processVisitRequestController.ts
+++ b/server/routes/visit/visitRequests/processVisitRequestController.ts
@@ -1,4 +1,5 @@
 import { RequestHandler } from 'express'
+import { body, matchedData, ValidationChain, validationResult } from 'express-validator'
 import { AuditService, VisitRequestsService, VisitService } from '../../../services'
 import { MoJAlert } from '../../../@types/bapv'
 import { VisitReferenceParams } from '../../../@types/requestParameterTypes'
@@ -14,15 +15,7 @@ import { visitRequestRejectionReasons } from '../../../constants/visitRequestRej
 
 type RequestAction = 'approve' | 'reject'
 type RejectVisitRequestBody = {
-  rejectionReason?: unknown
-}
-
-function getVisitRequestRejectionReason(rejectionReason: unknown): VisitRequestRejectionReason {
-  if (typeof rejectionReason === 'string' && rejectionReason in visitRequestRejectionReasons) {
-    return rejectionReason as VisitRequestRejectionReason
-  }
-
-  return null
+  rejectionReason?: VisitRequestRejectionReason
 }
 
 export default class ProcessVisitRequestController {
@@ -51,7 +44,9 @@ export default class ProcessVisitRequestController {
             username,
           })
         } else {
-          const visitRequestRejectionReason = getVisitRequestRejectionReason(req.body?.rejectionReason)
+          validationResult(req)
+          const { rejectionReason } = matchedData<RejectVisitRequestBody>(req)
+          const visitRequestRejectionReason = rejectionReason ?? null
 
           visitRequestResponse = await this.visitRequestsService.rejectVisitRequest({
             username,
@@ -82,6 +77,10 @@ export default class ProcessVisitRequestController {
         return next(error)
       }
     }
+  }
+
+  public validate(): ValidationChain[] {
+    return [body('rejectionReason').optional().isIn(Object.keys(visitRequestRejectionReasons))]
   }
 
   private getRedirectPath(navState: VisitNavState, prisonerIdParam: unknown): string {
@@ -140,7 +139,6 @@ export default class ProcessVisitRequestController {
       return message
     }
 
-    // TODO may be more cases to handle here when request withdrawal, etc implemented
     return null
   }
 }

--- a/server/routes/visit/visitRequests/processVisitRequestController.ts
+++ b/server/routes/visit/visitRequests/processVisitRequestController.ts
@@ -1,32 +1,71 @@
 import { RequestHandler } from 'express'
-import { VisitRequestsService, VisitService } from '../../../services'
+import { AuditService, VisitRequestsService, VisitService } from '../../../services'
 import { MoJAlert } from '../../../@types/bapv'
 import { VisitReferenceParams } from '../../../@types/requestParameterTypes'
 import { convertToTitleCase } from '../../../utils/utils'
-import { VisitBookingDetails, VisitRequestResponse } from '../../../data/orchestrationApiTypes'
+import {
+  VisitBookingDetails,
+  VisitRequestRejectionReason,
+  VisitRequestResponse,
+} from '../../../data/orchestrationApiTypes'
 import { isValidPrisonerNumber } from '../../validationChecks'
 import { extractVisitNavState, type VisitNavState } from '../visitNavigationUtils'
+import { visitRequestRejectionReasons } from '../../../constants/visitRequestRejection'
 
 type RequestAction = 'approve' | 'reject'
+type RejectVisitRequestBody = {
+  rejectionReason?: unknown
+}
+
+function getVisitRequestRejectionReason(rejectionReason: unknown): VisitRequestRejectionReason {
+  if (typeof rejectionReason === 'string' && rejectionReason in visitRequestRejectionReasons) {
+    return rejectionReason as VisitRequestRejectionReason
+  }
+
+  return null
+}
 
 export default class ProcessVisitRequestController {
   public constructor(
+    private readonly auditService: AuditService,
     private readonly visitRequestsService: VisitRequestsService,
     private readonly visitService: VisitService,
   ) {}
 
-  public processRequest(action: RequestAction): RequestHandler<VisitReferenceParams> {
+  public processRequest(action: RequestAction): RequestHandler<VisitReferenceParams, unknown, RejectVisitRequestBody> {
     return async (req, res, next) => {
       const { reference } = req.params
       const { username } = res.locals.user
+
       const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
       const redirectPath = this.getRedirectPath(navState, req.query?.prisonerId)
 
       try {
-        const visitRequestResponse =
-          action === 'approve'
-            ? await this.visitRequestsService.approveVisitRequest(username, reference)
-            : await this.visitRequestsService.rejectVisitRequest(username, reference)
+        let visitRequestResponse
+        if (action === 'approve') {
+          visitRequestResponse = await this.visitRequestsService.approveVisitRequest({ username, reference })
+
+          await this.auditService.approvedVisitRequest({
+            visitReference: reference,
+            operationId: res.locals.appInsightsOperationId,
+            username,
+          })
+        } else {
+          const visitRequestRejectionReason = getVisitRequestRejectionReason(req.body?.rejectionReason)
+
+          visitRequestResponse = await this.visitRequestsService.rejectVisitRequest({
+            username,
+            reference,
+            visitRequestRejectionReason,
+          })
+
+          await this.auditService.rejectedVisitRequest({
+            visitReference: reference,
+            rejectionReason: visitRequestRejectionReason,
+            operationId: res.locals.appInsightsOperationId,
+            username,
+          })
+        }
 
         req.flash('messages', this.getSuccessMessage(action, visitRequestResponse))
 

--- a/server/routes/visit/visitRequests/visitRequestRejectionReasonController.test.ts
+++ b/server/routes/visit/visitRequests/visitRequestRejectionReasonController.test.ts
@@ -1,0 +1,57 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import * as cheerio from 'cheerio'
+import { appWithAllRoutes } from '../../testutils/appSetup'
+
+let app: Express
+
+beforeEach(() => {
+  app = appWithAllRoutes({})
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET /visit/:reference/request/reject/reason', () => {
+  it('should render the rejection reason page with all reasons listed', () => {
+    return request(app)
+      .get('/visit/ab-cd-ef-gh/request/reject/reason')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('h1').text().trim()).toBe('Rejection reason (optional)')
+        expect($('input[name="rejectionReason"]').length).toBe(2)
+        expect($('label[for="rejectionReason"]').text().trim()).toBe('The prisoner has used up their entitlement')
+        expect($('label[for="rejectionReason-2"]').text().trim()).toBe('A restriction or an alert prevents this visit')
+        expect($('[data-test="submit"]').text().trim()).toBe('Confirm rejection')
+      })
+  })
+
+  it('should set the form action and back link with no nav state when no query params given', () => {
+    return request(app)
+      .get('/visit/ab-cd-ef-gh/request/reject/reason')
+      .expect(200)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('form').attr('action')).toBe('/visit/ab-cd-ef-gh/request/reject')
+        expect($('.govuk-back-link').attr('href')).toBe('/visit/ab-cd-ef-gh')
+      })
+  })
+
+  it('should preserve nav state in form action and back link', () => {
+    return request(app)
+      .get('/visit/ab-cd-ef-gh/request/reject/reason?from=visits&query=type%3DOPEN%26selectedDate%3D2024-02-01')
+      .expect(200)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('form').attr('action')).toBe(
+          '/visit/ab-cd-ef-gh/request/reject?from=visits&query=type%3DOPEN%26selectedDate%3D2024-02-01',
+        )
+        expect($('.govuk-back-link').attr('href')).toBe(
+          '/visit/ab-cd-ef-gh?from=visits&query=type%3DOPEN%26selectedDate%3D2024-02-01',
+        )
+      })
+  })
+})

--- a/server/routes/visit/visitRequests/visitRequestRejectionReasonController.ts
+++ b/server/routes/visit/visitRequests/visitRequestRejectionReasonController.ts
@@ -1,0 +1,22 @@
+import { RequestHandler } from 'express'
+import { appendNavStateToPath, extractVisitNavState } from '../visitNavigationUtils'
+import { VisitReferenceParams } from '../../../@types/requestParameterTypes'
+import { visitRequestRejectionReasons } from '../../../constants/visitRequestRejection'
+
+export default class VisitRequestRejectionReasonController {
+  public constructor() {}
+
+  public view(): RequestHandler<VisitReferenceParams> {
+    return async (req, res) => {
+      const { reference } = req.params
+      const navState = extractVisitNavState({ from: req.query.from, query: req.query.query })
+
+      return res.render('pages/visit/visitRequests/rejectionReason', {
+        backLinkHref: appendNavStateToPath(`/visit/${reference}`, navState),
+        formAction: appendNavStateToPath(`/visit/${reference}/request/reject`, navState),
+        reference,
+        visitRequestRejectionReasons,
+      })
+    }
+  }
+}

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -500,6 +500,53 @@ describe('Audit service', () => {
     })
   })
 
+  it('sends an approved visit request audit message', async () => {
+    await auditService.approvedVisitRequest({
+      visitReference: 'ab-cd-ef-gh',
+      username: 'username',
+      operationId: 'operation-id',
+    })
+
+    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
+    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
+      input: {
+        MessageBody: JSON.stringify({
+          what: 'APPROVED_VISIT_REQUEST',
+          when: fakeDate,
+          operationId: 'operation-id',
+          who: 'username',
+          service: 'book-a-prison-visit-staff-ui',
+          details: '{"visitReference":"ab-cd-ef-gh"}',
+        }),
+        QueueUrl,
+      },
+    })
+  })
+
+  it('sends a rejected visit request audit message', async () => {
+    await auditService.rejectedVisitRequest({
+      visitReference: 'ab-cd-ef-gh',
+      rejectionReason: 'ALERT_OR_RESTRICTION',
+      username: 'username',
+      operationId: 'operation-id',
+    })
+
+    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
+    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
+      input: {
+        MessageBody: JSON.stringify({
+          what: 'REJECTED_VISIT_REQUEST',
+          when: fakeDate,
+          operationId: 'operation-id',
+          who: 'username',
+          service: 'book-a-prison-visit-staff-ui',
+          details: '{"visitReference":"ab-cd-ef-gh","rejectionReason":"ALERT_OR_RESTRICTION"}',
+        }),
+        QueueUrl,
+      },
+    })
+  })
+
   it('sends an approved visitor request audit message', async () => {
     await auditService.approvedVisitorRequest({
       requestReference: 'cccc-dddd-eeee',

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -1,7 +1,12 @@
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
 import logger from '../../logger'
 import config from '../config'
-import { PrisonerBalanceAdjustmentReason, RejectVisitorRequestDto, Visit } from '../data/orchestrationApiTypes'
+import {
+  PrisonerBalanceAdjustmentReason,
+  RejectVisitorRequestDto,
+  Visit,
+  VisitRequestRejectionReason,
+} from '../data/orchestrationApiTypes'
 import { PrisonRemandConfig } from '../@types/bapv'
 
 export default class AuditService {
@@ -456,6 +461,42 @@ export default class AuditService {
       who: username,
       operationId,
       details: { reference, prisonerId, visitorId },
+    })
+  }
+
+  async approvedVisitRequest({
+    visitReference,
+    username,
+    operationId,
+  }: {
+    visitReference: string
+    username: string
+    operationId: string
+  }) {
+    return this.sendAuditMessage({
+      action: 'APPROVED_VISIT_REQUEST',
+      who: username,
+      operationId,
+      details: { visitReference },
+    })
+  }
+
+  async rejectedVisitRequest({
+    visitReference,
+    rejectionReason,
+    username,
+    operationId,
+  }: {
+    visitReference: string
+    rejectionReason: VisitRequestRejectionReason
+    username: string
+    operationId: string
+  }) {
+    return this.sendAuditMessage({
+      action: 'REJECTED_VISIT_REQUEST',
+      who: username,
+      operationId,
+      details: { visitReference, rejectionReason },
     })
   }
 

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -488,7 +488,7 @@ export default class AuditService {
     operationId,
   }: {
     visitReference: string
-    rejectionReason: VisitRequestRejectionReason
+    rejectionReason: VisitRequestRejectionReason | null
     username: string
     operationId: string
   }) {

--- a/server/services/visitRequestsService.test.ts
+++ b/server/services/visitRequestsService.test.ts
@@ -30,9 +30,17 @@ describe('Visit requests service', () => {
       const visitRequestResponse = TestData.visitRequestResponse()
       orchestrationApiClient.rejectVisitRequest.mockResolvedValue(visitRequestResponse)
 
-      const result = await visitRequestsService.rejectVisitRequest('user', reference)
+      const result = await visitRequestsService.rejectVisitRequest({
+        username: 'user',
+        reference,
+        visitRequestRejectionReason: null,
+      })
 
-      expect(orchestrationApiClient.rejectVisitRequest).toHaveBeenCalledWith({ username: 'user', reference })
+      expect(orchestrationApiClient.rejectVisitRequest).toHaveBeenCalledWith({
+        username: 'user',
+        reference,
+        visitRequestRejectionReason: null,
+      })
       expect(result).toStrictEqual(visitRequestResponse)
     })
   })
@@ -43,7 +51,7 @@ describe('Visit requests service', () => {
       const visitRequestResponse = TestData.visitRequestResponse()
       orchestrationApiClient.approveVisitRequest.mockResolvedValue(visitRequestResponse)
 
-      const result = await visitRequestsService.approveVisitRequest('user', reference)
+      const result = await visitRequestsService.approveVisitRequest({ username: 'user', reference })
 
       expect(orchestrationApiClient.approveVisitRequest).toHaveBeenCalledWith({ username: 'user', reference })
       expect(result).toStrictEqual(visitRequestResponse)

--- a/server/services/visitRequestsService.ts
+++ b/server/services/visitRequestsService.ts
@@ -1,5 +1,5 @@
 import { HmppsAuthClient, OrchestrationApiClient, RestClientBuilder } from '../data'
-import { VisitRequestResponse, VisitRequestSummary } from '../data/orchestrationApiTypes'
+import { VisitRequestRejectionReason, VisitRequestResponse, VisitRequestSummary } from '../data/orchestrationApiTypes'
 
 export default class VisitRequestsService {
   constructor(
@@ -7,14 +7,28 @@ export default class VisitRequestsService {
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
 
-  async rejectVisitRequest(username: string, reference: string): Promise<VisitRequestResponse> {
+  async rejectVisitRequest({
+    username,
+    reference,
+    visitRequestRejectionReason,
+  }: {
+    username: string
+    reference: string
+    visitRequestRejectionReason: VisitRequestRejectionReason
+  }): Promise<VisitRequestResponse> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 
-    return orchestrationApiClient.rejectVisitRequest({ reference, username })
+    return orchestrationApiClient.rejectVisitRequest({ reference, username, visitRequestRejectionReason })
   }
 
-  async approveVisitRequest(username: string, reference: string): Promise<VisitRequestResponse> {
+  async approveVisitRequest({
+    username,
+    reference,
+  }: {
+    username: string
+    reference: string
+  }): Promise<VisitRequestResponse> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)
 

--- a/server/services/visitRequestsService.ts
+++ b/server/services/visitRequestsService.ts
@@ -14,7 +14,7 @@ export default class VisitRequestsService {
   }: {
     username: string
     reference: string
-    visitRequestRejectionReason: VisitRequestRejectionReason
+    visitRequestRejectionReason: VisitRequestRejectionReason | null
   }): Promise<VisitRequestResponse> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const orchestrationApiClient = this.orchestrationApiClientFactory(token)

--- a/server/views/pages/visit/details/visitDetails.njk
+++ b/server/views/pages/visit/details/visitDetails.njk
@@ -121,15 +121,15 @@
           }) }}
         </form>
 
-        <form action="{{ processRequestRejectAction }}" method="POST" novalidate>
-          <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        <div>
           {{ govukButton({
             text: "Reject request",
             classes: "govuk-!-margin-top-5 govuk-!-margin-left-6 govuk-button--secondary",
+            href: processRequestRejectAction,
             attributes: { "data-test": "reject-visit-request" },
             preventDoubleClick: true
           }) }}
-        </form>
+        </div>
       </div>
     {% endif %}
 

--- a/server/views/pages/visit/visitRequests/rejectionReason.njk
+++ b/server/views/pages/visit/visitRequests/rejectionReason.njk
@@ -1,0 +1,47 @@
+{% extends "layout.njk" %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageHeaderTitle = "Rejection reason (optional)" %}
+
+{% set rejectionReasonRadios = [] %}
+{% for key, text in visitRequestRejectionReasons %}
+  {% set rejectionReasonRadios = (rejectionReasonRadios.push(
+    {
+      value: key,
+      text: text
+    }
+  ), rejectionReasonRadios) %}
+{% endfor %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form action="{{ formAction }}" method="POST" novalidate>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+        {{ govukRadios({
+          name: "rejectionReason",
+          fieldset: {
+            legend: {
+              text: pageHeaderTitle,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: "Select the reason for rejecting this visit request."
+          },
+          items: rejectionReasonRadios
+        }) }}
+
+        {{ govukButton({
+          text: "Confirm rejection",
+          attributes: { "data-test": "submit" },
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
* Add a new screen in the visit rejection flow that allows staff to (optionally) choose from a set of reasons why a visit is being rejected
* Update top-of-page alerts and booking history timeline to include these new reasons
* Maintain back-link handling - as the visit details page with the rejection flow start may be accessed from multiple places
* Add HMPPS Audit events for approving and rejecting a visit request

**Rejection reason screen**

<img width="650" height="495" alt="Screenshot 2026-07-21 at 18 13 44" src="https://github.com/user-attachments/assets/74f06802-a17e-458a-9600-bc41b11761da" />
