### PR TITLE
chore: adopt @ministryofjustice/hmpps-audit-client for proxy-aware au…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-sqs": "^3.1101.0",
         "@ministryofjustice/frontend": "^10.0.1",
+        "@ministryofjustice/hmpps-audit-client": "2.0.0-beta.1",
         "@ministryofjustice/hmpps-auth-clients": "3.0.0",
         "@ministryofjustice/hmpps-azure-telemetry": "1.0.2",
         "@ministryofjustice/hmpps-connect-dps-components": "^6.3.0",
@@ -86,13 +86,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.1101.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1101.0.tgz",
-      "integrity": "sha512-Ui4QpE1EII3CfTKxGHN4egx2GpowSb+r8o4g9cqcubc7j9fN3FOCKmQNCVMwQMxr33mXcM9yn8ZHrOiD2/ajeg==",
+      "version": "3.1106.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1106.0.tgz",
+      "integrity": "sha512-U+QW8p+T/4zG11UvsWU/EfNeq/ShiLtv1S+0TFyKxj49fNKBa88ifT/cWbRHr5Mfm/FDmXKwc7YZUZ9+IHBFTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-node": "^3.972.76",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
         "@aws-sdk/middleware-sdk-sqs": "^3.972.39",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
@@ -106,10 +106,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.4.tgz",
-      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
-      "deprecated": "Deprecated due to Document number parsing bug in JSON, see\n  https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.",
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
@@ -126,12 +125,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
-      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -142,12 +141,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
-      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
@@ -160,19 +159,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
-      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-login": "^3.972.72",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -184,13 +183,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
-      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -201,17 +200,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.76",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
-      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-ini": "^3.973.10",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -223,12 +222,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
-      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -239,14 +238,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
-      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/token-providers": "3.1100.0",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -257,13 +256,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
-      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -289,12 +288,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
-      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
@@ -323,13 +322,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1100.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
-      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -385,6 +384,16 @@
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright/node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -634,14 +643,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -791,13 +800,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1061,18 +1070,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1080,9 +1089,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1512,9 +1521,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2358,6 +2367,20 @@
         "moment": "2.30.1"
       }
     },
+    "node_modules/@ministryofjustice/hmpps-audit-client": {
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-audit-client/-/hmpps-audit-client-2.0.0-beta.1.tgz",
+      "integrity": "sha512-tWlfJo2pfwv8mSzibgC70rFtKpfz1rF/ZX6mNi1sy9h41CQrcVRmMYmt1n5YYheGAL5Z0hXhN8IMIljs8aYjnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-sqs": "^3.1092.0",
+        "@smithy/node-http-handler": "^4.4.10",
+        "https-proxy-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": "22 || 24 || 26"
+      }
+    },
     "node_modules/@ministryofjustice/hmpps-auth-clients": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-auth-clients/-/hmpps-auth-clients-3.0.0.tgz",
@@ -2395,13 +2418,13 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-connect-dps-components": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-connect-dps-components/-/hmpps-connect-dps-components-6.3.0.tgz",
-      "integrity": "sha512-f2sQIHcqrWyUxQ3OSRbvGgFeaSZDIMFrAdRyZiRjpdcAYGx7rqTqsqnJKCS8QP7XpyQuTtkCQaEQvJXwAmQuVg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-connect-dps-components/-/hmpps-connect-dps-components-6.3.2.tgz",
+      "integrity": "sha512-fdshAtENZOilwzQVBi1Gzey+du01WGAh/3hioRWRdYiTsu+NJv62M4FYWFYghVAk0raPfkI47yfRpMMgS45u5A==",
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/hmpps-rest-client": "2.2.0",
-        "@types/node": "24.13.2",
+        "@types/node": "24.13.3",
         "@types/nunjucks": "^3.2.6",
         "nunjucks": "^3.2.4",
         "superagent": "^10.3.0"
@@ -2411,15 +2434,6 @@
       },
       "engines": {
         "node": "22 || 24 || 26"
-      }
-    },
-    "node_modules/@ministryofjustice/hmpps-connect-dps-components/node_modules/@types/node": {
-      "version": "24.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@ministryofjustice/hmpps-monitoring": {
@@ -2505,9 +2519,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz",
-      "integrity": "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2762,9 +2776,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan/node_modules/import-in-the-middle": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz",
-      "integrity": "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -3140,9 +3154,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3164,9 +3175,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3188,9 +3196,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3212,9 +3217,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3236,9 +3238,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3260,9 +3259,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3696,9 +3692,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
-      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3933,17 +3929,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/type-utils": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -3956,7 +3952,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -3972,16 +3968,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3997,14 +3993,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.65.0",
-        "@typescript-eslint/types": "^8.65.0",
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4019,14 +4015,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0"
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4037,9 +4033,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4054,15 +4050,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4079,9 +4075,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4093,16 +4089,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.65.0",
-        "@typescript-eslint/tsconfig-utils": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4137,16 +4133,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0"
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4161,13 +4157,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/types": "8.66.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4319,9 +4315,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4336,9 +4329,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4353,9 +4343,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4370,9 +4357,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4387,9 +4371,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4404,9 +4385,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4421,9 +4399,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4438,9 +4413,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4455,9 +4427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4472,9 +4441,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4631,7 +4597,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -4935,9 +4900,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
-      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -5109,9 +5074,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.8.tgz",
-      "integrity": "sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ==",
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5227,9 +5192,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
-      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -5247,11 +5212,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.44",
-        "caniuse-lite": "^1.0.30001806",
-        "electron-to-chromium": "^1.5.393",
-        "node-releases": "^2.0.51",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5404,9 +5369,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {
@@ -6361,9 +6326,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.399",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
-      "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
+      "version": "1.5.403",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
+      "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7607,6 +7572,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7782,9 +7748,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8116,7 +8082,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -10295,9 +10260,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -11035,9 +11000,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12489,9 +12454,9 @@
       }
     },
     "node_modules/sass/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13237,9 +13202,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13714,9 +13679,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "npm": "^11"
   },
   "dependencies": {
-    "@aws-sdk/client-sqs": "^3.1101.0",
     "@ministryofjustice/frontend": "^10.0.1",
+    "@ministryofjustice/hmpps-audit-client": "2.0.0-beta.1",
     "@ministryofjustice/hmpps-auth-clients": "3.0.0",
     "@ministryofjustice/hmpps-azure-telemetry": "1.0.2",
     "@ministryofjustice/hmpps-connect-dps-components": "^6.3.0",

--- a/server/config.ts
+++ b/server/config.ts
@@ -121,7 +121,9 @@ export default {
         'http://localhost:4566/000000000000/audit_event_queue',
         requiredInProduction,
       ),
+      region: get('AUDIT_SQS_REGION', 'eu-west-2'),
       serviceName: get('AUDIT_SERVICE_NAME', 'book-a-prison-visit-staff-ui', requiredInProduction),
+      enabled: get('AUDIT_ENABLED', 'true') === 'true',
     },
     orchestration: {
       url: get('ORCHESTRATION_API_URL', 'http://localhost:8080', requiredInProduction),

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -1,23 +1,14 @@
-import config from '../config'
 import AuditService from './auditService'
 
-const sqsClientInstance = {
-  send: jest.fn().mockReturnThis(),
-}
+const sendMessage = jest.fn().mockResolvedValue(undefined)
 
-jest.mock('@aws-sdk/client-sqs', () => {
-  const { SendMessageCommand } = jest.requireActual('@aws-sdk/client-sqs')
+jest.mock('@ministryofjustice/hmpps-audit-client', () => {
   return {
-    SQSClient: jest.fn(() => sqsClientInstance),
-    SendMessageCommand,
+    AuditClient: jest.fn().mockImplementation(() => ({ sendMessage })),
   }
 })
 
 const prisonId = 'HEI'
-const fakeDate = '2022-07-11T09:00:00.000Z'
-jest.useFakeTimers().setSystemTime(new Date(fakeDate))
-
-const QueueUrl = config.apis.audit.queueUrl
 
 describe('Audit service', () => {
   let auditService: AuditService
@@ -38,20 +29,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'SEARCHED_PRISONERS',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"searchTerms":"Smith","prisonId":"HEI"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'SEARCHED_PRISONERS',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { searchTerms: 'Smith', prisonId: 'HEI' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a view prisoner audit message', async () => {
@@ -62,20 +50,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'VIEWED_PRISONER',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"prisonerId":"A1234BC","prisonId":"HEI"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'VIEWED_PRISONER',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { prisonerId: 'A1234BC', prisonId: 'HEI' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a visit reserved audit message', async () => {
@@ -92,22 +77,26 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'RESERVED_VISIT',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details:
-            '{"applicationReference":"aaa-bbb-ccc","visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI","visitorIds":["abc123","bcd321"],' +
-            '"startTimestamp":"2022-08-24T11:00:00","endTimestamp":"2022-08-24T12:00:00","visitRestriction":"OPEN"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'RESERVED_VISIT',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: {
+          applicationReference: 'aaa-bbb-ccc',
+          visitReference: 'ab-cd-ef-gh',
+          prisonerId: 'A1234BC',
+          prisonId: 'HEI',
+          visitorIds: ['abc123', 'bcd321'],
+          startTimestamp: '2022-08-24T11:00:00',
+          endTimestamp: '2022-08-24T12:00:00',
+          visitRestriction: 'OPEN',
+        },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a visit booked audit message', async () => {
@@ -124,22 +113,26 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'BOOKED_VISIT',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details:
-            '{"applicationReference":"aaa-bbb-ccc","visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI","visitorIds":["abc123","bcd321"],' +
-            '"startTimestamp":"2022-08-24T11:00:00","endTimestamp":"2022-08-24T12:00:00","visitRestriction":"OPEN"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'BOOKED_VISIT',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: {
+          applicationReference: 'aaa-bbb-ccc',
+          visitReference: 'ab-cd-ef-gh',
+          prisonerId: 'A1234BC',
+          prisonId: 'HEI',
+          visitorIds: ['abc123', 'bcd321'],
+          startTimestamp: '2022-08-24T11:00:00',
+          endTimestamp: '2022-08-24T12:00:00',
+          visitRestriction: 'OPEN',
+        },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a notifications dismissed audit message', async () => {
@@ -152,20 +145,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'DISMISSED_NOTIFICATIONS',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI","reason":"Dismiss reason"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'DISMISSED_NOTIFICATIONS',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { visitReference: 'ab-cd-ef-gh', prisonerId: 'A1234BC', prisonId: 'HEI', reason: 'Dismiss reason' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a cancelled visit audit message', async () => {
@@ -178,21 +168,22 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'CANCELLED_VISIT',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details:
-            '{"visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI","reason":"PRISONER_CANCELLED: illness"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'CANCELLED_VISIT',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: {
+          visitReference: 'ab-cd-ef-gh',
+          prisonerId: 'A1234BC',
+          prisonId: 'HEI',
+          reason: 'PRISONER_CANCELLED: illness',
+        },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a viewed visits page audit message', async () => {
@@ -203,39 +194,33 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'VIEWED_VISITS',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"viewDate":"2022-06-01T12:12:12","prisonId":"HEI"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'VIEWED_VISITS',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { viewDate: '2022-06-01T12:12:12', prisonId: 'HEI' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a zero VO overridden audit message', async () => {
     await auditService.overrodeZeroVO({ prisonerId: 'A1234BC', username: 'username', operationId: 'operation-id' })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'OVERRODE_ZERO_VO',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"prisonerId":"A1234BC"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'OVERRODE_ZERO_VO',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { prisonerId: 'A1234BC' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a visit restriction (open/closed) selected audit message', async () => {
@@ -247,39 +232,33 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'VISIT_RESTRICTION_SELECTED',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"prisonerId":"A1234BC","visitRestriction":"CLOSED","visitorIds":["abc123","bcd321"]}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'VISIT_RESTRICTION_SELECTED',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { prisonerId: 'A1234BC', visitRestriction: 'CLOSED', visitorIds: ['abc123', 'bcd321'] },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a visit search audit message', async () => {
     await auditService.visitSearch({ searchTerms: 'ab-cd-ef-gh', username: 'username', operationId: 'operation-id' })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'SEARCHED_VISITS',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"searchTerms":"ab-cd-ef-gh"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'SEARCHED_VISITS',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { searchTerms: 'ab-cd-ef-gh' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a viewed visit details audit message', async () => {
@@ -291,20 +270,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'VIEWED_VISIT_DETAILS',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'VIEWED_VISIT_DETAILS',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { visitReference: 'ab-cd-ef-gh', prisonerId: 'A1234BC', prisonId: 'HEI' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a visit date blocked message', async () => {
@@ -315,20 +291,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'BLOCKED_VISIT_DATE',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"prisonId":"HEI","date":"2024-09-06"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'BLOCKED_VISIT_DATE',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { prisonId: 'HEI', date: '2024-09-06' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a visit date unblocked message', async () => {
@@ -339,20 +312,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'UNBLOCKED_VISIT_DATE',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"prisonId":"HEI","date":"2024-09-06"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'UNBLOCKED_VISIT_DATE',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { prisonId: 'HEI', date: '2024-09-06' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a visit session blocked message', async () => {
@@ -363,20 +333,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'BLOCKED_VISIT_SESSION',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"date":"2024-09-06","sessionReference":"session-ref"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'BLOCKED_VISIT_SESSION',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { date: '2024-09-06', sessionReference: 'session-ref' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a visit session unblocked message', async () => {
@@ -387,20 +354,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'UNBLOCKED_VISIT_SESSION',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"date":"2024-09-06","sessionReference":"session-ref"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'UNBLOCKED_VISIT_SESSION',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { date: '2024-09-06', sessionReference: 'session-ref' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a booker search audit message', async () => {
@@ -410,20 +374,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'SEARCHED_BOOKERS',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"search":"booker@example.com"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'SEARCHED_BOOKERS',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { search: 'booker@example.com' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a viewed booker audit message', async () => {
@@ -434,20 +395,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'VIEWED_BOOKER',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"reference":"aaaa-bbbb-cccc","prisonerIds":["A1234BC","A4567DE"]}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'VIEWED_BOOKER',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { reference: 'aaaa-bbbb-cccc', prisonerIds: ['A1234BC', 'A4567DE'] },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a linked booker visitor audit message', async () => {
@@ -459,20 +417,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'LINKED_BOOKER_VISITOR',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"reference":"aaaa-bbbb-cccc","prisonerId":"A1234BC","visitorId":"1234"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'LINKED_BOOKER_VISITOR',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { reference: 'aaaa-bbbb-cccc', prisonerId: 'A1234BC', visitorId: '1234' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a unlinked booker visitor audit message', async () => {
@@ -484,20 +439,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'UNLINKED_BOOKER_VISITOR',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"reference":"aaaa-bbbb-cccc","prisonerId":"A1234BC","visitorId":"1234"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'UNLINKED_BOOKER_VISITOR',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { reference: 'aaaa-bbbb-cccc', prisonerId: 'A1234BC', visitorId: '1234' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends an approved visit request audit message', async () => {
@@ -507,20 +459,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'APPROVED_VISIT_REQUEST',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"visitReference":"ab-cd-ef-gh"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'APPROVED_VISIT_REQUEST',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { visitReference: 'ab-cd-ef-gh' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a rejected visit request audit message', async () => {
@@ -531,20 +480,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'REJECTED_VISIT_REQUEST',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"visitReference":"ab-cd-ef-gh","rejectionReason":"ALERT_OR_RESTRICTION"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'REJECTED_VISIT_REQUEST',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { visitReference: 'ab-cd-ef-gh', rejectionReason: 'ALERT_OR_RESTRICTION' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends an approved visitor request audit message', async () => {
@@ -555,20 +501,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'APPROVED_VISITOR_REQUEST',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"requestReference":"cccc-dddd-eeee","visitorId":"1234"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'APPROVED_VISITOR_REQUEST',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { requestReference: 'cccc-dddd-eeee', visitorId: '1234' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a rejected visitor request audit message', async () => {
@@ -579,20 +522,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'REJECTED_VISITOR_REQUEST',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"requestReference":"cccc-dddd-eeee","rejectionReason":"REJECT"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'REJECTED_VISITOR_REQUEST',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { requestReference: 'cccc-dddd-eeee', rejectionReason: 'REJECT' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a visit balance adjusted audit message', async () => {
@@ -606,21 +546,23 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'ADJUSTED_VISIT_BALANCE',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details:
-            '{"prisonerId":"A1234BC","voChange":2,"pvoChange":-1,"reason":"GOVERNOR_ADJUSTMENT","reasonDetails":"comment text"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'ADJUSTED_VISIT_BALANCE',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: {
+          prisonerId: 'A1234BC',
+          voChange: 2,
+          pvoChange: -1,
+          reason: 'GOVERNOR_ADJUSTMENT',
+          reasonDetails: 'comment text',
+        },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a update prison allowances audit message', async () => {
@@ -632,20 +574,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'UPDATED_VISIT_ALLOWANCES',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"weekStartDay":"MONDAY","remandVisitLimitPerWeek":3,"prisonId":"HEI"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'UPDATED_VISIT_ALLOWANCES',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { weekStartDay: 'MONDAY', remandVisitLimitPerWeek: 3, prisonId: 'HEI' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a printed visit pass audit message', async () => {
@@ -657,20 +596,17 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'PRINTED_VISIT_PASS',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"visitReference":"ab-cd-ef-gh","prisonerId":"A1234BC","prisonId":"HEI"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'PRINTED_VISIT_PASS',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { visitReference: 'ab-cd-ef-gh', prisonerId: 'A1234BC', prisonId: 'HEI' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 
   it('sends a printed visit passes audit message', async () => {
@@ -681,19 +617,16 @@ describe('Audit service', () => {
       operationId: 'operation-id',
     })
 
-    expect(sqsClientInstance.send).toHaveBeenCalledTimes(1)
-    expect(sqsClientInstance.send.mock.lastCall[0]).toMatchObject({
-      input: {
-        MessageBody: JSON.stringify({
-          what: 'PRINTED_VISIT_PASSES',
-          when: fakeDate,
-          operationId: 'operation-id',
-          who: 'username',
-          service: 'book-a-prison-visit-staff-ui',
-          details: '{"date":"2024-06-01","prisonId":"HEI"}',
-        }),
-        QueueUrl,
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        action: 'PRINTED_VISIT_PASSES',
+        who: 'username',
+        correlationId: 'operation-id',
+        subjectType: 'NOT_APPLICABLE',
+        details: { date: '2024-06-01', prisonId: 'HEI' },
       },
-    })
+      { logOnError: true, throwOnError: false },
+    )
   })
 })

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -1,4 +1,4 @@
-import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
+import { AuditClient } from '@ministryofjustice/hmpps-audit-client'
 import logger from '../../logger'
 import config from '../config'
 import {
@@ -10,13 +10,17 @@ import {
 import { PrisonRemandConfig } from '../@types/bapv'
 
 export default class AuditService {
-  private sqsClient: SQSClient
-
-  constructor(private readonly queueUrl = config.apis.audit.queueUrl) {
-    this.sqsClient = new SQSClient({
-      useQueueUrlAsEndpoint: false,
-    })
-  }
+  constructor(
+    private readonly auditClient = new AuditClient(
+      {
+        queueUrl: config.apis.audit.queueUrl,
+        region: config.apis.audit.region,
+        serviceName: config.apis.audit.serviceName,
+        enabled: config.apis.audit.enabled,
+      },
+      logger,
+    ),
+  ) {}
 
   async prisonerSearch({
     searchTerms,
@@ -629,37 +633,28 @@ export default class AuditService {
   private async sendAuditMessage({
     action,
     who,
-    timestamp = new Date(),
     operationId,
     details,
   }: {
     action: string
     who: string
-    timestamp?: Date
     operationId: string
     details: object
   }) {
-    const message = JSON.stringify({
-      what: action,
-      when: timestamp,
-      operationId,
-      who,
-      service: config.apis.audit.serviceName,
-      details: JSON.stringify(details, this.replaceUndefinedWithNull),
-    })
-
-    try {
-      const messageResponse = await this.sqsClient.send(
-        new SendMessageCommand({
-          MessageBody: message,
-          QueueUrl: this.queueUrl,
-        }),
-      )
-      logger.info(`SQS message sent (MessageId: ${messageResponse.MessageId}, message: ${message})`)
-    } catch (error) {
-      logger.error(`Problem sending message to SQS queue (message: ${message})`)
-      logger.error(error)
-    }
+    // subjectType is required by AuditEvent but this service doesn't currently track a specific
+    // audited subject (prisoner, CRN, etc.) per action, so every event is sent as NOT_APPLICABLE.
+    // Pre-resolve undefined -> null (matching the previous local SQS message behaviour) before
+    // handing off, since the audit client JSON.stringifies `details` itself.
+    await this.auditClient.sendMessage(
+      {
+        action,
+        who,
+        correlationId: operationId,
+        subjectType: 'NOT_APPLICABLE',
+        details: JSON.parse(JSON.stringify(details, this.replaceUndefinedWithNull)),
+      },
+      { logOnError: true, throwOnError: false },
+    )
   }
 
   private replaceUndefinedWithNull(_key: string, value: unknown) {


### PR DESCRIPTION
…dit SQS (Phase 1)

Replace the hand-rolled AuditService (constructing new SQSClient directly from @aws-sdk/client-sqs, with no proxy support) with @ministryofjustice/hmpps-audit-client@2.0.0-beta.1, which is proxy-aware from major version 2.0 onwards and already respects NODE_USE_ENV_PROXY / HTTP(S)_PROXY, both of which are already configured in helm_deploy/values-dev.yaml.

- server/config.ts: add region (AUDIT_SQS_REGION, default eu-west-2) and enabled (AUDIT_ENABLED, default true) to config.apis.audit, matching the library's AuditClientConfig shape.
- server/services/auditService.ts: keep the existing public method surface (prisonerSearch, viewPrisoner, etc, used across ~30 call sites) unchanged, but delegate the underlying send to AuditClient#sendMessage instead of a local SQSClient. Every event is sent with subjectType: 'NOT_APPLICABLE' since this service doesn't yet track a specific audited subject per action; operationId is now passed through as the library's correlationId. undefined -> null detail normalisation is preserved to keep the SQS wire message unchanged.
- server/services/auditService.test.ts: mock @ministryofjustice/hmpps-audit-client instead of @aws-sdk/client-sqs and assert on AuditClient#sendMessage calls.
- package.json/package-lock.json: swap @aws-sdk/client-sqs for @ministryofjustice/hmpps-audit-client@2.0.0-beta.1 (pinned explicitly, since npm's 'latest' dist-tag is still on the pre-proxy-aware 1.x line).

Validated with npm run typecheck, npm run lint, and npm run test (all passing), plus a clean rm -rf node_modules package-lock.json && npm install && npm ci to confirm the regenerated lock file installs cleanly.